### PR TITLE
fix: update image generation model to gpt-image-1 and handle new resp…

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -64,6 +64,7 @@ class Settings(BaseSettings):
     # Legacy direct provider API keys (deprecated, use Gateway instead)
     AI_PROVIDER: Literal["openai", "anthropic", "ollama"] = "openai"
     AI_MODEL: str = "gpt-4o"
+    AI_IMAGE_MODEL: str = "gpt-image-1"
     OPENAI_API_KEY: str | None = None
     ANTHROPIC_API_KEY: str | None = None
     OLLAMA_BASE_URL: str = "http://localhost:11434/v1"

--- a/backend/app/services/open_ai.py
+++ b/backend/app/services/open_ai.py
@@ -16,6 +16,7 @@ Architecture Notes:
 """
 
 import asyncio
+import base64
 import logging
 import warnings
 from dataclasses import dataclass
@@ -186,7 +187,11 @@ class AIService:
             raise RuntimeError("OpenAI client not available. Use AI_PROVIDER=openai for image/audio features.")
 
     async def generate_image(self, *, prompt: str, return_bytes: bool = False) -> str | bytes:
-        """Generate an image using DALL-E via direct OpenAI API.
+        """Generate an image using OpenAI's image model.
+
+        Uses the configured AI_IMAGE_MODEL (default: gpt-image-1).
+        Falls back to URL-based fetching for legacy model responses, but the new
+        gpt-image-* models return b64_json directly.
 
         Note: Image generation uses direct OpenAI client, not Gateway.
         Gateway's ImageGenerationTool requires Agent pattern which is incompatible
@@ -198,12 +203,29 @@ class AIService:
         if self._using_gateway:
             logger.debug("Image generation via direct OpenAI client (Gateway doesn't support image API)")
         response = await asyncio.to_thread(
-            self._client.images.generate, model="dall-e-3", prompt=prompt, size="1024x1024", quality="standard", n=1
+            self._client.images.generate,
+            model=settings.AI_IMAGE_MODEL,
+            prompt=prompt,
+            size="1024x1024",
+            quality="auto",
+            n=1,
         )
-        url = response.data[0].url
-        if url is None:
-            raise RuntimeError("Failed to generate image: no URL returned")
-        return await image_url_to_bytes(url) if return_bytes else url
+        data = response.data[0]
+
+        if return_bytes:
+            if data.b64_json:
+                return base64.b64decode(data.b64_json)
+            if data.url:
+                result = await image_url_to_bytes(data.url)
+                if result is None:
+                    raise RuntimeError("Failed to fetch image from URL")
+                return result
+            raise RuntimeError("Failed to generate image: no image data returned")
+
+        if data.url:
+            return data.url
+        msg = "Image generation did not return a URL. Use return_bytes=True to receive image data as bytes."
+        raise RuntimeError(msg)
 
     async def generate_audio(self, text: str, voice: str = "alloy", model: str = "tts-1") -> bytes:
         """Generate audio from text using OpenAI's TTS API via direct client.


### PR DESCRIPTION
…onse format

- Make image model configurable via AI_IMAGE_MODEL setting (default: gpt-image-1)
- Change quality parameter from 'standard' to 'auto' (new API requirement)
- Handle b64_json response from gpt-image-* models instead of relying on URL
- Decode base64 image data to bytes for return_bytes=True path
- Keep fallback for legacy URL-based model responses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple image response formats in image generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ElderEvil/falloutProject/pull/318?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->