### PR TITLE
feat: repurpose soft-deleted dweller assets for radio recruitment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,48 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ---
 
+## [2.14.0] - 2026-05-26
+
+### Added
+
+- **Radio asset repurpose** - When the radio recruits a new dweller, it now prefers restoring a
+  soft-deleted dweller from the cross-vault recycling pool (reusing their existing S3 image,
+  thumbnail, bio, and original rarity) over generating a blank new one
+  - Falls back to `create_random` when the pool is empty or the caller supplies an override
+  - Config-gated: `RADIO_RECYCLE_ENABLED` (default `true`), `RADIO_RECYCLE_PROBABILITY` (default `0.8`),
+    `RADIO_RECYCLE_MIN_AGE_DAYS` (default `7`)
+  - `RecruitmentResponse` gains a `recycled` boolean field; frontend shows a distinct
+    "A familiar face answers the call" toast when `recycled: true`
+  - 11 new service tests covering recycling, fallback, stat reset, asset preservation,
+    rarity preservation, config flags, and race-condition handling
+
+### Fixed
+
+- **SQLAlchemy async concurrency in game tick** - `InterfaceError: cannot perform operation:
+another operation is in progress` during objective queries inside game tick tasks.
+  Root cause: concurrent async operations sharing the same session. Fix: ensure proper
+  session isolation per task (`async with` session per query) _(carried from v2.13.2 plan)_
+
+### Changed
+
+- **Test session uses SQLModel `AsyncSession`** - `conftest.py` now uses
+  `sqlmodel.ext.asyncio.session.AsyncSession` instead of SQLAlchemy's base class, making
+  `.exec()` available to all service tests without patching
+- **Removed unused sync PostgreSQL drivers** - `psycopg` (psycopg3) and `psycopg2-binary`
+  were leftover from the Celery era (psycopg2 was required by `sqlalchemy-celery-beat`);
+  the app and Alembic use `asyncpg` exclusively
+- **Docker infra: PG18 volume mount** - `docker-compose.infra.yml` volume path updated from
+  `/var/lib/postgresql/data` to `/var/lib/postgresql` for PostgreSQL 18 compatibility
+- **ROADMAP** - Retired `v2.13.2` placeholder, promoted its items into `v2.14.0`
+
+### Chores
+
+- **Version bump** - Backend and frontend versions updated to `2.14.0`
+- **Lockfiles** - Regenerated `uv.lock` (removed `psycopg`, `psycopg2-binary`;
+  133 → 131 packages); `pnpm` lockfile unchanged
+
+---
+
 ## [2.13.1] - 2026-05-19
 
 ### Fixed
@@ -336,7 +378,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 - **Objective Build Progress** - Building rooms now correctly counts toward build objectives
   - Fixed room type format mismatch between event data (display name) and objective targets (snake_case)
-  - Added support for "any" wildcard in addition to "*"
+  - Added support for "any" wildcard in addition to "\*"
 - **Objective Collect Progress** - Collecting resources now correctly counts toward collect objectives
   - Added wildcard support for resource_type matching
 - **Objective Reach Progress** - Population objectives now show actual dweller count as progress
@@ -461,6 +503,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [2.9.3] - 2026-02-08
 
 ### What's New
+
 - **Component Refactoring** - Major frontend architecture improvements
   - Deep split: `RoomDetailModal.vue` broken into 7 focused components + 4 composables
     - Components: RoomDetailHeader, RoomPreviewSection, RoomInfoGrid, ProductionStats, DwellerList, RoomActions, RadioControls
@@ -475,6 +518,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   - Removed unused `get_spreading_incidents()` function from incident CRUD
 
 ### Fixed
+
 - **DwellerChat Message Keys** - Uses messageId-based keys for better WebSocket correlation
 - **RoomDetailModal Edge Cases** - Better null handling and radio room conditional rendering
 
@@ -483,6 +527,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [2.9.2] - 2026-02-08
 
 ### What's New
+
 - **Boosted Start** - New vault creation option for faster progression
   - Creates vault with 6 dwellers (3F/3M), 1000 caps, and starter resources
   - Reduced initial build costs for faster early game
@@ -492,6 +537,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [2.9.1] - 2026-02-08
 
 ### Fixed
+
 - **Chat Message Display** - Messages now use proper message-id-based keys for WebSocket updates
 - **DwellerChat PLAN.md Compliance** - All PLAN.md requirements verified and working
   - Latest-only action suggestion rendering
@@ -502,6 +548,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [2.9.0] - 2026-02-07
 
 ### What's New
+
 - **Dwellers Can Move to Any Room** - Chat room assignments now work for all room types
   - Ask your dweller to move to any room — capacity, crafting, misc, production, quests, theme, or training
   - Dwellers follow your orders strictly when you name a specific room
@@ -517,6 +564,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   - Room coordinates, costs, and speedup multipliers are now visible
 
 ### Fixed
