### PR TITLE
fix: misc fixes for 2.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   `contains()` performs substring matching as intended, making push events to `master` trigger builds
   when files under `backend/` or `frontend/` are modified.
 
+- **Dweller AI service** - Replaced module-level singleton calls (`dweller_ai.generate_photo/audio`) with
+  `self.` inside `generate_dweller_avatar` for consistency with rest of the class
+
+- **RustFS config drift** - Added `RUSTFS_BUCKET` as an alias for `RUSTFS_DEFAULT_BUCKET` so the env var
+  set in the k8s deployment actually takes effect instead of being silently ignored
+
 ---
 
 ## [2.14.0] - 2026-05-26

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import EmailStr, Field, PostgresDsn, field_validator, model_validator
+from pydantic import AliasChoices, EmailStr, Field, PostgresDsn, field_validator, model_validator
 from pydantic_core.core_schema import FieldValidationInfo
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -45,7 +45,10 @@ class Settings(BaseSettings):
     RUSTFS_USE_HTTPS: bool = True
     RUSTFS_ACCESS_KEY: str | None = None
     RUSTFS_SECRET_KEY: str | None = None
-    RUSTFS_DEFAULT_BUCKET: str = "fallout-shelter"
+    RUSTFS_DEFAULT_BUCKET: str = Field(
+        default="fallout-shelter",
+        validation_alias=AliasChoices("RUSTFS_DEFAULT_BUCKET", "RUSTFS_BUCKET"),
+    )
     RUSTFS_PUBLIC_URL: str | None = None
     RUSTFS_PUBLIC_BUCKET_WHITELIST: list[str] = [
         "fallout-shelter",

--- a/backend/app/services/dweller_ai.py
+++ b/backend/app/services/dweller_ai.py
@@ -381,10 +381,10 @@ class DwellerAIService:
         # For now, let's assume dweller_ai_service.generate_photo pulls what it needs from dweller_obj
         # after it's updated.
 
-        # 3. Generate Photo (using your existing DwellerAIService)
-        dweller_obj = await dweller_ai.generate_photo(db_session=db_session, dweller_info=updated_dweller, user=user)
+        # 3. Generate Photo
+        dweller_obj = await self.generate_photo(db_session=db_session, dweller_info=updated_dweller, user=user)
         # 4. Generate Audio
-        return await dweller_ai.generate_audio(
+        return await self.generate_audio(
             db_session=db_session,
             dweller_info=dweller_obj,
             user=user,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fallout-shelter-fast-api"
-version = "2.14.0"
+version = "2.14.2"
 authors = [{ name = "ElderEvil", email = "elder.evil.dev@proton.me" }, ]
 description = "Fallout Shelter FastAPI Game is a web-based simulation game where the player manages a vault full of dwellers, balancing their needs and resources to keep the vault thriving."
 requires-python = ">=3.12,<3.14"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "fallout-shelter-fast-api"
-version = "2.14.0"
+version = "2.14.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosmtplib" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "2.14.0",
+  "version": "2.14.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Changes

- **Dweller AI service** - Use `self.` instead of module-level singleton in `generate_dweller_avatar`
- **RustFS config drift** - `RUSTFS_BUCKET` env var now properly maps to `RUSTFS_DEFAULT_BUCKET` via `AliasChoices`
- **Version bump** to 2.14.2 (backend + frontend)