### PR TITLE
:bug: Fix MinIO internal connection using wrong protocol

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -70,13 +70,6 @@ class Settings(BaseSettings):
         # Fallback to internal hostname:port for local development
         return f"http://{self.MINIO_HOSTNAME}:{self.MINIO_PORT}"
 
-    @property
-    def minio_use_https(self) -> bool:
-        """Determine if MinIO connection should use HTTPS based on public URL."""
-        if self.MINIO_PUBLIC_URL:
-            return self.MINIO_PUBLIC_URL.startswith("https://")
-        return False
-
     AI_PROVIDER: Literal["openai", "anthropic", "ollama"] = "openai"
     AI_MODEL: str = "gpt-4o"
     OPENAI_API_KEY: str | None = None

--- a/backend/app/services/minio.py
+++ b/backend/app/services/minio.py
@@ -49,7 +49,7 @@ class MinioService:
                     f"{settings.MINIO_HOSTNAME}:{settings.MINIO_PORT}",
                     access_key=settings.MINIO_ROOT_USER,
                     secret_key=settings.MINIO_ROOT_PASSWORD,
-                    secure=settings.minio_use_https,
+                    secure=False,  # Internal Docker connection is always HTTP
                 )
                 self._ensure_bucket_exists(self.default_bucket_name)
                 logger.info("MinIO client initialized successfully")


### PR DESCRIPTION
- MinIO client must use HTTP for internal Docker network connection
- MINIO_PUBLIC_URL is only for generating public URLs, not for client connection
- Removed minio_use_https property (was incorrectly applying public URL scheme to internal connection)
- Internal connection: always HTTP (minio:9000)
- Public URLs: use MINIO_PUBLIC_URL (https://fallout-media.evillab.dev)

Fixes MaxRetryError when backend tries to connect to MinIO via HTTPS internally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified MinIO configuration by removing dynamic protocol detection.
  * Internal service connections now consistently use HTTP for MinIO operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->