### PR TITLE
:pushpin: Pydantic ignore for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,9 +24,7 @@ updates:
       include: "scope"
     ignore:
       - dependency-name: "pydantic"
-        versions:
-          - "^2.13.0"
-          - "2.12.x"
+        versions: [ "^2.13.0", "2.12.x", ]
 
   # Frontend dependencies (pnpm)
   - package-ecosystem: "npm"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency management to ignore specific pydantic versions (2.13.0 and 2.12.x) for Python backend dependencies to prevent automatic updates to those versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->