+
 - **Chat Training Actions** - No more "Unable to access vault data" errors
   - Fixed: training room lookup was reading from vault data (which doesn't include rooms) instead of the room store
   - Training actions from chat now work reliably
@@ -537,6 +585,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   - Empty audio files get a clear validation error instead of generic server error
 
 ### Technical
+
 - **Auth Token Refresh** - Fixed 422 validation error when refreshing access tokens
   - Backend now accepts `refresh_token` in request body (JSON) instead of query parameter
   - More RESTful and secure (tokens no longer exposed in URLs/logs)
@@ -558,6 +607,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [2.8.5] - 2026-02-04
 
 ### Changed
+
 - **Code Quality & Refactoring** - Major backend cleanup and simplification
   - Removed empty CRUD wrappers for weapon/outfit/junk items (use CRUDItem directly)
   - Deduplicated vault_id item list filtering in weapon/outfit endpoints
@@ -567,6 +617,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   - Simplified exploration loot transfer logic (reduced from 171 to ~110 lines, removed complexity suppressions)
 
 ### Added
+
 - **Storage Provider** - RustFS support added alongside MinIO for S3-compatible object storage
   - Add STORAGE_PROVIDER config option (minio/rustfs)
   - RustFS services in docker-compose.yml and docker-compose.infra.yml
@@ -576,6 +627,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **Testing** - Added 5 new tests for exploration loot transfer (weapon/outfit creation, missing data, invalid rarity)
 
 ### Fixed
+
 - **Room Images** - Room images now load correctly in dockerized HTTPS staging environments
   - Frontend prepends API base URL to image paths
   - Fixes "failed to load room image" errors on staging
@@ -586,17 +638,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [2.8.3] - 2026-02-02
 
 ### What's New
+
 - **Smarter Dweller Assignments** - Dwellers assigned to training rooms now correctly show "Training" status instead of "Working"
   - No more confusion about what your dwellers are actually doing
   - Training progress and status now match up perfectly
 
 ### Improvements
+
 - **Better Error Messages** - When things go wrong, you'll get clearer, more helpful error messages
   - Missing dwellers or resources? The game now tells you exactly what couldn't be found
   - Validation errors (like trying to recruit with the wrong gender) are more descriptive
   - All error messages now follow a consistent format for easier reading
 
 ### Behind the Scenes
+
 - **More Reliable Timestamps** - Database seed data now uses consistent UTC timestamps
 - **Stronger Code Quality** - Added comprehensive tests for error handling and edge cases
 - **Cleaner Architecture** - Standardized how the backend handles different types of errors
@@ -608,12 +663,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [2.8.0] - 2026-01-29
 
 ### What's New
+
 - **Dweller Renaming** - Rename your dwellers! Click the pencil icon next to their name on the detail page
 - **Easter Eggs** - Discover hidden vault secrets! Try naming a dweller "Gary" or rapidly clicking the version number in About page
 - **Toast Notifications** - All feedback messages now match your chosen theme color and automatically group duplicates
 - **Better Room Refunds** - Get 50% of your caps back when destroying upgraded rooms (up from 20%)
 
 ### Improvements
+
 - **Changelog** - Cleaner modal design, works properly, and won't freeze your game anymore
 - **Keyboard Shortcuts** - Build mode hotkey (B) now works with all keyboard layouts
 - **Happiness Dashboard** - Quick actions are now easier to find and use
@@ -626,6 +683,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [2.4.1] - 2026-01-25
 
 ### Fixed
+
 - **Critical: Celery Worker Crashes** - Resolved production crashes caused by mixing timezone-aware and timezone-naive datetime objects
   - Fixed `death_service.py` - All datetime operations now use consistent naive datetime format
   - Fixed `breeding_service.py` - Pregnancy and child aging operations use naive datetimes
@@ -634,22 +692,26 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **Test Suite** - Fixed `test_get_info_returns_valid_build_date` expecting timezone info in ISO format
 
 ### Added
+
 - **Documentation**
   - Hotfix deployment guide with rollback procedures
   - Timezone-naive analysis (169 occurrences identified)
   - Comprehensive release notes
 
 ### Changed
+
 - Version bumped from 2.4.0 to 2.4.1 (backend and frontend)
 - Updated `uv.lock` to reflect version change
 
 ### Impact
+
 - ✅ Celery workers no longer crash on dweller death events
 - ✅ Game tick processing continues uninterrupted
 - ✅ Breeding and pregnancy systems function correctly
 - ✅ All tests passing
 
 ### Notes
+
 - This is a temporary fix ensuring all datetime objects remain naive to match database schema (`TIMESTAMP WITHOUT TIME ZONE`)
 - Future work: Full migration to timezone-aware system
 
@@ -658,6 +720,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [2.7.5] - 2026-01-29
 
 ### Added
+
 - **Changelog System** - Version update notifications and changelog display
   - ChangelogModal component with terminal-themed design and smooth animations
   - Version comparison logic to show new entries since last seen version
@@ -667,6 +730,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   - Version detection composable for automatic new version notifications
 
 ### Fixed
+
 - **API Architecture** - Moved changelog endpoints from `/changelog/` to `/system/changelog/`
   - Added `/system/changelog/latest` endpoint for latest version lookup
   - Fixed module import paths for UI components and API utilities
@@ -674,6 +738,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   - Fixed modal v-model binding and lifecycle management
 
 ### Changed
+
 - **API Organization** - Changelog endpoints now under `/api/v1/system/` as public endpoints
 - **Frontend Structure** - Added profile module with changelog routes and services
 - **Modal Design** - Clean terminal-themed modal with proper UCard integration
@@ -684,6 +749,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [2.7.0] - 2026-01-28
 
 ### Added
+
 - **Storage Management System**
   - Storage sidebar navigation entry (hotkey: 9)
   - Storage space tracking and visualization
@@ -705,6 +771,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   - Replaced Prettier with oxfmt across frontend
 
 ### Fixed
+
 - **Junk Item Pricing** - Now based on rarity (Common=2, Rare=50, Legendary=200)
 - **Equipment Filtering** - Weapons and outfits now properly filter by vault
 - **Storage Schema** - Added missing storage_id fields to weapon/outfit/junk schemas
@@ -713,23 +780,27 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **UI Consistency** - Migrated components to UCard, UButton, UTails components
 
 ### Changed
+
 - Version bumped from 2.6.6 to 2.7.0 (backend and frontend)
 - Replaced Prettier with oxfmt for 30x faster formatting
 - Updated frontend to use Tailwind utilities instead of scoped CSS
 - Enhanced storage item cards with Weight and Durability stats
 
 ### Changed
+
 - Version bumped from 2.6.6 to 2.7.0 (backend and frontend)
 - Replaced Prettier with oxfmt for 30x faster formatting
 - Updated frontend to use Tailwind utilities instead of scoped CSS
 - Enhanced storage item cards with Weight and Durability stats
 
 ### Documentation
+
 - Easter eggs documentation added to ROADMAP.md
 - Development scripts cleanup
 - Moved documentation to proper docs/ directory
 
 ### Testing
+
 - Added comprehensive tests for weapon scrap/sell/vault filtering (9 tests)
 - Added comprehensive tests for outfit scrap/sell/vault filtering (9 tests)
 - Added junk sell tests with pricing verification (6 tests)
@@ -740,6 +811,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [2.6.6] - 2026-01-27
 
 ### Changed
+
 - **Backend Dependencies Updated**
   - alembic: 1.18.0 → 1.18.1
   - faker: 40.1.0 → 40.1.2
@@ -751,10 +823,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   - ty: 0.0.11 → 0.0.13
 
 ### Fixed
+
 - **UI Theme Consistency** - Replaced hardcoded colors in notification components with CSS theme variables
 - **Documentation Organization** - Archived completed refactoring documentation
 
 ### Removed
+
 - Obsolete development scripts (check_rooms.py, test_config.py)
 
 ---
@@ -762,6 +836,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [2.6.5] - 2026-01-27
 
 ### Added
+
 - **Notification Bell UI Component**
   - Notification bell in NavBar with unread count badge
   - Pop-up UI showing recent notifications
@@ -775,17 +850,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   - Comprehensive notification integration tests (4 tests)
 
 ### Fixed
+
 - **Notification Error Handling** - Wrapped notification calls in try/except to prevent failures from breaking core flows
 - **Memory Leak** - Clear notification polling interval on component unmount
 - **Incident Types** - Added missing incident type mappings (MOLE_RAT_ATTACK, FERAL_GHOUL_ATTACK)
 - **Duplicate Notifications** - Removed duplicate notifications for dweller arrivals and baby births
 
 ### Changed
+
 - Improved incident names with emoji icons for better UX
 - Simplified notification bell display condition
 - Enhanced notification error logging with full context
 
 ### Testing
+
 - Added comprehensive notification integration tests
 - Moved test fixtures to conftest.py following established pattern
 - All 4 notification tests passing
@@ -795,6 +873,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [2.6.0] - 2026-01-26
 
 ### Added
+
 - **Wasteland Exploration Enhancements**
   - Distributed WebSocket system for exploration events
   - Enhanced exploration UI with real-time updates
@@ -805,6 +884,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   - Enhanced UI polish and user experience improvements
 
 ### Changed
+
 - Improved WebSocket infrastructure for better real-time performance
 - Enhanced exploration coordination and event handling
 
@@ -813,6 +893,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [2.5.0] - 2026-01-26
 
 ### Added
+
 - **Room Visual Assets**
   - 220+ room sprite images for all room types, tiers, and sizes
   - Room images render in vault overview grid as backgrounds
@@ -827,6 +908,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   - Real-time capacity validation on drag-and-drop
 
 ### Changed
+
 - **UI Improvements**
   - Compact room info overlay for better visibility
   - Reduced font sizes and padding for room name, category, tier
@@ -846,6 +928,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [2.4.0] - 2026-01-25
 
 ### Added
+
 - **Death System** - Complete dweller death and revival mechanics
   - Death causes: Health depletion, radiation poisoning, incidents, exploration, combat
   - Revival system with bottle cap cost (configurable)
@@ -861,12 +944,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [2.3.0] - 2026-01-24
 
 ### Added
+
 - **Pregnancy Debug Panel** - UI controls for testing pregnancy system (superuser only)
   - Force conception between any two adult dwellers
   - Accelerate pregnancy to be immediately due
   - Accessible from Relationships → Pregnancies tab
 
 ### Fixed
+
 - **Exploration Item Tracking** - Item count now updates in real-time during exploration
 - **Exploration Rewards Modal** - Modal stays open until user collects rewards (no auto-close)
 - **Storage Duplicate Items** - Removed unique constraint on item names (fixes crash when finding multiple items)
@@ -875,10 +960,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **Relationships View** - Fixed dweller loading for pregnancy debug panel
 
 ### Changed
+
 - Compacted AGENTS.md development guide (830 → 200 lines)
 - Updated pregnancy text to clarify conception chance is configurable
 
 ### Testing
+
 - All 684 frontend tests passing
 
 ---
@@ -886,10 +973,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [2.1.1] - 2026-01-22
 
 ### Added
+
 - Implementation plan for v2.2.0 (death system, UX enhancements)
 - Floating tooltips for improved UX
 
 ### Fixed
+
 - **UI Improvements** (#155)
   - AI generation button logic (Generate vs Regenerate states)
   - Theme color consistency fixes
@@ -897,6 +986,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   - Room menu styling
 
 ### Testing
+
 - All 670 frontend tests passing
 
 ---
@@ -904,6 +994,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [2.1.0] - 2026-01-22
 
 ### Added
+
 - **Modular Frontend Architecture** (#149)
   - 10 feature-based domain modules
   - 300+ files reorganized
@@ -911,10 +1002,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   - Complete architecture documentation
 
 ### Fixed
+
 - TypeScript strict build errors (#152)
 - Template type errors with strictTemplates (#153)
 
 ### Testing
+
 - All 639 frontend tests passing after refactor
 
 ---
@@ -922,10 +1015,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [2.0.2] - 2026-01-22
 
 ### Added
+
 - Agent skills documentation (#143)
 - Deployment optimization guide (#133)
 
 ### Changed
+
 - Documentation consolidation (#148)
 
 ---
@@ -933,6 +1028,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [2.0.1] - 2026-01-22
 
 ### Fixed
+
 - Relationship service and vault CRUD issues (#144)
 - Dependency updates (urllib3, pyasn1)
 
@@ -941,10 +1037,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [2.0.0] - 2026-01-22
 
 ### Changed
+
 - **BREAKING**: Major version bump from v1.4.2 for semantic-release alignment
 - No API breaking changes - version jump for release automation
 
 ### Notes
+
 - Docker images now follow v2.x.x tagging
 - See AGENTS.md for versioning strategy
 
@@ -955,6 +1053,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Fixed
 
 #### TypeScript Build & Module Polish (PR #152)
+
 - **Build Strict**: Resolved all `build:strict` TypeScript errors across modular architecture
 - **Config Fixes**: Fixed vite.config.ts and vitest.config.ts plugin array type issues
 - **Type Safety**: Fixed useTheme.ts parseInt non-null assertions for regex results
@@ -964,6 +1063,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **Cleanup**: Deleted orphaned view files replaced by module views, updated router paths
 
 ### Changed
+
 - Updated relative imports to `@/` alias throughout codebase (OutfitCard, WeaponCard, RadioStatsPanel, EmptyCell)
 - All 651 frontend tests passing
 
@@ -974,16 +1074,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Added
 
 #### System Information & About Page
+
 - **Backend**: Public `/api/v1/info` endpoint returning app version, API version, environment, Python version
 - **Frontend**: Terminal-themed About page displaying system information with GitHub link
 - **Testing**: 4 backend tests, 6 frontend tests for info endpoint and About page
 
 #### Rate Limit User Experience
+
 - **429 Error Handling**: User-friendly "Rate Limit Exceeded" messages in axios interceptor
 - **Retry-After Support**: Parses `Retry-After` header to show wait time to users
 - **Toast Notifications**: Clear messaging when rate limited instead of generic errors
 
 ### Changed
+
 - Updated ROADMAP.md with v1.13.6-7 and v1.14 completions
 - Moved "Training Drag-and-Drop UI" from P1 to P3 (nice-to-have)
 
@@ -994,6 +1097,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Added
 
 #### Modular Frontend Architecture
+
 - **Feature-Based Organization**: Complete restructure into 10 domain modules
   - `core/` - Shared UI components, composables, utilities
   - `modules/auth/` - Authentication and user management
@@ -1009,10 +1113,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **Documentation**: Complete architecture guide (archived)
 
 ### Changed
+
 - Reorganized 300+ frontend files into modular structure
 - Updated all import paths to use new module organization
 
 ### Fixed
+
 - All 639 frontend tests passing after refactor
 
 ---
@@ -1020,11 +1126,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [1.13.5-1.13.6] - 2026-01-17
 
 ### Added
+
 - **Proactive Token Refresh**: Automatic refresh 5 minutes before expiry
 - **Refresh Token Rotation**: Enhanced security with token rotation
 - **Production Security**: Rate limiting, IP filtering, auto-banning with Redis
 
 ### Fixed
+
 - **MinIO Production**: Internal connection protocol issues resolved
 - **Database Migrations**: Profile initialization and SQLAlchemy session errors
 - **CI/CD Performance**: Optimized caching strategies
@@ -1034,6 +1142,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [1.9-1.12] - 2026-01-03 to 2026-01-06
 
 ### Summary
+
 - Audio conversation system with STT/TTS
 - Multi-provider AI support (Ollama/Anthropic/OpenAI)
 - WebSocket chat with typing indicators
@@ -1235,10 +1344,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **Testing**: 11 comprehensive service tests
 
 ### Changed
+
 - Dweller: Added trainings relationship, max_health → 1500
 - Game balance: Training constants added
 
 ### Fixed
+
 - **Foreign Key Constraints**: Added `ondelete` behavior to prevent IntegrityError
   - Dweller self-references (partner_id, parent_1_id, parent_2_id): `SET NULL` on delete
   - Relationship table (dweller_1_id, dweller_2_id): `CASCADE` on delete
@@ -1251,7 +1362,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 #### Core Leveling System (Backend)
 
-- **XP Calculation**: Exponential curve (100 * level^1.5) for 1-50 progression
+- **XP Calculation**: Exponential curve (100 \* level^1.5) for 1-50 progression
 - **XP Sources**:
   - Exploration (survival +20%, luck +2% per point)
   - Combat (perfect combat +50%)
@@ -1260,6 +1371,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **Testing**: 11 comprehensive tests
 
 ### Changed
+
 - Enhanced exploration/combat XP with bonuses
 - Added ix_dweller_level index
 
@@ -1272,82 +1384,82 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 #### Breeding System (Backend)
 
 - **Relationship Management**:
-    - Complete CRUD API for dweller relationships
-    - Relationship types: acquaintance, friend, romantic, partner, ex
-    - Affinity system (0-100) tracking relationship strength
-    - Relationship progression endpoints (initiate romance, make partners, break up)
-    - Compatibility scoring based on SPECIAL stats and personality traits
-    - Quick-pair testing endpoint for development
-    - Relationship service layer with business logic
+  - Complete CRUD API for dweller relationships
+  - Relationship types: acquaintance, friend, romantic, partner, ex
+  - Affinity system (0-100) tracking relationship strength
+  - Relationship progression endpoints (initiate romance, make partners, break up)
+  - Compatibility scoring based on SPECIAL stats and personality traits
+  - Quick-pair testing endpoint for development
+  - Relationship service layer with business logic
 
 - **Pregnancy System**:
-    - Pregnancy creation with conception mechanics
-    - 3-hour pregnancy duration (configurable)
-    - Pregnancy status tracking (pregnant/delivered)
-    - Baby delivery endpoint with child creation
-    - Child inherits SPECIAL traits from both parents
-    - Age progression system (child → teen → adult)
-    - Due date calculation with timezone-aware comparisons
-    - Progress percentage and time remaining calculations
+  - Pregnancy creation with conception mechanics
+  - 3-hour pregnancy duration (configurable)
+  - Pregnancy status tracking (pregnant/delivered)
+  - Baby delivery endpoint with child creation
+  - Child inherits SPECIAL traits from both parents
+  - Age progression system (child → teen → adult)
+  - Due date calculation with timezone-aware comparisons
+  - Progress percentage and time remaining calculations
 
 #### Radio Recruitment System (Backend)
 
 - **Radio Room Functionality**:
-    - Manual recruitment endpoint (500 caps cost)
-    - Automatic recruitment rate calculation
-    - Radio mode toggle: Recruitment vs. Happiness boost
-    - Recruitment speedup multipliers (1.0x-10.0x per radio room)
-    - Multiple radio rooms stack for increased recruitment rates
-    - Happiness-based recruitment probability
-    - Charisma stat influence on recruitment
-    - Radio service layer with rate calculations
+  - Manual recruitment endpoint (500 caps cost)
+  - Automatic recruitment rate calculation
+  - Radio mode toggle: Recruitment vs. Happiness boost
+  - Recruitment speedup multipliers (1.0x-10.0x per radio room)
+  - Multiple radio rooms stack for increased recruitment rates
+  - Happiness-based recruitment probability
+  - Charisma stat influence on recruitment
+  - Radio service layer with rate calculations
 
 #### Database & Models
 
 - **New Models**:
-    - `Relationship` model with dweller associations
-    - `Pregnancy` model with parent tracking
-    - Extended `Dweller` model with age group and parent fields
-    - `RadioMode` enum for room mode tracking
+  - `Relationship` model with dweller associations
+  - `Pregnancy` model with parent tracking
+  - Extended `Dweller` model with age group and parent fields
+  - `RadioMode` enum for room mode tracking
 
 - **Enums**:
-    - `RelationshipTypeEnum` (acquaintance, friend, romantic, partner, ex)
-    - `PregnancyStatusEnum` (pregnant, delivered)
-    - `AgeGroupEnum` (child, teen, adult)
-    - `RadioModeEnum` (recruitment, happiness)
+  - `RelationshipTypeEnum` (acquaintance, friend, romantic, partner, ex)
+  - `PregnancyStatusEnum` (pregnant, delivered)
+  - `AgeGroupEnum` (child, teen, adult)
+  - `RadioModeEnum` (recruitment, happiness)
 
 ### Fixed
 
 - **Test Suite Corrections**:
-    - Fixed `create_with_user_id` to accept dict inputs in addition to Pydantic models
-    - Fixed pregnancy timezone comparison (naive vs. aware datetime handling)
-    - Fixed radio room test data (category enum: "misc" → "misc.")
-    - Added missing required fields to RoomCreate in tests (base_cost, upgrade costs, size constraints)
-    - Fixed test assertions to match actual API response schemas
-    - Fixed relationship query to use UUID conversion for database lookups
-    - Updated expected status codes (404 → 422 for validation errors)
-    - Updated expected response keys (child → child_id, status values)
+  - Fixed `create_with_user_id` to accept dict inputs in addition to Pydantic models
+  - Fixed pregnancy timezone comparison (naive vs. aware datetime handling)
+  - Fixed radio room test data (category enum: "misc" → "misc.")
+  - Added missing required fields to RoomCreate in tests (base_cost, upgrade costs, size constraints)
+  - Fixed test assertions to match actual API response schemas
+  - Fixed relationship query to use UUID conversion for database lookups
+  - Updated expected status codes (404 → 422 for validation errors)
+  - Updated expected response keys (child → child_id, status values)
 
 ### Testing
 
 - **Backend Tests**:
-    - 11 relationship API tests (CRUD, romance, partners, breakup)
-    - 8 pregnancy API tests (create, deliver, status tracking, progress)
-    - 6 radio API tests (manual recruit, mode toggle, rate calculation)
-    - Full test coverage for breeding and radio services
-    - All backend tests passing (600+ tests)
+  - 11 relationship API tests (CRUD, romance, partners, breakup)
+  - 8 pregnancy API tests (create, deliver, status tracking, progress)
+  - 6 radio API tests (manual recruit, mode toggle, rate calculation)
+  - Full test coverage for breeding and radio services
+  - All backend tests passing (600+ tests)
 
 ### Technical
 
 - **CRUD Operations**:
-    - `CRUDRelationship` with bidirectional relationship queries
-    - `CRUDPregnancy` with due date and delivery logic
-    - Enhanced `CRUDVault` with dict/model input handling
+  - `CRUDRelationship` with bidirectional relationship queries
+  - `CRUDPregnancy` with due date and delivery logic
+  - Enhanced `CRUDVault` with dict/model input handling
 
 - **Service Layer**:
-    - `RelationshipService` with compatibility and progression logic
-    - `BreedingService` with conception and delivery mechanics
-    - `RadioService` with recruitment rate calculations
+  - `RelationshipService` with compatibility and progression logic
+  - `BreedingService` with conception and delivery mechanics
+  - `RadioService` with recruitment rate calculations
 
 ## [1.3.1] - 2026-01-01
 
@@ -1356,19 +1468,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 #### Room Detail Modal Enhancements
 
 - **Frontend**:
-    - Added clickable dweller cards in Room Detail Modal
-    - Implemented navigation to dweller detail page when clicking on assigned dwellers
-    - Added hover effects with cursor pointer, lift animation, and enhanced glow for clickable dwellers
-    - Integrated Vue Router navigation with proper route params (vault ID and dweller ID)
+  - Added clickable dweller cards in Room Detail Modal
+  - Implemented navigation to dweller detail page when clicking on assigned dwellers
+  - Added hover effects with cursor pointer, lift animation, and enhanced glow for clickable dwellers
+  - Integrated Vue Router navigation with proper route params (vault ID and dweller ID)
 
 ### Fixed
 
 - Fixed Vue Router mock in RoomDetailModal tests by adding `useRouter` mock
 - Updated test expectations to match new component layout:
-    - Dweller capacity display format (e.g., "2 / 2" instead of "2 / 4")
-    - Room size display format (e.g., "1x merged" instead of raw numbers)
-    - Section title changed from "Assigned Dwellers" to "Dweller Details"
-    - Efficiency calculations updated to reflect actual room capacity logic
+  - Dweller capacity display format (e.g., "2 / 2" instead of "2 / 4")
+  - Room size display format (e.g., "1x merged" instead of raw numbers)
+  - Section title changed from "Assigned Dwellers" to "Dweller Details"
+  - Efficiency calculations updated to reflect actual room capacity logic
 - Fixed router error by properly importing and using `useRouter` at component setup level
 
 ### Testing
@@ -1383,36 +1495,36 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 #### Room Management System
 
 - **Backend**:
-    - Added room upgrade endpoint `POST /api/v1/rooms/upgrade/{room_id}`
-    - Implemented tier progression system (1→2→3) with capacity/output recalculation
-    - Added proportional scaling formula for capacity and output based on tier ratio
-    - Implemented upgrade cost validation (t2_upgrade_cost, t3_upgrade_cost)
-    - Added proper error handling for insufficient caps and max tier validation
-    - Added 7 comprehensive pytest tests for room upgrade functionality
+  - Added room upgrade endpoint `POST /api/v1/rooms/upgrade/{room_id}`
+  - Implemented tier progression system (1→2→3) with capacity/output recalculation
+  - Added proportional scaling formula for capacity and output based on tier ratio
+  - Implemented upgrade cost validation (t2_upgrade_cost, t3_upgrade_cost)
+  - Added proper error handling for insufficient caps and max tier validation
+  - Added 7 comprehensive pytest tests for room upgrade functionality
 
 - **Frontend**:
-    - Implemented 4×8 grid layout for visual vault room management
-    - Created room upgrade UI with cost display and tier progression
-    - Added `upgradeRoom()` function to room store with vault refresh
-    - Implemented upgrade button with golden styling and cost tooltip
-    - Added `canUpgrade()` and `getUpgradeCost()` helper functions
-    - Built room selection and detail view system
-    - Added 5 comprehensive Vitest tests for upgrade store functionality
+  - Implemented 4×8 grid layout for visual vault room management
+  - Created room upgrade UI with cost display and tier progression
+  - Added `upgradeRoom()` function to room store with vault refresh
+  - Implemented upgrade button with golden styling and cost tooltip
+  - Added `canUpgrade()` and `getUpgradeCost()` helper functions
+  - Built room selection and detail view system
+  - Added 5 comprehensive Vitest tests for upgrade store functionality
 
 #### Exploration System Enhancements
 
 - **Backend**:
-    - Fixed datetime timezone handling (reverted to `datetime.utcnow()`)
-    - Removed debug logging from exploration models
-    - Improved timezone compatibility between database and application
+  - Fixed datetime timezone handling (reverted to `datetime.utcnow()`)
+  - Removed debug logging from exploration models
+  - Improved timezone compatibility between database and application
 
 - **Frontend**:
-    - Implemented auto-complete detection for explorations at 100% progress
-    - Added manual Complete button for explorations
-    - Created `ExplorationRewardsModal.vue` with terminal-themed design
-    - Display experience (with golden pulse animation), caps, items, distance, enemies
-    - Added recalled early indicator with reduced rewards display
-    - Implemented duplicate call prevention for completion actions
+  - Implemented auto-complete detection for explorations at 100% progress
+  - Added manual Complete button for explorations
+  - Created `ExplorationRewardsModal.vue` with terminal-themed design
+  - Display experience (with golden pulse animation), caps, items, distance, enemies
+  - Added recalled early indicator with reduced rewards display
+  - Implemented duplicate call prevention for completion actions
 
 ### Fixed
 
@@ -1443,27 +1555,27 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 #### Equipment System
 
 - **Backend**:
-    - Added weapon and outfit equip/unequip endpoints
-    - Implemented eager loading for equipment relationships to prevent lazy loading errors
-    - Updated `DwellerReadFull` schema to include weapon and outfit fields
-    - Override `CRUDDweller.get()` to eager load weapon, outfit, vault, and room relationships
-    - Fixed SQLAlchemy async session issues with `selectinload()`
+  - Added weapon and outfit equip/unequip endpoints
+  - Implemented eager loading for equipment relationships to prevent lazy loading errors
+  - Updated `DwellerReadFull` schema to include weapon and outfit fields
+  - Override `CRUDDweller.get()` to eager load weapon, outfit, vault, and room relationships
+  - Fixed SQLAlchemy async session issues with `selectinload()`
 
 - **Frontend**:
-    - Created comprehensive TypeScript equipment type system (`equipment.ts`)
-        - Weapon types: MELEE, RANGED with subtypes (FIST, BLADE, PISTOL, RIFLE, etc.)
-        - Outfit types: CASUAL, WORK, COMBAT, SPECIAL
-        - Rarity system: COMMON, UNCOMMON, RARE, LEGENDARY
-    - Implemented equipment service layer with API integration
-    - Created Pinia equipment store with state management
-    - Built `WeaponCard.vue` component with damage stats and rarity coloring
-    - Built `OutfitCard.vue` component with SPECIAL stat bonuses
-    - Implemented `DwellerEquipment.vue` with:
-        - Equipment slots for weapon and outfit
-        - Inventory modal with tabbed interface
-        - Real-time equipment updates
-        - Empty states for unequipped slots
-    - Added refresh event chain for automatic data updates after equipment changes
+  - Created comprehensive TypeScript equipment type system (`equipment.ts`)
+    - Weapon types: MELEE, RANGED with subtypes (FIST, BLADE, PISTOL, RIFLE, etc.)
+    - Outfit types: CASUAL, WORK, COMBAT, SPECIAL
+    - Rarity system: COMMON, UNCOMMON, RARE, LEGENDARY
+  - Implemented equipment service layer with API integration
+  - Created Pinia equipment store with state management
+  - Built `WeaponCard.vue` component with damage stats and rarity coloring
+  - Built `OutfitCard.vue` component with SPECIAL stat bonuses
+  - Implemented `DwellerEquipment.vue` with:
+    - Equipment slots for weapon and outfit
+    - Inventory modal with tabbed interface
+    - Real-time equipment updates
+    - Empty states for unequipped slots
+  - Added refresh event chain for automatic data updates after equipment changes
 
 #### UI/UX Improvements
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -519,15 +519,15 @@ const handleVersionClick = () => {
 **Code Snippet**:
 
 ```typescript
-import { useMagicKeys } from "@vueuse/core";
+import { useMagicKeys } from '@vueuse/core'
 
-const { ArrowUp, ArrowDown, ArrowLeft, ArrowRight, b, a } = useMagicKeys();
-const sequence = ref("");
+const { ArrowUp, ArrowDown, ArrowLeft, ArrowRight, b, a } = useMagicKeys()
+const sequence = ref('')
 
 watch([ArrowUp, ArrowDown, ArrowLeft, ArrowRight, b, a], () => {
   // Track key sequence and check for Konami Code
   // ↑ ↑ ↓ ↓ ← → ← → B A
-});
+})
 ```
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,6 +10,7 @@ AI-powered dweller interactions.
 ## In Progress
 
 **Current work (post-v2.13.0):**
+
 - [ ] Nuxt UI component migration (phased, see archived plan)
 - [ ] Multi-theme support (Terminal Green, Amber, Teal + custom)
 - [ ] Staged axios deprecation (see `frontend/HTTP_CLIENT_MIGRATION.md`)
@@ -24,6 +25,7 @@ AI-powered dweller interactions.
 **Focus**: Replaced Celery with Dramatiq for simpler, more reliable task processing
 
 **Completed:**
+
 - ✅ **Dramatiq Task Queue** - Migrated from Celery + Celery Beat to Dramatiq + Periodiq
   - 8 task actors: `game_tick`, `process_vault_tick`, `check_permanent_deaths`, `check_quest_completion`, `refresh_daily_objectives`, `refresh_weekly_objectives`, `cleanup_old_records`, `create_task`
   - Periodiq scheduler replaces Celery Beat with cron syntax
@@ -33,15 +35,42 @@ AI-powered dweller interactions.
 - ✅ **Dependency Cleanup** - Removed `celery`, `sqlalchemy-celery-beat`, `celery-types`, `psycopg2`
 
 **Migration required:**
+
 - Update `.env`: remove `CELERY_BROKER_URL`, `CELERY_RESULT_BACKEND`, `FLOWER_USER`, `FLOWER_PASSWORD`
 - Update Docker Compose: replace `celery_worker` + `celery_beat` + `flower` with `dramatiq_worker`
 - Run DB migration to drop `celery_schedule_jobs` table
+
+### v2.13.1 - Security & Reliability Hardening (May 19, 2026)
+
+**Focus**: Security improvements and infrastructure reliability post-Dramatiq migration
+
+**Completed:**
+
+- ✅ **Non-root containers** - Backend Docker image no longer runs as root
+- ✅ **RustFS credential security** - Removed hardcoded credentials; `RUSTFS_ACCESS_KEY` / `RUSTFS_SECRET_KEY` now required explicitly
+- ✅ **Task scheduler auto-recovery** - Docker restart policy added for Dramatiq worker / Periodiq scheduler
+- ✅ **DB migration cleanup** - Fixed migration leaving orphaned PostgreSQL enum types on Celery table drop
+- ✅ **RustFS config restored** - `.env.prod.example` now includes all required `RUSTFS_*` variables
+- ✅ **Documentation cleanup** - Removed 11 outdated docs, archived 4 guides, compacted 12-factor report
+
+### v2.14 - Asset Repurpose & Bug Fixes (In Progress)
+
+**Focus**: Repurpose soft-deleted dweller assets for radio recruitment; address issues discovered post-Dramatiq migration
+
+**In Progress:**
+
+- [ ] **Radio asset repurpose** (`2.14-repurpose`) - When the radio recruits, prefer restoring a soft-deleted dweller (reusing their existing S3 image/thumbnail/bio assets) over generating a blank new one. Falls back to `create_random` when the recycling pool is empty or an override is supplied. Config-gated via `RADIO_RECYCLE_ENABLED` / `RADIO_RECYCLE_PROBABILITY` / `RADIO_RECYCLE_MIN_AGE_DAYS`. Frontend shows a distinct toast for recycled recruits.
+
+**Planned:**
+
+- [ ] **SQLAlchemy async concurrency error in `game_tick`** - `InterfaceError: cannot perform operation: another operation is in progress` during objective queries (`vaultobjectiveprogresslink`) inside game tick tasks. Root cause: concurrent async operations sharing the same SQLAlchemy connection/session. Fix: ensure proper session isolation per task (`async with` session per query).
 
 ### v2.12.0 - Stabilization & Quality (April 23, 2026)
 
 **Focus**: Fix all failing tests, remove deprecated code, harden error handling
 
 **Completed:**
+
 - ✅ **Chat Error Handling** - Hardened AI provider failure handling across all services
   - Fixed `AttributeError: 'coroutine' object has no attribute 'input_tokens'` bug
   - Added safe usage extraction with fallback to `None` for token counts
@@ -62,6 +91,7 @@ AI-powered dweller interactions.
 **Focus**: Vite+ unified toolchain, dweller recycling service, and test fixes
 
 **Completed:**
+
 - ✅ **Vite+ Unified Toolchain** - Migrated to Vite+ for improved bundling and DX
   - Unified build tooling across frontend
   - Improved build performance
@@ -80,6 +110,7 @@ AI-powered dweller interactions.
 **Focus**: AI usage monitoring, token quota enforcement, and observability improvements
 
 **Completed:**
+
 - ✅ **AI Usage API** - New `/me/profile/ai-usage` endpoint with token statistics
   - Tracks prompt, completion, and total tokens across all AI calls
   - Redis-cached responses for performance
@@ -105,6 +136,7 @@ AI-powered dweller interactions.
 **Focus**: Storage provider migration, objective improvements, code quality
 
 **Completed:**
+
 - ✅ **RustFS Migration** - Switched default storage from MinIO to RustFS
   - Added utility scripts for image URL fixes and bucket policies
   - Updated bucket whitelist with all required buckets
@@ -116,6 +148,7 @@ AI-powered dweller interactions.
 **Focus**: Fixed quest seeding bugs and verified quest system works
 
 **Completed:**
+
 - ✅ **Quest JSON Fixes** - Fixed invalid requirement types in quest files
   - Changed `dweller_level` → `level` in 4 quest files
   - Removed invalid `weapon_damage` requirement type
@@ -135,12 +168,14 @@ AI-powered dweller interactions.
 **Focus**: Stimpaks and Radaways vault storage with production from Medbay/Science Lab
 
 **Known Issue (needs fix):**
+
 - ⚠️ **Storage Model Refactor** - Currently stimpaks/radaways are on Vault model, should be on Storage model
   - Add fields to Storage: `stimpack`, `radaway`, `stimpack_max`, `radaway_max`
   - Remove from Vault model
   - Update all code to read/write from storage instead of vault
 
 **Planned:**
+
 - [ ] **Vault Storage for Medical Items** - Add stimpaks and radaways to vault storage
   - New storage model fields: `stimpaks`, `radaways`
   - Max capacity calculated from Medbay/Science Lab rooms (number + tier)
@@ -163,6 +198,7 @@ AI-powered dweller interactions.
 **Focus**: Fixed type errors and lint warnings
 
 **Completed:**
+
 - ✅ Fixed Vue TypeScript build errors (undefined array access, void elements)
 - ✅ Fixed backend lint warnings
 
@@ -173,6 +209,7 @@ AI-powered dweller interactions.
 **Focus**: Working quest system with proper reward distribution and objective progress tracking
 
 **Completed:**
+
 - ✅ **Quest JSON Loading** - Fixed `QuestJSON` schema to accept both space-separated ("Quest name") and snake_case ("quest_name") field names
 - ✅ **Quest Seeding** - All 19 quests across 7 chains now load correctly from JSON files
 - ✅ **Quest Rewards** - Implemented `reward_service.process_quest_rewards()` with caps, items, dwellers, stimpaks, radaways, and lunchboxes
@@ -190,6 +227,7 @@ AI-powered dweller interactions.
 **Focus**: Major frontend component refactoring and backend code quality improvements
 
 **Completed:**
+
 - ✅ **RoomDetailModal Deep Split** - Reduced from 1045 lines to ~200 lines (~80% reduction)
   - Extracted 7 focused components: RoomDetailHeader, RoomPreviewSection, RoomInfoGrid, ProductionStats, DwellerList, RoomActions, RadioControls
   - Extracted 4 composables: useRoomProduction, useRoomUpgrade, useRoomDwellers, useRadioRoom
@@ -206,6 +244,7 @@ AI-powered dweller interactions.
 **Focus**: Chat action suggestions, exploration integration, and smarter room assignment
 
 **Completed:**
+
 - ✅ **Exploration from Chat** - Start and recall explorations directly from dweller chat
   - `start_exploration` action with automatic supply packing (2 stimpaks / 1 radaway caps)
   - `recall_exploration` action with completion detection (collect rewards if done)
@@ -230,6 +269,7 @@ AI-powered dweller interactions.
 **Focus**: Technical debt reduction, code deduplication, and maintainability improvements
 
 **Completed:**
+
 - ✅ **Code Deduplication**
   - Removed empty CRUD classes (weapon, outfit, junk) - now use CRUDItem directly
   - Extracted vault filtering logic into shared `get_items_list()` utility
@@ -240,7 +280,7 @@ AI-powered dweller interactions.
   - Moved exploration/item constants to game_config.py (rarity priorities, junk values, scrap probabilities)
 - ✅ **Refactoring**
   - Refactored `_transfer_loot_to_storage()` - reduced from 171 to ~110 lines
-  - Extracted 4 helper methods (_parse_rarity_to_enum, _create_weapon_from_loot, _create_outfit_from_loot, _create_junk_from_loot)
+  - Extracted 4 helper methods (\_parse_rarity_to_enum, \_create_weapon_from_loot, \_create_outfit_from_loot, \_create_junk_from_loot)
   - Removed complexity suppressions (PLR0912, PLR0915)
 - ✅ **Storage & Infrastructure**
   - Added RustFS storage provider support (alongside MinIO)
@@ -253,6 +293,7 @@ AI-powered dweller interactions.
   - Added training room status assignment test
 
 **Deferred to Future Releases:**
+
 - Add query builder methods to CRUDBase for soft-delete and vault-scoped queries
 - Create `get_or_404()` helper to reduce ResourceNotFoundException boilerplate (28 locations)
 - Add notification error handling decorator/utility
@@ -267,6 +308,7 @@ AI-powered dweller interactions.
 **Focus**: Hidden features, terminal aesthetic polish, and UX bug fixes
 
 **Completed:**
+
 - ✅ **Changelog System**
   - Terminal-themed modal with version update notifications
   - Auto-show on login after update
@@ -298,6 +340,7 @@ AI-powered dweller interactions.
   - Resource tooltips now visible
 
 **Remaining for v2.10.0+:**
+
 - Token Management & Usage Tracking
 - Provider Rotation (Ollama URL config + health checking)
 - Admin & Configuration (birth control, room render config)
@@ -311,6 +354,7 @@ AI-powered dweller interactions.
 **Focus**: Vault storage system implementation and UI improvements
 
 **Completed:**
+
 - ✅ **Storage Management System**
   - Storage sidebar navigation entry (hotkey: 9)
   - Storage space tracking and visualization
@@ -334,6 +378,7 @@ AI-powered dweller interactions.
   - Improved button layout and grouping
 
 **Remaining for Future Updates:**
+
 - Layout Improvements (sticky panels, smooth scrolling)
 - Toast Notifications (unification, grouping, deduplication)
 - Exploration UI (overflow handling, pagination, history)
@@ -343,6 +388,7 @@ AI-powered dweller interactions.
 **Status**: Notification system implemented
 
 **Completed:**
+
 - ✅ Notification bell UI component with pop-up
 - ✅ Exploration completion notifications
 - ✅ Radio recruitment notifications
@@ -362,11 +408,13 @@ AI-powered dweller interactions.
 **Trigger**: Player renames a dweller to "Gary"
 
 **Effect**:
+
 - For 10 seconds, all text in the UI (headers, buttons, logs, tooltips) displays "Gary"
 - Terminal glitch/flicker animation during transformation
 - Audio: Distorted "Gary!" voice clip (optional)
 
 **Implementation Notes**:
+
 - Vue composable: `useGaryMode()`
 - Global reactive state that temporarily overrides text rendering
 - CSS class `.gary-mode` on `<body>` element
@@ -380,12 +428,14 @@ AI-powered dweller interactions.
 **Trigger**: Rename a dweller to "Todd"
 
 **Effect**:
+
 - **Permanent Buff**: +10 Charisma (CHA) stat
 - **Hidden 24h Buff**: 100% Rush Success Rate
 - **Audio**: On successful rush, play Todd Howard's "It just works" voice clip instead of default success sound
 - **Visual**: Special golden glow effect on the dweller card
 
 **Implementation Notes**:
+
 - Backend: Add hidden buff system for temporary bonuses
 - Track buff expiry with timestamp
 - Frontend: Custom sound effect for Todd dweller rush success
@@ -398,6 +448,7 @@ AI-powered dweller interactions.
 **Trigger**: Rapidly click the version number in footer 7 times
 
 **Effect**:
+
 1. Screen fades to black
 2. Terminal text types out: `CRITICAL FAILURE. INITIATING PROTOCOL 27...`
 3. Fake "Vault-Tec Terminal Crash" screen with CRT effects
@@ -406,6 +457,7 @@ AI-powered dweller interactions.
 6. Toast notification: "Emergency systems restored. Compensation awarded."
 
 **Implementation Notes**:
+
 - Click counter with timeout (reset after 2s of no clicks)
 - Full-screen modal overlay with CRT/terminal aesthetic
 - Typewriter text animation
@@ -413,6 +465,7 @@ AI-powered dweller interactions.
 - Version number extraction from `package.json` (not hardcoded)
 
 **Code Snippet**:
+
 ```vue
 <script setup>
 import { ref } from 'vue'
@@ -445,6 +498,7 @@ const handleVersionClick = () => {
 **Trigger**: Enter Konami Code sequence: ↑ ↑ ↓ ↓ ← → ← → B A
 
 **Effect**:
+
 - Toast notification: "Cheat Codes Enabled"
 - Unlock hidden "Debug Room" in build menu
 - Debug Room properties:
@@ -455,6 +509,7 @@ const handleVersionClick = () => {
   - Category: "Experimental" (new category)
 
 **Implementation Notes**:
+
 - Use VueUse `useMagicKeys()` composable for key sequence detection
 - Backend: Add "Debug Room" template (locked by default)
 - Frontend: Toggle room availability in build menu based on cheat code state
@@ -462,16 +517,17 @@ const handleVersionClick = () => {
 - Deathclaw spawn: Celery task with 50% probability
 
 **Code Snippet**:
-```typescript
-import { useMagicKeys } from '@vueuse/core'
 
-const { ArrowUp, ArrowDown, ArrowLeft, ArrowRight, b, a } = useMagicKeys()
-const sequence = ref('')
+```typescript
+import { useMagicKeys } from "@vueuse/core";
+
+const { ArrowUp, ArrowDown, ArrowLeft, ArrowRight, b, a } = useMagicKeys();
+const sequence = ref("");
 
 watch([ArrowUp, ArrowDown, ArrowLeft, ArrowRight, b, a], () => {
   // Track key sequence and check for Konami Code
   // ↑ ↑ ↓ ↓ ← → ← → B A
-})
+});
 ```
 
 ---
@@ -481,12 +537,14 @@ watch([ArrowUp, ArrowDown, ArrowLeft, ArrowRight, b, a], () => {
 **Trigger**: Player reaches exactly 1000 caps (or specific milestone)
 
 **Effect**:
+
 - Mouse cursor leaves glowing blue particle trail (Nuka Quantum style)
 - Particles fade out over 1-2 seconds
 - Effect persists for entire session
 - Subtle, non-intrusive visual enhancement
 
 **Implementation Notes**:
+
 - Canvas overlay with `pointer-events: none`
 - Track mouse coordinates with `mousemove` event
 - Render fading circles/bubbles on canvas
@@ -495,12 +553,10 @@ watch([ArrowUp, ArrowDown, ArrowLeft, ArrowRight, b, a], () => {
 - Z-index: 9999 to stay above all UI
 
 **Code Snippet**:
+
 ```vue
 <template>
-  <canvas
-    ref="quantumCanvas"
-    class="fixed inset-0 pointer-events-none z-[9999]"
-  />
+  <canvas ref="quantumCanvas" class="fixed inset-0 pointer-events-none z-[9999]" />
 </template>
 
 <script setup>
@@ -532,12 +588,14 @@ watch(() => userStore.caps, (caps) => {
 ### Technical Requirements
 
 **Backend**:
+
 - Hidden buff system (temporary stat modifiers)
 - Easter egg event tracking (analytics)
 - API endpoints for easter egg rewards
 - Debug room template data
 
 **Frontend**:
+
 - Global state management for active easter eggs
 - Composables: `useGaryMode()`, `useKonamiCode()`, `useQuantumMouse()`
 - Audio service for custom sound effects
@@ -545,12 +603,14 @@ watch(() => userStore.caps, (caps) => {
 - VueUse integration for key detection
 
 **Testing**:
+
 - Unit tests for each easter egg trigger
 - E2E tests for UI effects
 - Backend tests for buff system
 - Audio playback tests
 
 **Documentation**:
+
 - Easter egg hints in loading screen tips (subtle)
 - Achievement tracking for players who discover them
 - Optional: Hidden achievement badges for each easter egg
@@ -564,6 +624,7 @@ watch(() => userStore.caps, (caps) => {
 **Focus**: Backend refactoring and service improvements
 
 **Completed:**
+
 - ✅ **Backend Refactoring**
   - Split game loop relationship update logic into helper functions
   - Extracted exploration loot transfer into separate coordinator functions
@@ -575,6 +636,7 @@ watch(() => userStore.caps, (caps) => {
 **Focus**: Code quality and service layer enhancements
 
 **Completed:**
+
 - ✅ **Service Refactoring** - Improved game loop service structure
 - ✅ **Code Organization** - Better separation of concerns in backend services
 
@@ -583,44 +645,44 @@ watch(() => userStore.caps, (caps) => {
 **Feature Release** - Room sprite rendering and capacity enforcement
 
 - **Room Images**: Full visual representation of all rooms
-    - 220+ room sprite images for all room types, tiers, and sizes
-    - Images render in vault overview grid as backgrounds
-    - Images display in room detail modal preview section
-    - Intelligent fallback system for missing tier/segment combinations
-    - Automatic image URL generation based on room name, tier, and size
+  - 220+ room sprite images for all room types, tiers, and sizes
+  - Images render in vault overview grid as backgrounds
+  - Images display in room detail modal preview section
+  - Intelligent fallback system for missing tier/segment combinations
+  - Automatic image URL generation based on room name, tier, and size
 - **Room Capacity Enforcement**: Strict dweller assignment limits
-    - Capacity calculation: 2 dwellers per cell (3-cell room = 2, 6-cell = 4, 9-cell = 6)
-    - Prevents over-assignment with user-friendly error messages
-    - Allows reordering dwellers within same room
-    - Real-time capacity validation on drag-and-drop
+  - Capacity calculation: 2 dwellers per cell (3-cell room = 2, 6-cell = 4, 9-cell = 6)
+  - Prevents over-assignment with user-friendly error messages
+  - Allows reordering dwellers within same room
+  - Real-time capacity validation on drag-and-drop
 - **UI Improvements**: Compact room info overlay for better visibility
-    - Reduced font sizes and padding for room name, category, tier
-    - Room info positioned at top with semi-transparent background
-    - Dwellers positioned at bottom
-    - All content properly layered with z-index
+  - Reduced font sizes and padding for room name, category, tier
+  - Room info positioned at top with semi-transparent background
+  - Dwellers positioned at bottom
+  - All content properly layered with z-index
 - **Backend**: Migration to populate image_url for existing rooms
-    - Database migration: `fc75e738a303_add_room_image_urls`
-    - Automatic URL generation during room build and upgrade
-    - Static file serving through `/static` endpoint
+  - Database migration: `fc75e738a303_add_room_image_urls`
+  - Automatic URL generation during room build and upgrade
+  - Static file serving through `/static` endpoint
 - **Frontend**: Vite proxy configuration for image serving
-    - `/static` proxy forwards requests to backend
-    - Image loading with error handlers and console debugging
-    - Test page for verifying image loading functionality
+  - `/static` proxy forwards requests to backend
+  - Image loading with error handlers and console debugging
+  - Test page for verifying image loading functionality
 
 ### v2.4.1 Critical Hotfix (January 25, 2026)
 
 **Hotfix Release** - Resolved production Celery worker crashes
 
 - **Critical Fix**: Timezone-naive datetime mixing causing Celery crashes
-    - Fixed `death_service.py` - All datetime operations use consistent naive format
-    - Fixed `breeding_service.py` - Pregnancy and child aging use naive datetimes
-    - All datetime operations: `datetime.now(UTC).replace(tzinfo=None)`
-    - Prevents asyncpg DataError: "can't subtract offset-naive and offset-aware datetimes"
+  - Fixed `death_service.py` - All datetime operations use consistent naive format
+  - Fixed `breeding_service.py` - Pregnancy and child aging use naive datetimes
+  - All datetime operations: `datetime.now(UTC).replace(tzinfo=None)`
+  - Prevents asyncpg DataError: "can't subtract offset-naive and offset-aware datetimes"
 - **System Info Fix**: `build_date` now uses timezone-aware datetime for proper ISO format
 - **Documentation**:
-    - Hotfix deployment guide
-    - Timezone-naive analysis (169 occurrences)
-    - Release notes
+  - Hotfix deployment guide
+  - Timezone-naive analysis (169 occurrences)
+  - Release notes
 - **Impact**: Celery workers stable, game tick processing uninterrupted, all systems operational
 - **Note**: Temporary fix - full timezone-aware migration planned for future release
 
@@ -629,11 +691,11 @@ watch(() => userStore.caps, (caps) => {
 **Feature Release** - Complete death mechanics and core services
 
 - **Death System**: Full implementation of dweller mortality
-    - Death causes: health, radiation, incidents, exploration, combat
-    - Revival system with bottle cap costs
-    - Permanent death after 7 days (configurable)
-    - Death statistics tracking
-    - Epitaph generation
+  - Death causes: health, radiation, incidents, exploration, combat
+  - Revival system with bottle cap costs
+  - Permanent death after 7 days (configurable)
+  - Death statistics tracking
+  - Epitaph generation
 - **Incident Service**: Room-based incident management
 - **Security Utilities**: Core authentication and authorization helpers
 - **System Endpoint**: Application metadata and version information
@@ -643,8 +705,8 @@ watch(() => userStore.caps, (caps) => {
 **Feature Release** - Testing tools and bug fixes
 
 - **Pregnancy Debug Panel**: UI controls for testing pregnancy system (superuser only)
-    - Force conception between dwellers
-    - Accelerate pregnancy to immediate due date
+  - Force conception between dwellers
+  - Accelerate pregnancy to immediate due date
 - **Exploration Fixes**: Item tracking updates in real-time, rewards modal improvements
 - **Storage Fixes**: Removed unique constraint on item names (fixes duplicate item crash)
 - **Outfit Type Fix**: Fixed KeyError crash with tiered outfits
@@ -657,41 +719,41 @@ watch(() => userStore.caps, (caps) => {
 ### Death System Details
 
 - **Death Mechanics**: Full life/death cycle for dwellers
-    - Death model fields: `is_dead`, `death_timestamp`, `death_cause`, `is_permanently_dead`, `epitaph`
-    - Death causes: health, radiation, incident, exploration, combat
-    - Auto-generated epitaphs based on death cause
-    - 7-day revival window before permanent death
+  - Death model fields: `is_dead`, `death_timestamp`, `death_cause`, `is_permanently_dead`, `epitaph`
+  - Death causes: health, radiation, incident, exploration, combat
+  - Auto-generated epitaphs based on death cause
+  - 7-day revival window before permanent death
 - **Revival System**: Tiered revival costs by level
-    - Level 1-5: 50-250 caps
-    - Level 6-10: 450-750 caps
-    - Level 11+: 1100-2000 caps (capped)
-    - Revival restores 50% max health
+  - Level 1-5: 50-250 caps
+  - Level 6-10: 450-750 caps
+  - Level 11+: 1100-2000 caps (capped)
+  - Revival restores 50% max health
 - **Backend**: Complete death service and API
-    - `POST /api/v1/dwellers/{id}/revive` - Revive dead dweller
-    - `GET /api/v1/dwellers/{id}/revival_cost` - Get revival cost
-    - `GET /api/v1/dwellers/vault/{id}/dead` - List dead (revivable) dwellers
-    - `GET /api/v1/dwellers/vault/{id}/graveyard` - List permanently dead
-    - `GET /api/v1/users/me/profile/statistics` - Death statistics
-    - Celery task for daily permanent death check
+  - `POST /api/v1/dwellers/{id}/revive` - Revive dead dweller
+  - `GET /api/v1/dwellers/{id}/revival_cost` - Get revival cost
+  - `GET /api/v1/dwellers/vault/{id}/dead` - List dead (revivable) dwellers
+  - `GET /api/v1/dwellers/vault/{id}/graveyard` - List permanently dead
+  - `GET /api/v1/users/me/profile/statistics` - Death statistics
+  - Celery task for daily permanent death check
 - **Frontend**: Death UI components
-    - `DeadDwellerCard.vue` - Card for deceased dwellers
-    - `RevivalSection.vue` - Revival cost and action UI
-    - `LifeDeathStatistics.vue` - Death stats dashboard
-    - `GraveyardView.vue` - Memorial for permanently dead
-    - Integration in DwellersView, DwellerDetailView, ProfileView
+  - `DeadDwellerCard.vue` - Card for deceased dwellers
+  - `RevivalSection.vue` - Revival cost and action UI
+  - `LifeDeathStatistics.vue` - Death stats dashboard
+  - `GraveyardView.vue` - Memorial for permanently dead
+  - Integration in DwellersView, DwellerDetailView, ProfileView
 - **Tests**: 23 backend + 10 frontend tests for death system
 
 ### v2.1.3 Backend & Frontend Cleanup (January 22, 2026)
 
 - **Router Consolidation**: Reduced router count from 23 to 20
-    - Merged `settings.py` → `game_control.py` (`/game/balance`)
-    - Moved `info.py` → `system.py` (`/system/info`)
-    - Merged `profile.py` → `user.py` (`/users/me/profile`)
-    - Deleted 3 single-endpoint router files, merged tests
+  - Merged `settings.py` → `game_control.py` (`/game/balance`)
+  - Moved `info.py` → `system.py` (`/system/info`)
+  - Merged `profile.py` → `user.py` (`/users/me/profile`)
+  - Deleted 3 single-endpoint router files, merged tests
 - **Frontend Updates**: Updated to use new API endpoints
-    - AboutView now uses `/api/v1/system/info`
-    - Created systemService in profile module
-    - Dynamic version injection from package.json via Vite define
+  - AboutView now uses `/api/v1/system/info`
+  - Created systemService in profile module
+  - Dynamic version injection from package.json via Vite define
 
 ### v2.1.2 Quick Wins Complete (January 22, 2026)
 
@@ -776,18 +838,19 @@ watch(() => userStore.caps, (caps) => {
 
 ### Version Milestones
 
-| Version | Release      | Highlights                             |
-|---------|--------------|----------------------------------------|
-| v2.13.0 | May 01, 2026 | Dramatiq migration, Celery removal     |
-| v2.12.0 | Apr 23, 2026 | Test suite green, MinIO removed        |
-| v2.11.0 | Mar 19, 2026 | Vite+ toolchain, dweller recycling     |
-| v2.10.9 | Mar 13, 2026 | AI quota system, usage tracking        |
-| v2.10.0 | Feb 10, 2026 | Quest & Objective system launch        |
-| v2.9.0  | Feb 07, 2026 | Chat exploration actions               |
-| v2.8.0  | Jan 29, 2026 | Easter eggs, changelog system          |
-| v2.7.0  | Jan 28, 2026 | Storage management, keyboard shortcuts |
-| v2.6.5  | Jan 27, 2026 | Notification bell system               |
-| v2.5.0  | Jan 26, 2026 | Room visual assets, capacity enforcement|
+| Version | Release      | Highlights                               |
+| ------- | ------------ | ---------------------------------------- |
+| v2.13.1 | May 19, 2026 | Security hardening, non-root containers  |
+| v2.13.0 | May 01, 2026 | Dramatiq migration, Celery removal       |
+| v2.12.0 | Apr 23, 2026 | Test suite green, MinIO removed          |
+| v2.11.0 | Mar 19, 2026 | Vite+ toolchain, dweller recycling       |
+| v2.10.9 | Mar 13, 2026 | AI quota system, usage tracking          |
+| v2.10.0 | Feb 10, 2026 | Quest & Objective system launch          |
+| v2.9.0  | Feb 07, 2026 | Chat exploration actions                 |
+| v2.8.0  | Jan 29, 2026 | Easter eggs, changelog system            |
+| v2.7.0  | Jan 28, 2026 | Storage management, keyboard shortcuts   |
+| v2.6.5  | Jan 27, 2026 | Notification bell system                 |
+| v2.5.0  | Jan 26, 2026 | Room visual assets, capacity enforcement |
 
 ---
 
@@ -854,4 +917,4 @@ watch(() => userStore.caps, (caps) => {
 
 ---
 
-*Last updated: 2026-05-19*
+_Last updated: 2026-05-25_

--- a/backend/app/api/tasks.py
+++ b/backend/app/api/tasks.py
@@ -5,10 +5,9 @@ import time
 
 import dramatiq
 import periodiq
-
-import app.core.dramatiq  # noqa: F401 - ensures broker is configured (set_broker) when dramatiq CLI imports this module
 from pydantic import UUID4
 
+import app.core.dramatiq  # noqa: F401 - ensures broker is configured (set_broker) when dramatiq CLI imports this module
 from app.services.cleanup_service import cleanup_service
 from app.services.death_service import death_service
 from app.services.game_loop import game_loop_service

--- a/backend/app/api/v1/endpoints/radio.py
+++ b/backend/app/api/v1/endpoints/radio.py
@@ -40,7 +40,7 @@ async def manual_recruit_dweller(
     try:
         from app.core.game_config import game_config
 
-        dweller = await radio_service.manual_recruit(
+        dweller, recycled = await radio_service.manual_recruit(
             db_session,
             vault_id,
             override=recruit_request.override,
@@ -52,6 +52,7 @@ async def manual_recruit_dweller(
             dweller=dweller,  # type: ignore  # noqa: PGH003
             message=f"{dweller.first_name} {dweller.last_name} has joined your vault!",
             caps_spent=game_config.radio.manual_recruitment_cost,
+            recycled=recycled,
         )
     except ValueError as e:
         raise ValidationException(detail=str(e)) from e

--- a/backend/app/core/game_config.py
+++ b/backend/app/core/game_config.py
@@ -432,6 +432,14 @@ class RadioConfig(BaseSettings):
 
     happiness_bonus: int = Field(default=1, description="+1 happiness per dweller per tick", ge=0)
 
+    recycle_enabled: bool = Field(default=True, description="Prefer soft-deleted dwellers when radio recruits")
+    recycle_probability: float = Field(
+        default=0.8, description="Probability of using a recycled dweller when pool has candidates", ge=0.0, le=1.0
+    )
+    recycle_min_age_days: int = Field(
+        default=7, description="Minimum days since deletion before a dweller is eligible for radio recycling", ge=1
+    )
+
     def get_tier_multiplier(self, tier: int) -> float:
         """Get radio effectiveness multiplier for room tier."""
         multipliers = {

--- a/backend/app/schemas/radio.py
+++ b/backend/app/schemas/radio.py
@@ -40,3 +40,4 @@ class RecruitmentResponse(SQLModel):
     dweller: DwellerRead
     message: str
     caps_spent: int | None = Field(default=None, description="Caps spent if manual recruitment")
+    recycled: bool = Field(default=False, description="True if the recruit was restored from a soft-deleted dweller")

--- a/backend/app/services/radio_service.py
+++ b/backend/app/services/radio_service.py
@@ -245,7 +245,7 @@ class RadioService:
         vault_id: UUID4,
         caps_cost: int | None = None,
         override: DwellerCreateCommonOverride | None = None,
-    ) -> Dweller:
+    ) -> tuple[Dweller, bool]:
         """
         Manually recruit a dweller for caps.
 
@@ -256,7 +256,9 @@ class RadioService:
             override: Optional override for dweller attributes
 
         Returns:
-            Newly recruited dweller
+            Tuple of (dweller, recycled) — the recruited Dweller and a bool that
+            is True when a soft-deleted dweller was restored rather than a fresh
+            one created.
 
         Raises:
             ValueError: If insufficient caps or no radio room

--- a/backend/app/services/radio_service.py
+++ b/backend/app/services/radio_service.py
@@ -128,9 +128,12 @@ class RadioService:
 
         # Roll for recruitment
         if random.random() < rate:
-            dweller = await RadioService.recruit_dweller(db_session, vault_id)
+            dweller, _ = await RadioService.recruit_dweller(db_session, vault_id)
             logger.info(
-                f"Radio recruitment successful: {dweller.first_name} {dweller.last_name} joined vault {vault_id}"
+                "Radio recruitment successful: %s %s joined vault %s",
+                dweller.first_name,
+                dweller.last_name,
+                vault_id,
             )
             return dweller
 
@@ -141,26 +144,80 @@ class RadioService:
         db_session: AsyncSession,
         vault_id: UUID4,
         override: DwellerCreateCommonOverride | None = None,
-    ) -> Dweller:
+    ) -> tuple[Dweller, bool]:
         """
-        Recruit a new random dweller to the vault.
+        Recruit a new dweller to the vault.
+
+        Prefers restoring a soft-deleted dweller (reusing their S3 assets) when the
+        recycling pool has eligible candidates and the config allows it. Falls back to
+        creating a fresh random dweller when no candidates are found, recycling is
+        disabled, or an explicit override was supplied by the caller.
 
         Args:
             db_session: Database session
             vault_id: Vault ID
-            override: Optional override for dweller attributes
+            override: Optional override for dweller attributes (skips recycling)
 
         Returns:
-            Newly created dweller
+            Tuple of (dweller, recycled) where recycled=True means a soft-deleted
+            dweller was restored rather than a new one created.
         """
-        # Create random common dweller
-        dweller = await crud.dweller.create_random(
-            db_session=db_session,
-            obj_in=override,
-            vault_id=vault_id,
-        )
+        from app.services.dweller_recycling_service import dweller_recycling_service
+        from app.utils.exceptions import ResourceConflictException
 
-        logger.info(f"Recruited dweller: {dweller.first_name} {dweller.last_name} to vault {vault_id}")
+        recycled = False
+        dweller: Dweller | None = None
+
+        # Only attempt recycling when no caller-supplied override is present — an
+        # override signals an intentional customisation, so honour it with a fresh dweller.
+        if (
+            game_config.radio.recycle_enabled
+            and override is None
+            and random.random() < game_config.radio.recycle_probability
+        ):
+            candidates = await dweller_recycling_service.get_recyclable_dwellers(
+                db_session=db_session,
+                min_age_days=game_config.radio.recycle_min_age_days,
+                limit=5,
+            )
+            if candidates:
+                candidate = random.choice(candidates)
+                try:
+                    dweller = await dweller_recycling_service.recycle_dweller_for_vault(
+                        db_session=db_session,
+                        dweller_id=candidate.id,
+                        target_vault_id=vault_id,
+                        reset_stats=True,
+                    )
+                    recycled = True
+                    logger.info(
+                        "Radio recycled dweller %s (%s %s) into vault %s",
+                        candidate.id,
+                        dweller.first_name,
+                        dweller.last_name,
+                        vault_id,
+                    )
+                except ResourceConflictException:
+                    logger.warning(
+                        "Recycling candidate %s was no longer soft-deleted, falling back to create_random",
+                        candidate.id,
+                    )
+                    dweller = None
+
+        if dweller is None:
+            dweller = await crud.dweller.create_random(
+                db_session=db_session,
+                obj_in=override,
+                vault_id=vault_id,
+            )
+
+        logger.info(
+            "Radio recruited %s %s into vault %s (recycled=%s)",
+            dweller.first_name,
+            dweller.last_name,
+            vault_id,
+            recycled,
+        )
 
         # Send notification (non-critical, don't break recruitment on failure)
         try:
@@ -173,14 +230,14 @@ class RadioService:
                     user_id=vault.user_id,
                     vault_id=vault_id,
                     dweller_name=f"{dweller.first_name} {dweller.last_name or ''}".strip(),
-                    meta_data={"dweller_id": str(dweller.id)},
+                    meta_data={"dweller_id": str(dweller.id), "recycled": recycled},
                 )
         except Exception:
             logger.exception(
                 "Failed to send radio recruitment notification: vault_id=%s, dweller_id=%s", vault_id, dweller.id
             )
 
-        return dweller
+        return dweller, recycled
 
     @staticmethod
     async def manual_recruit(
@@ -236,13 +293,18 @@ class RadioService:
 
         await crud_vault.withdraw_caps(db_session=db_session, vault_obj=vault, amount=caps_cost)
 
-        dweller = await RadioService.recruit_dweller(db_session, vault_id, override)
+        dweller, recycled = await RadioService.recruit_dweller(db_session, vault_id, override)
 
         logger.info(
-            f"Manual recruitment: {dweller.first_name} {dweller.last_name} to vault {vault_id} for {caps_cost} caps"
+            "Manual recruitment: %s %s to vault %s for %d caps (recycled=%s)",
+            dweller.first_name,
+            dweller.last_name,
+            vault_id,
+            caps_cost,
+            recycled,
         )
 
-        return dweller
+        return dweller, recycled
 
     @staticmethod
     async def get_recruitment_stats(

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -12,12 +12,12 @@ from sqlalchemy import JSON, event
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import (
     AsyncConnection,
-    AsyncSession,
     create_async_engine,
 )
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 # Global engine reference for database cleanup across fixtures
 _test_async_engine = None
@@ -81,7 +81,7 @@ async def db_connection() -> AsyncConnection:
 
 
 @pytest_asyncio.fixture(scope="function")
-async def async_session(db_connection: AsyncConnection) -> AsyncSession:
+async def async_session(db_connection: AsyncConnection) -> AsyncSession:  # type: ignore[override]
     session = sessionmaker(
         bind=db_connection,
         class_=AsyncSession,

--- a/backend/app/tests/test_api/test_radio.py
+++ b/backend/app/tests/test_api/test_radio.py
@@ -545,7 +545,7 @@ async def test_manual_recruit_with_assigned_dweller(
     vault_id_copy = vault.id
 
     # Recruit a dweller - this should not corrupt the vault
-    new_dweller = await RadioService.manual_recruit(async_session, vault.id, caps_cost=500)
+    new_dweller, _ = await RadioService.manual_recruit(async_session, vault.id, caps_cost=500)
     assert new_dweller is not None
     assert new_dweller.vault_id == vault.id
 

--- a/backend/app/tests/test_services/test_notification_integrations.py
+++ b/backend/app/tests/test_services/test_notification_integrations.py
@@ -82,7 +82,7 @@ class TestRadioNotifications:
             mock_notify.return_value = AsyncMock()
 
             # Recruit a dweller
-            dweller = await RadioService.recruit_dweller(async_session, vault.id)
+            dweller, _ = await RadioService.recruit_dweller(async_session, vault.id)
 
             # Verify notification was called
             mock_notify.assert_called_once()

--- a/backend/app/tests/test_services/test_radio_service.py
+++ b/backend/app/tests/test_services/test_radio_service.py
@@ -1,6 +1,7 @@
 """Tests for radio service logic."""
 
-from unittest.mock import patch
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
 
 import pytest
 import pytest_asyncio
@@ -18,9 +19,15 @@ from app.schemas.common import (
     RoomTypeEnum,
     SPECIALEnum,
 )
-from app.schemas.dweller import DwellerCreate
+from app.schemas.dweller import DwellerCreate, DwellerCreateCommonOverride
 from app.schemas.room import RoomCreate
+from app.services.dweller_recycling_service import dweller_recycling_service
 from app.services.radio_service import RadioService
+from app.utils.exceptions import ResourceConflictException
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
 
 
 @pytest_asyncio.fixture(name="radio_room")
@@ -64,7 +71,6 @@ async def radio_dweller_fixture(async_session: AsyncSession, vault: Vault, radio
         "health": 100,
         "radiation": 0,
         "happiness": 80,
-        "room_id": radio_room.id,
         "strength": 3,
         "perception": 4,
         "endurance": 4,
@@ -79,6 +85,53 @@ async def radio_dweller_fixture(async_session: AsyncSession, vault: Vault, radio
     async_session.add(dweller)
     await async_session.commit()
     return dweller
+
+
+@pytest_asyncio.fixture(name="deleted_dweller")
+async def deleted_dweller_fixture(async_session: AsyncSession, vault: Vault) -> Dweller:
+    """Create a soft-deleted dweller with AI-generated assets, eligible for radio recycling.
+
+    The dweller has bio, image_url, thumbnail_url and a RARE rarity to verify that
+    recycling preserves the original identity and rarity rather than generating a blank dweller.
+    """
+    dweller_data = {
+        "first_name": "Ghost",
+        "last_name": "Signal",
+        "gender": GenderEnum.FEMALE,
+        "rarity": RarityEnum.RARE,
+        "age_group": AgeGroupEnum.ADULT,
+        "level": 3,
+        "experience": 50,
+        "max_health": 100,
+        "health": 100,
+        "radiation": 0,
+        "happiness": 50,
+        "strength": 4,
+        "perception": 5,
+        "endurance": 4,
+        "charisma": 6,
+        "intelligence": 7,
+        "agility": 5,
+        "luck": 4,
+        "bio": "A survivor from the wastes who was lost to time.",
+        "image_url": "https://s3-api.evillab.tech/dweller-images/ghost-signal.png",
+        "thumbnail_url": "https://s3-api.evillab.tech/dweller-thumbnails/ghost-signal_thumbnail.png",
+    }
+    dweller_in = DwellerCreate(**dweller_data, vault_id=vault.id)
+    dweller = await crud.dweller.create(db_session=async_session, obj_in=dweller_in)
+
+    # Soft-delete and back-date past the recycling eligibility window (default 7 days)
+    dweller.is_deleted = True
+    dweller.deleted_at = datetime.now(UTC) - timedelta(days=10)
+    async_session.add(dweller)
+    await async_session.commit()
+    await async_session.refresh(dweller)
+    return dweller
+
+
+# ---------------------------------------------------------------------------
+# Existing tests (radio rooms / rates / manual recruit)
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -166,7 +219,8 @@ async def test_check_for_recruitment_success(
     radio_room: Room,
 ):
     """Test successful recruitment via radio."""
-    # Mock random to always succeed
+    # Mock random to always succeed both the rate roll and the recycle probability roll.
+    # The pool is empty in this test so the service falls back to create_random.
     with patch("random.random", return_value=0.0):
         dweller = await RadioService.check_for_recruitment(async_session, vault.id)
 
@@ -182,7 +236,7 @@ async def test_check_for_recruitment_failure(
     radio_room: Room,
 ):
     """Test failed recruitment via radio."""
-    # Mock random to always fail
+    # Mock random to always fail the rate roll
     with patch("random.random", return_value=1.0):
         dweller = await RadioService.check_for_recruitment(async_session, vault.id)
 
@@ -190,18 +244,54 @@ async def test_check_for_recruitment_failure(
 
 
 @pytest.mark.asyncio
-async def test_recruit_dweller(
+async def test_recruit_dweller_returns_tuple(
     async_session: AsyncSession,
     vault: Vault,
 ):
-    """Test recruiting a dweller."""
-    dweller = await RadioService.recruit_dweller(async_session, vault.id)
+    """recruit_dweller must return a (Dweller, bool) tuple."""
+    result = await RadioService.recruit_dweller(async_session, vault.id)
 
-    assert dweller is not None
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    dweller, recycled = result
+    assert isinstance(dweller, Dweller)
+    assert isinstance(recycled, bool)
+
+
+@pytest.mark.asyncio
+async def test_recruit_dweller_fresh_when_pool_empty(
+    async_session: AsyncSession,
+    vault: Vault,
+):
+    """When no recyclable dwellers exist the service creates a fresh random dweller."""
+    with patch("random.random", return_value=0.0):
+        dweller, recycled = await RadioService.recruit_dweller(async_session, vault.id)
+
+    assert recycled is False
     assert dweller.vault_id == vault.id
     assert dweller.rarity == RarityEnum.COMMON
     assert dweller.first_name is not None
     assert dweller.last_name is not None
+
+
+@pytest.mark.asyncio
+async def test_manual_recruit_returns_tuple(
+    async_session: AsyncSession,
+    vault: Vault,
+    radio_room: Room,
+    radio_dweller: Dweller,
+):
+    """manual_recruit must return a (Dweller, bool) tuple."""
+    vault.bottle_caps = game_config.radio.manual_recruitment_cost + 100
+    await async_session.commit()
+
+    result = await RadioService.manual_recruit(async_session, vault.id)
+
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    dweller, recycled = result
+    assert isinstance(dweller, Dweller)
+    assert isinstance(recycled, bool)
 
 
 @pytest.mark.asyncio
@@ -212,9 +302,11 @@ async def test_manual_recruit_success(
     radio_dweller: Dweller,
 ):
     """Test manual recruitment with sufficient caps."""
+    vault.bottle_caps = game_config.radio.manual_recruitment_cost + 500
+    await async_session.commit()
     initial_caps = vault.bottle_caps
 
-    dweller = await RadioService.manual_recruit(async_session, vault.id)
+    dweller, _ = await RadioService.manual_recruit(async_session, vault.id)
 
     assert dweller is not None
     assert dweller.vault_id == vault.id
@@ -258,10 +350,12 @@ async def test_manual_recruit_custom_cost(
     radio_dweller: Dweller,
 ):
     """Test manual recruitment with custom cost."""
-    initial_caps = vault.bottle_caps
     custom_cost = 1000
+    vault.bottle_caps = custom_cost + 500
+    await async_session.commit()
+    initial_caps = vault.bottle_caps
 
-    dweller = await RadioService.manual_recruit(async_session, vault.id, caps_cost=custom_cost)
+    dweller, _ = await RadioService.manual_recruit(async_session, vault.id, caps_cost=custom_cost)
 
     assert dweller is not None
 
@@ -357,3 +451,205 @@ async def test_calculate_recruitment_rate_multiple_rooms(
     # Verify rate is positive and reasonable
     assert rate_two_rooms > 0
     assert rate_two_rooms < 1.0  # Should be less than 100% per tick
+
+
+# ---------------------------------------------------------------------------
+# New tests: radio asset repurpose (2.14-repurpose)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recruit_dweller_recycles_from_pool(
+    async_session: AsyncSession,
+    vault: Vault,
+    deleted_dweller: Dweller,
+):
+    """When a recyclable dweller exists the radio restores it instead of creating a new one."""
+    deleted_dweller_id = deleted_dweller.id
+
+    # Force recycle probability roll to pass
+    with patch("random.random", return_value=0.0):
+        dweller, recycled = await RadioService.recruit_dweller(async_session, vault.id)
+
+    assert recycled is True
+    assert dweller.id == deleted_dweller_id
+    assert dweller.vault_id == vault.id
+    assert dweller.is_deleted is False
+
+
+@pytest.mark.asyncio
+async def test_recruit_dweller_recycled_preserves_rarity(
+    async_session: AsyncSession,
+    vault: Vault,
+    deleted_dweller: Dweller,
+):
+    """The recycled dweller keeps its original rarity (RARE stays RARE, not capped to COMMON)."""
+    with patch("random.random", return_value=0.0):
+        dweller, recycled = await RadioService.recruit_dweller(async_session, vault.id)
+
+    assert recycled is True
+    assert dweller.rarity == RarityEnum.RARE
+
+
+@pytest.mark.asyncio
+async def test_recruit_dweller_recycled_preserves_assets(
+    async_session: AsyncSession,
+    vault: Vault,
+    deleted_dweller: Dweller,
+):
+    """The recycled dweller retains its existing bio, image_url, and thumbnail_url."""
+    with patch("random.random", return_value=0.0):
+        dweller, recycled = await RadioService.recruit_dweller(async_session, vault.id)
+
+    assert recycled is True
+    assert dweller.bio == "A survivor from the wastes who was lost to time."
+    assert dweller.image_url == "https://s3-api.evillab.tech/dweller-images/ghost-signal.png"
+    assert dweller.thumbnail_url == "https://s3-api.evillab.tech/dweller-thumbnails/ghost-signal_thumbnail.png"
+
+
+@pytest.mark.asyncio
+async def test_recruit_dweller_recycled_resets_stats(
+    async_session: AsyncSession,
+    vault: Vault,
+    deleted_dweller: Dweller,
+):
+    """Recycled dweller has its gameplay stats reset to level 1 defaults."""
+    with patch("random.random", return_value=0.0):
+        dweller, recycled = await RadioService.recruit_dweller(async_session, vault.id)
+
+    assert recycled is True
+    assert dweller.level == 1
+    assert dweller.experience == 0
+    assert dweller.radiation == 0
+    assert dweller.partner_id is None
+
+
+@pytest.mark.asyncio
+async def test_recruit_dweller_skips_recycling_when_disabled(
+    async_session: AsyncSession,
+    vault: Vault,
+    deleted_dweller: Dweller,
+):
+    """When recycle_enabled=False the service always creates a fresh dweller."""
+    with patch.object(game_config.radio, "recycle_enabled", new=False), patch("random.random", return_value=0.0):
+        dweller, recycled = await RadioService.recruit_dweller(async_session, vault.id)
+
+    assert recycled is False
+    assert dweller.id != deleted_dweller.id
+    assert dweller.rarity == RarityEnum.COMMON
+
+
+@pytest.mark.asyncio
+async def test_recruit_dweller_skips_recycling_when_override_provided(
+    async_session: AsyncSession,
+    vault: Vault,
+    deleted_dweller: Dweller,
+):
+    """An explicit override bypasses recycling so the caller gets a customised fresh dweller."""
+    override = DwellerCreateCommonOverride(first_name="Custom", last_name="Name")
+
+    with patch("random.random", return_value=0.0):
+        dweller, recycled = await RadioService.recruit_dweller(async_session, vault.id, override=override)
+
+    assert recycled is False
+    assert dweller.first_name == "Custom"
+    assert dweller.last_name == "Name"
+    assert dweller.id != deleted_dweller.id
+
+
+@pytest.mark.asyncio
+async def test_recruit_dweller_skips_recycling_when_probability_roll_fails(
+    async_session: AsyncSession,
+    vault: Vault,
+    deleted_dweller: Dweller,
+):
+    """When the probability roll loses, a fresh dweller is created even if pool has candidates."""
+    with patch("random.random", return_value=0.99):  # 0.99 > default 0.8, roll fails
+        dweller, recycled = await RadioService.recruit_dweller(async_session, vault.id)
+
+    assert recycled is False
+    assert dweller.id != deleted_dweller.id
+
+
+@pytest.mark.asyncio
+async def test_recruit_dweller_falls_back_on_resource_conflict(
+    async_session: AsyncSession,
+    vault: Vault,
+    deleted_dweller: Dweller,
+):
+    """If recycling raises ResourceConflictException the service falls back to create_random."""
+    with (
+        patch.object(
+            dweller_recycling_service,
+            "recycle_dweller_for_vault",
+            new_callable=AsyncMock,
+            side_effect=ResourceConflictException(detail="already restored"),
+        ),
+        patch("random.random", return_value=0.0),
+    ):
+        dweller, recycled = await RadioService.recruit_dweller(async_session, vault.id)
+
+    assert recycled is False
+    assert dweller is not None
+    assert dweller.vault_id == vault.id
+
+
+@pytest.mark.asyncio
+async def test_recruit_dweller_does_not_recycle_recently_deleted(
+    async_session: AsyncSession,
+    vault: Vault,
+):
+    """Dwellers deleted less than recycle_min_age_days ago are not eligible for radio recycling."""
+    # Create a dweller deleted just 1 day ago (below the 7-day threshold)
+    dweller_data = {
+        "first_name": "Fresh",
+        "last_name": "Delete",
+        "gender": GenderEnum.MALE,
+        "rarity": RarityEnum.COMMON,
+        "age_group": AgeGroupEnum.ADULT,
+        "level": 1,
+        "experience": 0,
+        "max_health": 50,
+        "health": 50,
+        "radiation": 0,
+        "happiness": 50,
+        "strength": 5,
+        "perception": 5,
+        "endurance": 5,
+        "charisma": 5,
+        "intelligence": 5,
+        "agility": 5,
+        "luck": 5,
+    }
+    dweller_in = DwellerCreate(**dweller_data, vault_id=vault.id)
+    recent = await crud.dweller.create(db_session=async_session, obj_in=dweller_in)
+    recent.is_deleted = True
+    recent.deleted_at = datetime.now(UTC) - timedelta(days=1)
+    async_session.add(recent)
+    await async_session.commit()
+
+    with patch("random.random", return_value=0.0):
+        dweller, recycled = await RadioService.recruit_dweller(async_session, vault.id)
+
+    assert recycled is False
+    assert dweller.id != recent.id
+
+
+@pytest.mark.asyncio
+async def test_manual_recruit_propagates_recycled_flag(
+    async_session: AsyncSession,
+    vault: Vault,
+    radio_room: Room,
+    radio_dweller: Dweller,
+    deleted_dweller: Dweller,
+):
+    """manual_recruit surfaces the recycled flag from recruit_dweller."""
+    vault.bottle_caps = game_config.radio.manual_recruitment_cost + 500
+    await async_session.commit()
+
+    with patch("random.random", return_value=0.0):
+        dweller, recycled = await RadioService.manual_recruit(async_session, vault.id)
+
+    assert recycled is True
+    assert dweller.id == deleted_dweller.id
+    assert dweller.is_deleted is False

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "pydantic-ai-slim[openai, anthropic, logfire]>=1.93.0",
     "aiosmtplib>=5.1.0",
     "python-json-logger>=4.0.0",
-    "psycopg2>=2.9.12",
+    "psycopg2-binary>=2.9.12",
     "uvloop>=0.21.0; sys_platform != 'win32'",
     "fastapi-guard>=7.1.0,<8",
 ]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fallout-shelter-fast-api"
-version = "2.13.1"
+version = "2.14.0"
 authors = [{ name = "ElderEvil", email = "elder.evil.dev@proton.me" }, ]
 description = "Fallout Shelter FastAPI Game is a web-based simulation game where the player manages a vault full of dwellers, balancing their needs and resources to keep the vault thriving."
 requires-python = ">=3.12,<3.14"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
     "passlib[bcrypt]>=1.7.4",
     "bcrypt>=4.0.0,<4.2",
     "pillow>=12.0,<13",
-    "psycopg>=3.3.4,<4",
     "pydantic>=2.13.3,<2.14",
     "pydantic-settings>=2.14.1,<3",
     "pydantic-extra-types>=2.11.0",
@@ -30,7 +29,6 @@ dependencies = [
     "pydantic-ai-slim[openai, anthropic, logfire]>=1.93.0",
     "aiosmtplib>=5.1.0",
     "python-json-logger>=4.0.0",
-    "psycopg2-binary>=2.9.12",
     "uvloop>=0.21.0; sys_platform != 'win32'",
     "fastapi-guard>=7.1.0,<8",
 ]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "fallout-shelter-fast-api"
-version = "2.13.1"
+version = "2.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosmtplib" },

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -581,7 +581,7 @@ dependencies = [
     { name = "periodiq" },
     { name = "pillow" },
     { name = "psycopg" },
-    { name = "psycopg2" },
+    { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "pydantic-ai-slim", extra = ["anthropic", "logfire", "openai"] },
     { name = "pydantic-extra-types" },
@@ -628,7 +628,7 @@ requires-dist = [
     { name = "periodiq", specifier = ">=0.2.0,<1" },
     { name = "pillow", specifier = ">=12.0,<13" },
     { name = "psycopg", specifier = ">=3.3.4,<4" },
-    { name = "psycopg2", specifier = ">=2.9.12" },
+    { name = "psycopg2-binary", specifier = ">=2.9.12" },
     { name = "pydantic", specifier = ">=2.13.3,<2.14" },
     { name = "pydantic-ai-slim", extras = ["openai", "anthropic", "logfire"], specifier = ">=1.93.0" },
     { name = "pydantic-extra-types", specifier = ">=2.11.0" },
@@ -1651,13 +1651,33 @@ wheels = [
 ]
 
 [[package]]
-name = "psycopg2"
+name = "psycopg2-binary"
 version = "2.9.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/bc/f66df707ed1aec949fbf24e4460e4f4277a7ba23cdadb3965bb1f634ddb9/psycopg2-2.9.12.tar.gz", hash = "sha256:1dedb1c7a1d8552c4a6044c6b1c41a52e6a8e2d144af83eccac758076b1b7c15", size = 379683, upload-time = "2026-04-20T23:36:11.013Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/60/a3624f79acea344c16fbef3a94d28b89a8042ddfb8f3e4ca83f538671409/psycopg2_binary-2.9.12.tar.gz", hash = "sha256:5ac9444edc768c02a6b6a591f070b8aae28ff3a99be57560ac996001580f294c", size = 379686, upload-time = "2026-04-21T09:40:34.304Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/b2/7319dc488444b1dfe9ce89c4440df1d5425e2579e6ce9a63e2b70f648491/psycopg2-2.9.12-cp312-cp312-win_amd64.whl", hash = "sha256:83d48e66e18c301d832e93c984a7bcbc0f4ac3bb79e2137e3bc335978c756dc0", size = 2757068, upload-time = "2026-04-20T23:33:20.664Z" },
-    { url = "https://files.pythonhosted.org/packages/91/ab/03403779a251ca14a7f1b07a41c7aa735fd451f0aebe4c4f901a231167a4/psycopg2-2.9.12-cp313-cp313-win_amd64.whl", hash = "sha256:3d23e684927d37b95cee9a943f6927b04ae2fdcd056fd0e2a30929ee89fee5a9", size = 2757176, upload-time = "2026-04-20T23:33:23.577Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/9f/ef4ef3c8e15083df90ca35265cfd1a081a2f0cc07bb229c6314c6af817f4/psycopg2_binary-2.9.12-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5cdc05117180c5fa9c40eea8ea559ce64d73824c39d928b7da9fb5f6a9392433", size = 3712459, upload-time = "2026-04-20T23:34:30.549Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/01/3dd14e46ba48c1e1a6ec58ee599fa1b5efa00c246d5046cd903d0eeb1af1/psycopg2_binary-2.9.12-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3227a3bc228c10d21011a99245edca923e4e8bf461857e869a507d9a41fe9f6", size = 3822936, upload-time = "2026-04-20T23:34:32.77Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/f7/0640e4901119d8a9f7a1784b927f494e2198e213ceb593753d1f2c8b1b30/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:995ce929eede89db6254b50827e2b7fd61e50d11f0b116b29fffe4a2e53c4580", size = 4578676, upload-time = "2026-04-20T23:34:35.18Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/55/44df3965b5f297c50cc0b1b594a31c67d6127a9d133045b8a66611b14dfb/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9fe06d93e72f1c048e731a2e3e7854a5bfaa58fc736068df90b352cefe66f03f", size = 4274917, upload-time = "2026-04-20T23:34:37.982Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/4b/74535248b1eac0c9336862e8617c765ac94dac76f9e25d7c4a79588c8907/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40e7b28b63aaf737cb3a1edc3a9bbc9a9f4ad3dcb7152e8c1130e4050eddcb7d", size = 5894843, upload-time = "2026-04-20T23:34:40.856Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/ba/f1bf8d2ae71868ad800b661099086ee52bc0f8d9f05be1acd8ebb06757cc/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:89d19a9f7899e8eb0656a2b3a08e0da04c720a06db6e0033eab5928aabe60fa9", size = 4110556, upload-time = "2026-04-20T23:34:44.016Z" },
+    { url = "https://files.pythonhosted.org/packages/45/46/c15706c338403b7c420bcc0c2905aad116cc064545686d8bf85f1999ea00/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:612b965daee295ae2da8f8218ce1d274645dc76ef3f1abf6a0a94fd57eff876d", size = 3655714, upload-time = "2026-04-20T23:34:46.233Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7c/a2d5dc09b64a4564db242a0fe418fde7d33f6f8259dd2c5b9d7def00fb5a/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b9a339b79d37c1b45f3235265f07cdeb0cb5ad7acd2ac7720a5920989c17c24e", size = 3301154, upload-time = "2026-04-20T23:34:49.528Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/e8/cc8c9a4ce71461f9ec548d38cadc41dc184b34c73e6455450775a9334ccd/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:3471336e1acfd9c7fe507b8bad5af9317b6a89294f9eb37bd9a030bb7bebcdc6", size = 3048882, upload-time = "2026-04-20T23:34:51.86Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/31e2296bc0787c5ab75d3d118e40b239db8151b5192b90b77c72bc9256e9/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7af18183109e23502c8b2ae7f6926c0882766f35b5175a4cd737ad825e4d7a1b", size = 3351298, upload-time = "2026-04-20T23:34:54.124Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a8/75f4e3e11203b590150abed2cf7794b9c9c9f7eceddae955191138b44dde/psycopg2_binary-2.9.12-cp312-cp312-win_amd64.whl", hash = "sha256:398fcd4db988c7d7d3713e2b8e18939776fd3fb447052daae4f24fa39daede4c", size = 2757230, upload-time = "2026-04-20T23:34:56.242Z" },
+    { url = "https://files.pythonhosted.org/packages/91/bb/4608c96f970f6e0c56572e87027ef4404f709382a3503e9934526d7ba051/psycopg2_binary-2.9.12-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7c729a73c7b1b84de3582f73cdd27d905121dc2c531f3d9a3c32a3011033b965", size = 3712419, upload-time = "2026-04-20T23:34:58.754Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/af/48f76af9d50d61cf390f8cd657b503168b089e2e9298e48465d029fcc713/psycopg2_binary-2.9.12-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4413d0caef93c5cf50b96863df4c2efe8c269bf2267df353225595e7e15e8df7", size = 3822990, upload-time = "2026-04-20T23:35:00.821Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/df/aba0f99397cd811d32e06fc0cc781f1f3ce98bc0e729cb423925085d781a/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4dfcf8e45ebb0c663be34a3442f65e17311f3367089cd4e5e3a3e8e62c978777", size = 4578696, upload-time = "2026-04-20T23:35:03.409Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/eaa74021ac4e4d5c2f83d82fc6615a63f4fe6c94dc4e94c3990427053f67/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c41321a14dd74aceb6a9a643b9253a334521babfa763fa873e33d89cfa122fb5", size = 4274982, upload-time = "2026-04-20T23:35:05.583Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ed/c25deff98bd26187ba48b3b250a3ffc3037c46c5b89362534a15d200e0db/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:83946ba43979ebfdc99a3cd0ee775c89f221df026984ba19d46133d8d75d3cd9", size = 5894867, upload-time = "2026-04-20T23:35:07.902Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/8d0e21ca77373c6c9589e5c4528f6e8f0c08c62cafc76fb0bddb7a2cee22/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:411e85815652d13560fbe731878daa5d92378c4995a22302071890ec3397d019", size = 4110578, upload-time = "2026-04-20T23:35:10.149Z" },
+    { url = "https://files.pythonhosted.org/packages/00/fc/f481e2435bd8f742d0123309174aae4165160ad3ef17c1b99c3622c241d2/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c8ad4c08e00f7679559eaed7aff1edfffc60c086b976f93972f686384a95e2c", size = 3655816, upload-time = "2026-04-20T23:35:12.56Z" },
+    { url = "https://files.pythonhosted.org/packages/53/79/b9f46466bdbe9f239c96cde8be33c1aace4842f06013b47b730dc9759187/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:00814e40fa23c2b37ef0a1e3c749d89982c73a9cb5046137f0752a22d432e82f", size = 3301307, upload-time = "2026-04-20T23:35:15.029Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/19/7dc003b32fe35024df89b658104f7c8538a8b2dcbde7a4e746ce929742e7/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:98062447aebc20ed20add1f547a364fd0ef8933640d5372ff1873f8deb9b61be", size = 3048968, upload-time = "2026-04-20T23:35:16.757Z" },
+    { url = "https://files.pythonhosted.org/packages/91/58/2dbd7db5c604d45f4950d988506aae672a14126ec22998ced5021cbb76bb/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:66a7685d7e548f10fb4ce32fb01a7b7f4aa702134de92a292c7bd9e0d3dbd290", size = 3351369, upload-time = "2026-04-20T23:35:18.933Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ee/dee8dcaad07f735824de3d6563bc67119fa6c28257b17977a8d624f02fab/psycopg2_binary-2.9.12-cp313-cp313-win_amd64.whl", hash = "sha256:b6937f5fe4e180aeee87de907a2fa982ded6f7f15d7218f78a083e4e1d68f2a0", size = 2757347, upload-time = "2026-04-20T23:35:21.283Z" },
 ]
 
 [[package]]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -580,8 +580,6 @@ dependencies = [
     { name = "passlib", extra = ["bcrypt"] },
     { name = "periodiq" },
     { name = "pillow" },
-    { name = "psycopg" },
-    { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "pydantic-ai-slim", extra = ["anthropic", "logfire", "openai"] },
     { name = "pydantic-extra-types" },
@@ -627,8 +625,6 @@ requires-dist = [
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
     { name = "periodiq", specifier = ">=0.2.0,<1" },
     { name = "pillow", specifier = ">=12.0,<13" },
-    { name = "psycopg", specifier = ">=3.3.4,<4" },
-    { name = "psycopg2-binary", specifier = ">=2.9.12" },
     { name = "pydantic", specifier = ">=2.13.3,<2.14" },
     { name = "pydantic-ai-slim", extras = ["openai", "anthropic", "logfire"], specifier = ">=1.93.0" },
     { name = "pydantic-extra-types", specifier = ">=2.11.0" },
@@ -1635,49 +1631,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
     { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
     { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
-]
-
-[[package]]
-name = "psycopg"
-version = "3.3.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
-]
-
-[[package]]
-name = "psycopg2-binary"
-version = "2.9.12"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2a/60/a3624f79acea344c16fbef3a94d28b89a8042ddfb8f3e4ca83f538671409/psycopg2_binary-2.9.12.tar.gz", hash = "sha256:5ac9444edc768c02a6b6a591f070b8aae28ff3a99be57560ac996001580f294c", size = 379686, upload-time = "2026-04-21T09:40:34.304Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/9f/ef4ef3c8e15083df90ca35265cfd1a081a2f0cc07bb229c6314c6af817f4/psycopg2_binary-2.9.12-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5cdc05117180c5fa9c40eea8ea559ce64d73824c39d928b7da9fb5f6a9392433", size = 3712459, upload-time = "2026-04-20T23:34:30.549Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/01/3dd14e46ba48c1e1a6ec58ee599fa1b5efa00c246d5046cd903d0eeb1af1/psycopg2_binary-2.9.12-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3227a3bc228c10d21011a99245edca923e4e8bf461857e869a507d9a41fe9f6", size = 3822936, upload-time = "2026-04-20T23:34:32.77Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/f7/0640e4901119d8a9f7a1784b927f494e2198e213ceb593753d1f2c8b1b30/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:995ce929eede89db6254b50827e2b7fd61e50d11f0b116b29fffe4a2e53c4580", size = 4578676, upload-time = "2026-04-20T23:34:35.18Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/55/44df3965b5f297c50cc0b1b594a31c67d6127a9d133045b8a66611b14dfb/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9fe06d93e72f1c048e731a2e3e7854a5bfaa58fc736068df90b352cefe66f03f", size = 4274917, upload-time = "2026-04-20T23:34:37.982Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/4b/74535248b1eac0c9336862e8617c765ac94dac76f9e25d7c4a79588c8907/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40e7b28b63aaf737cb3a1edc3a9bbc9a9f4ad3dcb7152e8c1130e4050eddcb7d", size = 5894843, upload-time = "2026-04-20T23:34:40.856Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/ba/f1bf8d2ae71868ad800b661099086ee52bc0f8d9f05be1acd8ebb06757cc/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:89d19a9f7899e8eb0656a2b3a08e0da04c720a06db6e0033eab5928aabe60fa9", size = 4110556, upload-time = "2026-04-20T23:34:44.016Z" },
-    { url = "https://files.pythonhosted.org/packages/45/46/c15706c338403b7c420bcc0c2905aad116cc064545686d8bf85f1999ea00/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:612b965daee295ae2da8f8218ce1d274645dc76ef3f1abf6a0a94fd57eff876d", size = 3655714, upload-time = "2026-04-20T23:34:46.233Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/7c/a2d5dc09b64a4564db242a0fe418fde7d33f6f8259dd2c5b9d7def00fb5a/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b9a339b79d37c1b45f3235265f07cdeb0cb5ad7acd2ac7720a5920989c17c24e", size = 3301154, upload-time = "2026-04-20T23:34:49.528Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/e8/cc8c9a4ce71461f9ec548d38cadc41dc184b34c73e6455450775a9334ccd/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:3471336e1acfd9c7fe507b8bad5af9317b6a89294f9eb37bd9a030bb7bebcdc6", size = 3048882, upload-time = "2026-04-20T23:34:51.86Z" },
-    { url = "https://files.pythonhosted.org/packages/19/6a/31e2296bc0787c5ab75d3d118e40b239db8151b5192b90b77c72bc9256e9/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7af18183109e23502c8b2ae7f6926c0882766f35b5175a4cd737ad825e4d7a1b", size = 3351298, upload-time = "2026-04-20T23:34:54.124Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/a8/75f4e3e11203b590150abed2cf7794b9c9c9f7eceddae955191138b44dde/psycopg2_binary-2.9.12-cp312-cp312-win_amd64.whl", hash = "sha256:398fcd4db988c7d7d3713e2b8e18939776fd3fb447052daae4f24fa39daede4c", size = 2757230, upload-time = "2026-04-20T23:34:56.242Z" },
-    { url = "https://files.pythonhosted.org/packages/91/bb/4608c96f970f6e0c56572e87027ef4404f709382a3503e9934526d7ba051/psycopg2_binary-2.9.12-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7c729a73c7b1b84de3582f73cdd27d905121dc2c531f3d9a3c32a3011033b965", size = 3712419, upload-time = "2026-04-20T23:34:58.754Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/af/48f76af9d50d61cf390f8cd657b503168b089e2e9298e48465d029fcc713/psycopg2_binary-2.9.12-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4413d0caef93c5cf50b96863df4c2efe8c269bf2267df353225595e7e15e8df7", size = 3822990, upload-time = "2026-04-20T23:35:00.821Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/df/aba0f99397cd811d32e06fc0cc781f1f3ce98bc0e729cb423925085d781a/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4dfcf8e45ebb0c663be34a3442f65e17311f3367089cd4e5e3a3e8e62c978777", size = 4578696, upload-time = "2026-04-20T23:35:03.409Z" },
-    { url = "https://files.pythonhosted.org/packages/95/9c/eaa74021ac4e4d5c2f83d82fc6615a63f4fe6c94dc4e94c3990427053f67/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c41321a14dd74aceb6a9a643b9253a334521babfa763fa873e33d89cfa122fb5", size = 4274982, upload-time = "2026-04-20T23:35:05.583Z" },
-    { url = "https://files.pythonhosted.org/packages/35/ed/c25deff98bd26187ba48b3b250a3ffc3037c46c5b89362534a15d200e0db/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:83946ba43979ebfdc99a3cd0ee775c89f221df026984ba19d46133d8d75d3cd9", size = 5894867, upload-time = "2026-04-20T23:35:07.902Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/81/8d0e21ca77373c6c9589e5c4528f6e8f0c08c62cafc76fb0bddb7a2cee22/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:411e85815652d13560fbe731878daa5d92378c4995a22302071890ec3397d019", size = 4110578, upload-time = "2026-04-20T23:35:10.149Z" },
-    { url = "https://files.pythonhosted.org/packages/00/fc/f481e2435bd8f742d0123309174aae4165160ad3ef17c1b99c3622c241d2/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c8ad4c08e00f7679559eaed7aff1edfffc60c086b976f93972f686384a95e2c", size = 3655816, upload-time = "2026-04-20T23:35:12.56Z" },
-    { url = "https://files.pythonhosted.org/packages/53/79/b9f46466bdbe9f239c96cde8be33c1aace4842f06013b47b730dc9759187/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:00814e40fa23c2b37ef0a1e3c749d89982c73a9cb5046137f0752a22d432e82f", size = 3301307, upload-time = "2026-04-20T23:35:15.029Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/19/7dc003b32fe35024df89b658104f7c8538a8b2dcbde7a4e746ce929742e7/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:98062447aebc20ed20add1f547a364fd0ef8933640d5372ff1873f8deb9b61be", size = 3048968, upload-time = "2026-04-20T23:35:16.757Z" },
-    { url = "https://files.pythonhosted.org/packages/91/58/2dbd7db5c604d45f4950d988506aae672a14126ec22998ced5021cbb76bb/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:66a7685d7e548f10fb4ce32fb01a7b7f4aa702134de92a292c7bd9e0d3dbd290", size = 3351369, upload-time = "2026-04-20T23:35:18.933Z" },
-    { url = "https://files.pythonhosted.org/packages/42/ee/dee8dcaad07f735824de3d6563bc67119fa6c28257b17977a8d624f02fab/psycopg2_binary-2.9.12-cp313-cp313-win_amd64.whl", hash = "sha256:b6937f5fe4e180aeee87de907a2fa982ded6f7f15d7218f78a083e4e1d68f2a0", size = 2757347, upload-time = "2026-04-20T23:35:21.283Z" },
 ]
 
 [[package]]

--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -8,11 +8,11 @@ services:
     restart: always
     env_file: ".env"
     volumes:
-      - postgres-data-infra:/var/lib/postgresql/data
+      - postgres-data-infra:/var/lib/postgresql
     ports:
       - "5432:5432"
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB" ]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -48,7 +48,12 @@ services:
       rustfs:
         condition: service_started
     working_dir: /app
-    command: [ "sh", "-c", "uv run periodiq app.core.dramatiq app.api.tasks & PERIODIQ_PID=$!; uv run dramatiq app.api.tasks & DRAMATIQ_PID=$!; wait -n; kill $PERIODIQ_PID $DRAMATIQ_PID 2>/dev/null; wait" ]
+    command:
+      [
+        "sh",
+        "-c",
+        "uv run periodiq app.core.dramatiq app.api.tasks & PERIODIQ_PID=$!; uv run dramatiq app.api.tasks & DRAMATIQ_PID=$!; wait -n; kill $PERIODIQ_PID $DRAMATIQ_PID 2>/dev/null; wait",
+      ]
 
   rustfs:
     image: rustfs/rustfs:latest

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "2.14.0"
+  "version": "2.14.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "2.13.1",
+  "version": "2.14.0"
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/modules/radio/models/radio.ts
+++ b/frontend/src/modules/radio/models/radio.ts
@@ -36,4 +36,5 @@ export interface RecruitmentResponse {
   dweller: Dweller
   message: string
   caps_spent?: number
+  recycled?: boolean
 }

--- a/frontend/src/modules/radio/stores/radio.ts
+++ b/frontend/src/modules/radio/stores/radio.ts
@@ -41,7 +41,11 @@ export const useRadioStore = defineStore('radio', () => {
       const response = await axios.post(`/api/v1/radio/vault/${vaultId}/recruit`, request)
       const result: RecruitmentResponse = response.data
 
-      toast.success(result.message)
+      if (result.recycled) {
+        toast.success(`📡 ${result.message} A familiar face answers the call from the wastes.`)
+      } else {
+        toast.success(result.message)
+      }
       return result
     } catch (error: unknown) {
       console.error('Failed to recruit dweller:', error)


### PR DESCRIPTION
- Radio recruit_dweller() now prefers restoring a soft-deleted dweller (reusing existing S3 image/thumbnail/bio/rarity) over creating a blank new one. Falls back to create_random when pool is empty or an override is supplied.
- Three new RadioConfig fields: recycle_enabled, recycle_probability, recycle_min_age_days (all env-overridable via RADIO_ prefix).
- RecruitmentResponse gains a recycled bool field; endpoint and frontend store propagate it; frontend shows a distinct toast for recycled recruits.
- 29/29 radio service tests passing (11 new, existing tests fixed for updated tuple return types).
- conftest: swap SQLAlchemy AsyncSession for SQLModel AsyncSession so .exec() is available in all service tests.
- psycopg2 -> psycopg2-binary (no pg_config required in dev/CI).
- docker-compose.infra.yml: fix postgres volume mount for PG18 (/var/lib/postgresql instead of /var/lib/postgresql/data).
- ROADMAP: retire v2.13.2, promote items into v2.14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Radio recruitment can now recycle soft-deleted dwellers based on configurable probability and eligibility settings.
  * The UI now displays whether a recruit was newly created or recycled from a deleted dweller.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ElderEvil/falloutProject/pull/317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->