### PR TITLE
fix(vault): include medical storage in responses

### DIFF
--- a/backend/app/crud/vault.py
+++ b/backend/app/crud/vault.py
@@ -146,10 +146,13 @@ class CRUDVault(CRUDBase[Vault, VaultCreate, VaultUpdate]):
                 self.model,
                 func.count(Room.id.distinct()).label("room_count"),
                 func.count(Dweller.id.distinct()).label("dweller_count"),
+                func.coalesce(func.max(Storage.stimpack), 0).label("stimpack"),
+                func.coalesce(func.max(Storage.radaway), 0).label("radaway"),
             )
             .select_from(Vault)
             .join(Room, Room.vault_id == self.model.id, isouter=True)
             .join(Dweller, Dweller.vault_id == self.model.id, isouter=True)
+            .join(Storage, Storage.vault_id == self.model.id, isouter=True)
             .where(Vault.user_id == user_id)
             .where(Vault.deleted_at.is_(None))
             .group_by(Vault.id)
@@ -161,6 +164,8 @@ class CRUDVault(CRUDBase[Vault, VaultCreate, VaultUpdate]):
                 **vault_obj.model_dump(),
                 room_count=room_count,
                 dweller_count=dweller_count,
+                stimpack=stimpack,
+                radaway=radaway,
                 resource_warnings=ResourceManager._check_resource_warnings(
                     vault_obj,
                     {
@@ -170,7 +175,7 @@ class CRUDVault(CRUDBase[Vault, VaultCreate, VaultUpdate]):
                     },
                 ),
             )
-            for vault_obj, room_count, dweller_count in vaults
+            for vault_obj, room_count, dweller_count, stimpack, radaway in vaults
         ]
 
     async def get_vault_with_room_and_dweller_count(
@@ -181,20 +186,25 @@ class CRUDVault(CRUDBase[Vault, VaultCreate, VaultUpdate]):
                 self.model,
                 func.count(Room.id.distinct()).label("room_count"),
                 func.count(Dweller.id.distinct()).label("dweller_count"),
+                func.coalesce(func.max(Storage.stimpack), 0).label("stimpack"),
+                func.coalesce(func.max(Storage.radaway), 0).label("radaway"),
             )
             .select_from(Vault)
             .join(Room, Room.vault_id == self.model.id, isouter=True)
             .join(Dweller, Dweller.vault_id == self.model.id, isouter=True)
+            .join(Storage, Storage.vault_id == self.model.id, isouter=True)
             .where(Vault.id == vault_id)
             .group_by(Vault.id)
         )
 
         vault_data = result.one()
-        vault_obj, room_count, dweller_count = vault_data
+        vault_obj, room_count, dweller_count, stimpack, radaway = vault_data
         return VaultReadWithNumbers(
             **vault_obj.model_dump(),
             room_count=room_count,
             dweller_count=dweller_count,
+            stimpack=stimpack,
+            radaway=radaway,
             resource_warnings=ResourceManager._check_resource_warnings(
                 vault_obj,
                 {

--- a/backend/app/tests/test_api/test_vault.py
+++ b/backend/app/tests/test_api/test_vault.py
@@ -81,6 +81,19 @@ async def test_read_vault(
     # user_id is not included in VaultReadWithNumbers response (GET /vaults/{id})
     assert "room_count" in response_data
     assert "dweller_count" in response_data
+    # Older vaults may not have a storage record yet.
+    assert response_data["stimpack"] == 0
+    assert response_data["radaway"] == 0
+
+    storage = await crud.vault.create_storage(db_session=async_session, vault_id=created_vault.id)
+    storage.stimpack = 12
+    storage.radaway = 4
+    await async_session.commit()
+
+    response = await async_client.get(f"/vaults/{created_vault.id}", headers=superuser_token_headers)
+    assert response.status_code == 200
+    assert response.json()["stimpack"] == 12
+    assert response.json()["radaway"] == 4
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Restores the required medical inventory fields on VaultReadWithNumbers by sourcing them from the vault Storage record, with a zero fallback for legacy vaults. Adds API regression coverage for both cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vault details now display stored stimpack and radaway quantities.
  * Vaults without storage records show zero for both resource counts.

* **Bug Fixes**
  * Vault list and detail responses now consistently include storage resource values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->