### PR TITLE
:bug: Fix training session assignment on dweller drop

### DIFF
--- a/backend/app/services/training_service.py
+++ b/backend/app/services/training_service.py
@@ -77,13 +77,14 @@ class TrainingService:
         if room.category != RoomTypeEnum.TRAINING:
             return False, "Room is not a training room"
 
-        # Check dweller availability
-        if dweller.status != DwellerStatusEnum.IDLE:
-            return False, f"Dweller is {dweller.status} and cannot train"
-
+        # Check if dweller has an active training session
         existing_training = await training_crud.training.get_active_by_dweller(db_session, dweller.id)
         if existing_training:
             return False, f"Dweller is already training {existing_training.stat_being_trained}"
+
+        # Check dweller availability (allow TRAINING status if no active session exists)
+        if dweller.status not in (DwellerStatusEnum.IDLE, DwellerStatusEnum.TRAINING):
+            return False, f"Dweller is {dweller.status} and cannot train"
 
         # Determine which stat this room trains and check if maxed
         if not room.ability:

--- a/frontend/src/components/rooms/RoomGrid.vue
+++ b/frontend/src/components/rooms/RoomGrid.vue
@@ -4,6 +4,7 @@ import { useRoute } from 'vue-router'
 import { useRoomStore } from '@/stores/room'
 import { useAuthStore } from '@/stores/auth'
 import { useDwellerStore } from '@/stores/dweller'
+import { useTrainingStore } from '@/stores/training'
 import { useRoomInteractions } from '@/composables/useRoomInteractions'
 import { useHoverPreview } from '@/composables/useHoverPreview'
 import RoomDwellers from '@/components/dwellers/RoomDwellers.vue'
@@ -39,6 +40,7 @@ const route = useRoute()
 const roomStore = useRoomStore()
 const authStore = useAuthStore()
 const dwellerStore = useDwellerStore()
+const trainingStore = useTrainingStore()
 const rooms = computed(() => Array.isArray(roomStore.rooms) ? roomStore.rooms : [])
 
 const { selectedRoomId, toggleRoomSelection, destroyRoom } = useRoomInteractions()
@@ -171,7 +173,16 @@ const handleDrop = async (event: DragEvent, roomId: string) => {
       return
     }
 
+    // Find the target room to check if it's a training room
+    const targetRoom = rooms.value.find(r => r.id === roomId)
+
+    // Assign dweller to room
     await dwellerStore.assignDwellerToRoom(dwellerId, roomId, authStore.token as string)
+
+    // If it's a training room, start a training session
+    if (targetRoom?.category?.toLowerCase() === 'training') {
+      await trainingStore.startTraining(dwellerId, roomId, authStore.token as string)
+    }
 
     const action = currentRoomId ? 'moved' : 'assigned'
     assignmentSuccess.value = `${firstName} ${lastName} ${action} successfully!`

--- a/frontend/src/stores/dweller.ts
+++ b/frontend/src/stores/dweller.ts
@@ -292,10 +292,10 @@ export const useDwellerStore = defineStore('dweller', () => {
         }
       );
 
-      // Update the dweller in the list
+      // Update the dweller in the list with full response data
       const dwellerIndex = dwellers.value.findIndex(d => d.id === dwellerId);
       if (dwellerIndex !== -1 && dwellers.value[dwellerIndex]) {
-        dwellers.value[dwellerIndex] = { ...dwellers.value[dwellerIndex]!, room_id: null };
+        dwellers.value[dwellerIndex] = { ...dwellers.value[dwellerIndex]!, room_id: null, status: response.data.status };
       }
 
       // Update detailed dweller if cached
@@ -303,7 +303,6 @@ export const useDwellerStore = defineStore('dweller', () => {
         detailedDwellers.value[dwellerId] = response.data;
       }
 
-      toast.success('Dweller recalled successfully!');
       return response.data;
     } catch (error) {
       console.error(`Failed to unassign dweller ${dwellerId}`, error);

--- a/frontend/src/stores/training.ts
+++ b/frontend/src/stores/training.ts
@@ -58,7 +58,6 @@ export const useTrainingStore = defineStore('training', () => {
     try {
       const training = await trainingService.startTraining(dwellerId, roomId, token)
       activeTrainings.value.set(training.id!, training)
-      toast.success('Training started successfully!')
       return training
     } catch (err: unknown) {
       console.error('Failed to start training:', err)


### PR DESCRIPTION
**Problem:**
- Dropping dweller into training room didn't create training session
- Backend validation rejected TRAINING status even without active session
- Duplicate debug toasts on assignment/unassignment

**Backend Fix:**
- Allow TRAINING status when no active session exists
- Reordered validation checks (session first, then status)

**Frontend Fix:**
- Simplified training start logic in RoomGrid
- Removed duplicate success toasts from stores
- Added status update on dweller unassignment

**Tests:**
- Added 3 new RoomGrid tests for training assignment flow
- All 12 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Training sessions now automatically start when assigning a dweller to a training room.
  * Enhanced training eligibility validation with updated control flow logic.

* **Refactor**
  * Removed success notifications for training action completions.

* **Tests**
  * Added comprehensive test coverage for automatic training initiation on room assignment, including success and failure scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->