### PR TITLE
:bug: Fix Docker build error with package installation

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,7 +28,7 @@ COPY pyproject.toml uv.lock /app/
 
 # Create virtual environment and install dependencies using uv sync
 RUN uv venv $VIRTUAL_ENV && \
-    uv sync --frozen --no-dev
+    uv sync --frozen --no-dev --no-install-project
 
 # Copy application code
 COPY . .


### PR DESCRIPTION
Resolves "package directory 'app' does not exist" error during docker-compose build.

Added --no-install-project flag to uv sync command in Dockerfile. This prevents setuptools from attempting to install the project as a package before the app/ directory is copied, since the application runs directly via uvicorn and doesn't need to be installed as a package.
