### PR TITLE
:arrow_up: Remove check and bump versions

### DIFF
--- a/backend/app/services/health_check.py
+++ b/backend/app/services/health_check.py
@@ -371,7 +371,7 @@ class HealthCheckService:
         *,
         include_celery: bool = True,
         include_smtp: bool = True,
-        include_ollama: bool = True,
+        include_ollama: bool = False,
     ) -> dict[str, HealthCheckResult]:
         """
         Check all services and return results.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fallout-shelter-fast-api-vue"
-version = "1.13.1"
+version = "1.13.2"
 authors = [{ name = "ElderEvil", email = "elder.evil.dev@proton.me" }, ]
 description = "Fallout Shelter FastAPI Game is a web-based simulation game where the player manages a vault full of dwellers, balancing their needs and resources to keep the vault thriving."
 requires-python = ">=3.12,<3.14"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -630,7 +630,7 @@ wheels = [
 
 [[package]]
 name = "fallout-shelter-fast-api-vue"
-version = "1.13.1"
+version = "1.13.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosmtplib" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.13.0",
+  "version": "1.13.2",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.26.2",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Ollama service health check behavior has been changed to opt-in mode. The check is now disabled by default and requires explicit configuration to run, providing users with more granular control over their service monitoring settings.

* **Chores**
  * Version bumped to 1.13.2 for both backend and frontend components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->