### PR TITLE
fix: align rustfs health check endpoint with adapter logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **RustFS config drift** - Added `RUSTFS_BUCKET` as an alias for `RUSTFS_DEFAULT_BUCKET` so the env var
   set in the k8s deployment actually takes effect instead of being silently ignored
 
+- **RustFS health check shows degraded** - `check_rustfs()` used `RUSTFS_PUBLIC_URL` (defaulting to `None`)
+  for the endpoint URL instead of building it from `RUSTFS_HOSTNAME` + `RUSTFS_PORT` + `RUSTFS_USE_HTTPS`
+  like `RustFSAdapter._get_endpoint_url()` does. This caused the health check to try AWS S3 with rustfs
+  credentials, fail with `InvalidAccessKeyId`, and report `degraded`. Fixed by aligning endpoint
+  construction with the adapter's logic.
+
 ---
 
 ## [2.14.0] - 2026-05-26

--- a/backend/app/services/health_check.py
+++ b/backend/app/services/health_check.py
@@ -152,11 +152,17 @@ class HealthCheckService:
                 details={"configured": False, "note": "Image/audio upload features disabled"},
             )
 
+        # Build endpoint the same way as RustFSAdapter._get_endpoint_url()
+        hostname = getattr(settings, "RUSTFS_HOSTNAME", None) or "s3.evillab.dev"
+        port = getattr(settings, "RUSTFS_PORT", "")
+        use_https = getattr(settings, "RUSTFS_USE_HTTPS", False)
+        scheme = "https" if use_https else "http"
+        endpoint_url = f"{scheme}://{hostname}:{port}" if port else f"{scheme}://{hostname}"
+
         try:
             import boto3
             from botocore.config import Config
 
-            endpoint_url = getattr(settings, "RUSTFS_PUBLIC_URL", "https://s3.evillab.dev")
             client = boto3.client(
                 "s3",
                 endpoint_url=endpoint_url,
@@ -185,7 +191,7 @@ class HealthCheckService:
                 service="rustfs",
                 status=ServiceStatus.DEGRADED,
                 message=f"RustFS connection failed (optional service): {e!s}",
-                details={"endpoint": getattr(settings, "RUSTFS_PUBLIC_URL", "unknown"), "error": str(e)},
+                details={"endpoint": endpoint_url, "error": str(e)},
             )
         except (OSError, ValueError, ImportError) as e:
             logger.warning("RustFS health check failed (non-critical): %s", e)
@@ -193,7 +199,7 @@ class HealthCheckService:
                 service="rustfs",
                 status=ServiceStatus.DEGRADED,
                 message=f"RustFS connection failed (optional service): {e!s}",
-                details={"endpoint": getattr(settings, "RUSTFS_PUBLIC_URL", "unknown"), "error": str(e)},
+                details={"endpoint": endpoint_url, "error": str(e)},
             )
 
     @staticmethod

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fallout-shelter-fast-api"
-version = "2.14.2"
+version = "2.14.3"
 authors = [{ name = "ElderEvil", email = "elder.evil.dev@proton.me" }, ]
 description = "Fallout Shelter FastAPI Game is a web-based simulation game where the player manages a vault full of dwellers, balancing their needs and resources to keep the vault thriving."
 requires-python = ">=3.12,<3.14"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "fallout-shelter-fast-api"
-version = "2.14.2"
+version = "2.14.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiosmtplib" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "2.14.2",
+  "version": "2.14.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Problem
`check_rustfs()` was using `RUSTFS_PUBLIC_URL` (default: `None`) as the S3 endpoint URL. Since this isn't set in the k8s deployment, boto3 defaulted to AWS S3, which rejected the rustfs credentials with `InvalidAccessKeyId` — causing the health check to always report `degraded`.

## Fix
Build the endpoint the same way `RustFSAdapter._get_endpoint_url()` does: from `RUSTFS_HOSTNAME` + `RUSTFS_PORT` + `RUSTFS_USE_HTTPS`.

## Verification
- Tested inside the cluster: health check now returns `HEALTHY` with correct bucket list