### PR TITLE
chore: clean internal Ruff findings

### DIFF
--- a/backend/app/crud/base.py
+++ b/backend/app/crud/base.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Any, TypeVar
+from typing import Any
 
 from pydantic import UUID4
 from sqlalchemy import Row, RowMapping
@@ -9,12 +9,8 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.utils.exceptions import ResourceAlreadyExistsException, ResourceNotFoundException
 
-ModelType = TypeVar("ModelType", bound=SQLModel)
-CreateSchemaType = TypeVar("CreateSchemaType", bound=SQLModel)
-UpdateSchemaType = TypeVar("UpdateSchemaType", bound=SQLModel)
 
-
-class CRUDBase[ModelType, CreateSchemaType, UpdateSchemaType]:
+class CRUDBase[ModelType: SQLModel, CreateSchemaType: (SQLModel | None), UpdateSchemaType: (SQLModel | None)]:
     """
     Base class for CRUD (Create, Read, Update, Delete) operations on a SQLModel in a database session.
 

--- a/backend/app/crud/base.py
+++ b/backend/app/crud/base.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Any, Generic, TypeVar
+from typing import Any, TypeVar
 
 from pydantic import UUID4
 from sqlalchemy import Row, RowMapping
@@ -14,7 +14,7 @@ CreateSchemaType = TypeVar("CreateSchemaType", bound=SQLModel)
 UpdateSchemaType = TypeVar("UpdateSchemaType", bound=SQLModel)
 
 
-class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
+class CRUDBase[ModelType, CreateSchemaType, UpdateSchemaType]:
     """
     Base class for CRUD (Create, Read, Update, Delete) operations on a SQLModel in a database session.
 
@@ -38,7 +38,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
 
         # Filter out soft-deleted items if the model has is_deleted attribute
         if not include_deleted and hasattr(self.model, "is_deleted"):
-            query = query.where(col(self.model.is_deleted) == False)
+            query = query.where(~col(self.model.is_deleted))
 
         response = await db_session.execute(query)
         db_obj = response.scalar_one_or_none()
@@ -61,7 +61,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
 
         # Filter out soft-deleted items if the model has is_deleted attribute
         if not include_deleted and hasattr(self.model, "is_deleted"):
-            query = query.where(col(self.model.is_deleted) == False)
+            query = query.where(~col(self.model.is_deleted))
 
         response = await db_session.execute(query)
         return response.scalars().all()
@@ -78,7 +78,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
 
         # Filter out soft-deleted items if the model has is_deleted attribute
         if not include_deleted and hasattr(self.model, "is_deleted"):
-            query = query.where(col(self.model.is_deleted) == False)
+            query = query.where(~col(self.model.is_deleted))
 
         response = await db_session.execute(query)
         return response.scalar_one()
@@ -100,7 +100,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
 
         # Filter out soft-deleted items if the model has is_deleted attribute
         if not include_deleted and hasattr(self.model, "is_deleted"):
-            query = query.where(col(self.model.is_deleted) == False)
+            query = query.where(~col(self.model.is_deleted))
 
         response = await db_session.execute(query)
         return response.scalars().all()
@@ -301,7 +301,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
 
         query = (
             select(self.model)
-            .where(col(self.model.is_deleted) == True)
+            .where(col(self.model.is_deleted))
             .offset(skip)
             .limit(limit)
             .order_by(col(self.model.deleted_at).desc())

--- a/backend/app/crud/dweller.py
+++ b/backend/app/crud/dweller.py
@@ -58,7 +58,7 @@ class CRUDDweller(CRUDBase[Dweller, DwellerCreate, DwellerUpdate]):
 
         # Filter out soft-deleted dwellers by default
         if not include_deleted:
-            query = query.where(self.model.is_deleted == False)
+            query = query.where(~self.model.is_deleted)
 
         response = await db_session.execute(query)
         db_obj = response.scalar_one_or_none()
@@ -84,7 +84,7 @@ class CRUDDweller(CRUDBase[Dweller, DwellerCreate, DwellerUpdate]):
 
         # Filter out soft-deleted dwellers by default
         if not include_deleted:
-            query = query.where(self.model.is_deleted == False)
+            query = query.where(~self.model.is_deleted)
 
         # Filter by status
         if status:
@@ -110,7 +110,7 @@ class CRUDDweller(CRUDBase[Dweller, DwellerCreate, DwellerUpdate]):
                 query = query.order_by(self.model.first_name.desc(), self.model.last_name.desc())
         elif hasattr(self.model, sort_by):
             sort_column = getattr(self.model, sort_by)
-            if order.lower() == "asc":  # noqa: SIM108
+            if order.lower() == "asc":
                 query = query.order_by(sort_column.asc())
             else:
                 query = query.order_by(sort_column.desc())
@@ -133,7 +133,7 @@ class CRUDDweller(CRUDBase[Dweller, DwellerCreate, DwellerUpdate]):
 
         # Filter out soft-deleted dwellers by default
         if not include_deleted:
-            query = query.where(self.model.is_deleted == False)
+            query = query.where(~self.model.is_deleted)
 
         query = query.offset(skip).limit(limit)
         response = await db_session.execute(query)
@@ -410,7 +410,7 @@ class CRUDDweller(CRUDBase[Dweller, DwellerCreate, DwellerUpdate]):
         query = (
             select(self.model)
             .where(self.model.vault_id == vault_id)
-            .where(self.model.is_deleted == True)
+            .where(self.model.is_deleted)
             .order_by(self.model.deleted_at.desc())
             .offset(skip)
             .limit(limit)

--- a/backend/app/crud/game_state.py
+++ b/backend/app/crud/game_state.py
@@ -63,7 +63,7 @@ class CRUDGameState:
     @staticmethod
     async def get_all_active(db_session: AsyncSession) -> list[GameState]:
         """Get all active (not paused) game states."""
-        query = select(GameState).where((GameState.is_active == True) & (GameState.is_paused == False))
+        query = select(GameState).where(GameState.is_active & ~GameState.is_paused)
         result = await db_session.exec(query)
         return list(result.all())
 

--- a/backend/app/crud/item_base.py
+++ b/backend/app/crud/item_base.py
@@ -12,8 +12,6 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.core.game_config import game_config
 from app.crud.base import CreateSchemaType, CRUDBase, ModelType, UpdateSchemaType
 from app.crud.vault import vault as vault_crud
-
-# from app.crud.mixins import SellItemMixin
 from app.models import Outfit, Storage, Vault, Weapon
 from app.models.dweller import Dweller
 from app.models.junk import Junk
@@ -90,7 +88,6 @@ async def get_items_list(
 
 class CRUDItem(
     CRUDBase[ModelType, CreateSchemaType, UpdateSchemaType],
-    # SellItemMixin[ModelType]
 ):
     async def create(self, db_session: AsyncSession, obj_in: CreateSchemaType | dict) -> ModelType:
         obj_in = obj_in if isinstance(obj_in, dict) else obj_in.model_dump()
@@ -160,10 +157,10 @@ class CRUDItem(
     async def _fetch_unequip_data(
         db_session: AsyncSession, item_id: UUID4
     ) -> tuple[Dweller, UUID4, str] | tuple[None, None, None]:
-        WeaponAlias, OutfitAlias = aliased(Weapon), aliased(Outfit)  # noqa: N806
+        WeaponAlias, OutfitAlias = aliased(Weapon), aliased(Outfit)
 
         query = (
-            select(Dweller, Storage.id.label("storage_id"), (WeaponAlias.id != None).label("is_weapon"))  # noqa: E711
+            select(Dweller, Storage.id.label("storage_id"), (WeaponAlias.id != None).label("is_weapon"))
             .select_from(Dweller)
             .join(Vault, Dweller.vault_id == Vault.id)
             .join(Storage, Vault.id == Storage.vault_id)

--- a/backend/app/crud/item_base.py
+++ b/backend/app/crud/item_base.py
@@ -6,11 +6,11 @@ from pydantic import UUID4
 from sqlalchemy import update
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import aliased
-from sqlmodel import select
+from sqlmodel import SQLModel, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.game_config import game_config
-from app.crud.base import CreateSchemaType, CRUDBase, ModelType, UpdateSchemaType
+from app.crud.base import CRUDBase
 from app.crud.vault import vault as vault_crud
 from app.models import Outfit, Storage, Vault, Weapon
 from app.models.dweller import Dweller
@@ -86,8 +86,8 @@ async def get_items_list(
     return await crud_instance.get_multi(db_session, skip=skip, limit=limit)
 
 
-class CRUDItem(
-    CRUDBase[ModelType, CreateSchemaType, UpdateSchemaType],
+class CRUDItem[ModelType: Weapon | Outfit, CreateSchemaType: SQLModel, UpdateSchemaType: SQLModel](
+    CRUDBase[ModelType, CreateSchemaType, UpdateSchemaType]
 ):
     async def create(self, db_session: AsyncSession, obj_in: CreateSchemaType | dict) -> ModelType:
         obj_in = obj_in if isinstance(obj_in, dict) else obj_in.model_dump()
@@ -157,16 +157,16 @@ class CRUDItem(
     async def _fetch_unequip_data(
         db_session: AsyncSession, item_id: UUID4
     ) -> tuple[Dweller, UUID4, str] | tuple[None, None, None]:
-        WeaponAlias, OutfitAlias = aliased(Weapon), aliased(Outfit)
+        weapon_alias, outfit_alias = aliased(Weapon), aliased(Outfit)
 
         query = (
-            select(Dweller, Storage.id.label("storage_id"), (WeaponAlias.id != None).label("is_weapon"))
+            select(Dweller, Storage.id.label("storage_id"), weapon_alias.id.is_not(None).label("is_weapon"))
             .select_from(Dweller)
             .join(Vault, Dweller.vault_id == Vault.id)
             .join(Storage, Vault.id == Storage.vault_id)
-            .outerjoin(WeaponAlias, (Dweller.id == WeaponAlias.dweller_id) & (WeaponAlias.id == item_id))
-            .outerjoin(OutfitAlias, (Dweller.id == OutfitAlias.dweller_id) & (OutfitAlias.id == item_id))
-            .where((WeaponAlias.id == item_id) | (OutfitAlias.id == item_id))
+            .outerjoin(weapon_alias, (Dweller.id == weapon_alias.dweller_id) & (weapon_alias.id == item_id))
+            .outerjoin(outfit_alias, (Dweller.id == outfit_alias.dweller_id) & (outfit_alias.id == item_id))
+            .where((weapon_alias.id == item_id) | (outfit_alias.id == item_id))
         )
 
         result = await db_session.execute(query)

--- a/backend/app/crud/llm_interaction.py
+++ b/backend/app/crud/llm_interaction.py
@@ -1,8 +1,9 @@
-from app.crud.base import CreateSchemaType, CRUDBase, ModelType, UpdateSchemaType
+from app.crud.base import CRUDBase
 from app.models.llm_interaction import LLMInteraction
+from app.schemas.llm_interaction import LLMInteractionCreate
 
 
-class CRUDLLMInteraction(CRUDBase[ModelType, CreateSchemaType, UpdateSchemaType]):
+class CRUDLLMInteraction(CRUDBase[LLMInteraction, LLMInteractionCreate, None]):
     pass
 
 

--- a/backend/app/crud/notification.py
+++ b/backend/app/crud/notification.py
@@ -21,10 +21,10 @@ class CRUDNotification(CRUDBase[Notification, NotificationCreate, NotificationUp
         """Get notifications for a user"""
         from sqlalchemy import desc
 
-        query = select(Notification).where(Notification.user_id == user_id).where(Notification.is_dismissed == False)
+        query = select(Notification).where(Notification.user_id == user_id).where(~Notification.is_dismissed)
 
         if unread_only:
-            query = query.where(Notification.is_read == False)
+            query = query.where(~Notification.is_read)
 
         query = query.order_by(desc(Notification.created_at)).offset(offset).limit(limit)
         result = await db.execute(query)
@@ -35,8 +35,8 @@ class CRUDNotification(CRUDBase[Notification, NotificationCreate, NotificationUp
         query = (
             select(Notification)
             .where(Notification.user_id == user_id)
-            .where(Notification.is_read == False)
-            .where(Notification.is_dismissed == False)
+            .where(~Notification.is_read)
+            .where(~Notification.is_dismissed)
         )
         result = await db.execute(query)
         return len(list(result.scalars().all()))
@@ -55,7 +55,7 @@ class CRUDNotification(CRUDBase[Notification, NotificationCreate, NotificationUp
 
     async def mark_all_as_read(self, db: AsyncSession, user_id: UUID) -> int:
         """Mark all notifications as read for a user"""
-        query = select(Notification).where(Notification.user_id == user_id).where(Notification.is_read == False)
+        query = select(Notification).where(Notification.user_id == user_id).where(~Notification.is_read)
         result = await db.execute(query)
         notifications = result.scalars().all()
 

--- a/backend/app/crud/relationship.py
+++ b/backend/app/crud/relationship.py
@@ -1,7 +1,5 @@
 """CRUD operations for relationships."""
 
-from typing import TYPE_CHECKING
-
 from pydantic import UUID4
 from sqlalchemy import and_
 from sqlmodel import select
@@ -10,9 +8,6 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.crud.base import CRUDBase
 from app.models.relationship import Relationship
 from app.schemas.relationship import RelationshipCreate, RelationshipUpdate
-
-if TYPE_CHECKING:
-    pass
 
 
 class CRUDRelationship(CRUDBase[Relationship, RelationshipCreate, RelationshipUpdate]):

--- a/backend/app/crud/room.py
+++ b/backend/app/crud/room.py
@@ -1,4 +1,6 @@
+import ast
 import logging
+import operator
 
 from pydantic import UUID4
 from sqlalchemy import func
@@ -7,17 +9,54 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.constants import GRID_X_MAX, GRID_X_MIN, GRID_Y_MAX, GRID_Y_MIN
 from app.core.game_config import game_config
-from app.crud.base import CRUDBase, ModelType
+from app.crud.base import CRUDBase
 from app.crud.vault import vault as vault_crud
 from app.models.room import Room
 from app.schemas.common import RoomActionEnum, RoomTypeEnum
 from app.schemas.room import RoomCreate, RoomUpdate
 from app.services.event_bus import GameEvent, event_bus
-from app.utils.exceptions import InsufficientResourcesException, NoSpaceAvailableException, UniqueRoomViolationException
+from app.utils.exceptions import (
+    InsufficientResourcesException,
+    NoSpaceAvailableException,
+    UniqueRoomViolationException,
+    VaultOperationException,
+)
 from app.utils.room_assets import get_room_image_url
 from app.utils.static_data import game_data_store
 
 logger = logging.getLogger(__name__)
+
+_ROOM_FORMULA_OPERATORS = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.FloorDiv: operator.floordiv,
+    ast.Mod: operator.mod,
+    ast.Pow: operator.pow,
+}
+_ROOM_FORMULA_UNARY_OPERATORS = {ast.UAdd: operator.pos, ast.USub: operator.neg}
+
+
+def _evaluate_room_formula(formula: str, level: int, size: int) -> int:
+    """Evaluate a backend-owned room formula containing only arithmetic over L and S."""
+
+    def evaluate(node: ast.AST) -> int | float:
+        if isinstance(node, ast.Constant) and isinstance(node.value, int | float):
+            return node.value
+        if isinstance(node, ast.Name) and node.id in {"L", "S"}:
+            return {"L": level, "S": size}[node.id]
+        if isinstance(node, ast.BinOp) and type(node.op) in _ROOM_FORMULA_OPERATORS:
+            return _ROOM_FORMULA_OPERATORS[type(node.op)](evaluate(node.left), evaluate(node.right))
+        if isinstance(node, ast.UnaryOp) and type(node.op) in _ROOM_FORMULA_UNARY_OPERATORS:
+            return _ROOM_FORMULA_UNARY_OPERATORS[type(node.op)](evaluate(node.operand))
+        raise ValueError(f"Unsupported room formula: {formula!r}")
+
+    try:
+        expression = ast.parse(formula, mode="eval")
+        return int(evaluate(expression.body))
+    except (ArithmeticError, SyntaxError, ValueError) as exc:
+        raise ValueError(f"Invalid room formula: {formula!r}") from exc
 
 
 class CRUDRoom(CRUDBase[Room, RoomCreate, RoomUpdate]):
@@ -36,9 +75,7 @@ class CRUDRoom(CRUDBase[Room, RoomCreate, RoomUpdate]):
     @staticmethod
     def evaluate_capacity_formula(formula: str, level: int, size: int) -> int:
         try:
-            result = eval(  # ruff: ignore[suspicious-eval-usage] - trusted, repository-owned game formula
-                formula, {"L": level, "S": size}
-            )
+            result = _evaluate_room_formula(formula, level, size)
             return int(result)
         except (ValueError, SyntaxError) as e:
             logger.exception("Error evaluating capacity formula.", exc_info=e)
@@ -47,9 +84,7 @@ class CRUDRoom(CRUDBase[Room, RoomCreate, RoomUpdate]):
     @staticmethod
     def evaluate_output_formula(formula: str, level: int, size: int) -> int:
         try:
-            result = eval(  # ruff: ignore[suspicious-eval-usage] - trusted, repository-owned game formula
-                formula, {"L": level, "S": size}
-            )
+            result = _evaluate_room_formula(formula, level, size)
             return int(result)
         except (ValueError, SyntaxError) as e:
             logger.exception("Error evaluating output formula.", exc_info=e)
@@ -182,7 +217,13 @@ class CRUDRoom(CRUDBase[Room, RoomCreate, RoomUpdate]):
             if room_spec.output_formula:
                 obj_in.output_formula = room_spec.output_formula
         else:
-            logger.warning("No room spec found for '%s', using client-sent formulas", obj_in.name)
+            raise VaultOperationException(detail=f"Unknown room specification: {obj_in.name}")
+
+        if obj_in.capacity_formula and not room_spec.capacity_formula:
+            raise VaultOperationException(detail=f"Room specification has no capacity formula: {obj_in.name}")
+
+        if obj_in.output_formula and not room_spec.output_formula:
+            raise VaultOperationException(detail=f"Room specification has no output formula: {obj_in.name}")
 
         if obj_in.capacity_formula:
             # Use actual size if provided, otherwise fall back to size_min
@@ -261,7 +302,7 @@ class CRUDRoom(CRUDBase[Room, RoomCreate, RoomUpdate]):
                 )
                 raise ValueError(msg)
 
-    async def destroy(self, db_session: AsyncSession, id: int | UUID4) -> ModelType:
+    async def destroy(self, db_session: AsyncSession, id: int | UUID4) -> Room:
         # Get room before deletion to check if it's a vault door
         room_to_delete = await self.get(db_session, id)
 

--- a/backend/app/crud/room.py
+++ b/backend/app/crud/room.py
@@ -36,7 +36,9 @@ class CRUDRoom(CRUDBase[Room, RoomCreate, RoomUpdate]):
     @staticmethod
     def evaluate_capacity_formula(formula: str, level: int, size: int) -> int:
         try:
-            result = eval(formula, {"L": level, "S": size})
+            result = eval(  # ruff: ignore[suspicious-eval-usage] - trusted, repository-owned game formula
+                formula, {"L": level, "S": size}
+            )
             return int(result)
         except (ValueError, SyntaxError) as e:
             logger.exception("Error evaluating capacity formula.", exc_info=e)
@@ -45,7 +47,9 @@ class CRUDRoom(CRUDBase[Room, RoomCreate, RoomUpdate]):
     @staticmethod
     def evaluate_output_formula(formula: str, level: int, size: int) -> int:
         try:
-            result = eval(formula, {"L": level, "S": size})
+            result = eval(  # ruff: ignore[suspicious-eval-usage] - trusted, repository-owned game formula
+                formula, {"L": level, "S": size}
+            )
             return int(result)
         except (ValueError, SyntaxError) as e:
             logger.exception("Error evaluating output formula.", exc_info=e)
@@ -115,7 +119,7 @@ class CRUDRoom(CRUDBase[Room, RoomCreate, RoomUpdate]):
             room_obj.category == RoomTypeEnum.PRODUCTION and room_obj.name != "Radio studio"
         )
 
-    async def build(self, *, db_session: AsyncSession, obj_in: RoomCreate) -> Room:  # noqa: C901, PLR0912, PLR0915
+    async def build(self, *, db_session: AsyncSession, obj_in: RoomCreate) -> Room:
         """Implements the objectives to build a room checking for business logic constraints."""
         vault = await vault_crud.get(db_session, id=obj_in.vault_id)
 

--- a/backend/app/crud/user.py
+++ b/backend/app/crud/user.py
@@ -17,7 +17,7 @@ class CRUDUser(CRUDBase[User, UserCreate, UserUpdate]):
     async def get_by_email(self, db_session: AsyncSession, email: str, include_deleted: bool = False) -> User | None:
         query = select(self.model).where(self.model.email == email)
         if not include_deleted:
-            query = query.where(self.model.is_deleted == False)
+            query = query.where(~self.model.is_deleted)
         response = await db_session.execute(query)
         return response.scalar_one_or_none()
 
@@ -26,7 +26,7 @@ class CRUDUser(CRUDBase[User, UserCreate, UserUpdate]):
     ) -> User | None:
         query = select(self.model).where(self.model.username == username)
         if not include_deleted:
-            query = query.where(self.model.is_deleted == False)
+            query = query.where(~self.model.is_deleted)
         response = await db_session.execute(query)
         return response.scalar_one_or_none()
 

--- a/backend/app/crud/vault.py
+++ b/backend/app/crud/vault.py
@@ -24,7 +24,7 @@ class CRUDVault(CRUDBase[Vault, VaultCreate, VaultUpdate]):
     ) -> Sequence[Vault]:
         query = select(self.model).where(self.model.user_id == user_id)
         if not include_deleted:
-            query = query.where(self.model.is_deleted == False)
+            query = query.where(~self.model.is_deleted)
         response = await db_session.execute(query)
         return response.scalars().all()
 

--- a/backend/app/crud/wasteland_location.py
+++ b/backend/app/crud/wasteland_location.py
@@ -3,17 +3,21 @@
 from __future__ import annotations
 
 import logging
-from uuid import UUID
+from typing import TYPE_CHECKING
 
-from pydantic import UUID4
 from sqlalchemy import update as sa_update
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
-from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.dweller import Dweller
 from app.models.wasteland_location import DwellerLocation, DwellerLocationRelationEnum, WastelandLocation
 from app.utils.places import collision_nudge, normalize_place_name, schematic_coords
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from pydantic import UUID4
+    from sqlmodel.ext.asyncio.session import AsyncSession
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +54,7 @@ class CRUDWastelandLocation:
         db_session: AsyncSession,
         vault_id: UUID4,
         name: str,
-        type: str,  # noqa: A002  — LocationTypeEnum pass-through
+        type: str,
         description: str | None = None,
         exploration_id: UUID4 | None = None,
     ) -> WastelandLocation:
@@ -100,8 +104,6 @@ class CRUDWastelandLocation:
             db_session.add(obj)
             try:
                 await db_session.commit()
-                await db_session.refresh(obj)
-                return obj
             except IntegrityError:
                 # Race: another request already inserted this name
                 await db_session.rollback()
@@ -119,6 +121,9 @@ class CRUDWastelandLocation:
                     max_retries,
                 )
                 # Fall through to next iteration — occupied set is rebuilt from DB
+            else:
+                await db_session.refresh(obj)
+                return obj
 
         # Exhausted all retries
         raise IntegrityError(
@@ -155,8 +160,6 @@ class CRUDWastelandLocation:
         db_session.add(link)
         try:
             await db_session.commit()
-            await db_session.refresh(link)
-            return link
         except IntegrityError:
             await db_session.rollback()
             result = await db_session.execute(stmt)
@@ -164,6 +167,9 @@ class CRUDWastelandLocation:
             if existing is not None:
                 return existing
             raise
+        else:
+            await db_session.refresh(link)
+            return link
 
     async def get_dweller_refs(self, db_session: AsyncSession, location_ids: list[UUID4]) -> dict[UUID4, list[dict]]:
         """Batch-load dweller references for a list of location ids.

--- a/backend/app/models/dweller.py
+++ b/backend/app/models/dweller.py
@@ -58,7 +58,6 @@ class DwellerBaseWithoutStats(SQLModel):
     epitaph: str | None = Field(default=None, max_length=255)
 
     # TBD
-    # job: str | None
 
 
 class DwellerBase(DwellerBaseWithoutStats, SPECIALModel):

--- a/backend/app/models/junk.py
+++ b/backend/app/models/junk.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from pydantic import UUID4, model_validator
 from sqlmodel import Field, Relationship
@@ -15,7 +15,7 @@ class JunkBase(ItemBase):
     junk_type: JunkTypeEnum
     description: str = Field(min_length=3, max_length=255)
 
-    _value_by_rarity = {
+    _value_by_rarity: ClassVar[dict[RarityEnum, int]] = {
         RarityEnum.COMMON: 2,
         RarityEnum.RARE: 50,
         RarityEnum.LEGENDARY: 200,

--- a/backend/app/models/llm_interaction.py
+++ b/backend/app/models/llm_interaction.py
@@ -12,7 +12,6 @@ if TYPE_CHECKING:
 
 
 class LLMInteractionBase(SQLModel):
-    # ai_model_type: AIModelType = Field(default=AIModelType.CHATGPT)
     parameters: str | None
     response: str | None
     usage: str | None  # Legacy field - stores operation type (kept for backward compatibility)
@@ -27,7 +26,7 @@ class LLMInteractionBase(SQLModel):
 
 
 class LLMInteraction(BaseUUIDModel, LLMInteractionBase, table=True):
-    created_at: datetime | None = Field(default_factory=lambda: datetime.utcnow())  # noqa: PLW0108
+    created_at: datetime | None = Field(default_factory=lambda: datetime.utcnow())
 
     prompt: "Prompt" = Relationship(back_populates="llm_interactions")
     user: "User" = Relationship(back_populates="llm_interactions")

--- a/backend/app/models/prompt.py
+++ b/backend/app/models/prompt.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
 
 
 class PromptBase(SQLModel):
-    # ai_model_type: AIModelType = Field(default=AIModelType.CHATGPT)
     prompt_name: str = Field(min_length=3, max_length=32, index=True)
     description: str = Field(min_length=3, max_length=1000)
     prompt_template: str = Field()

--- a/backend/app/models/user_profile.py
+++ b/backend/app/models/user_profile.py
@@ -16,7 +16,6 @@ class UserProfileBase(SQLModel):
     avatar_url: str | None = Field(default=None, max_length=255)
     preferences: dict | None = Field(default=None, sa_column=sa.Column(JSONB))
 
-    # Statistics (calculated, not user-editable)
     total_dwellers_created: int = Field(default=0, ge=0)
     total_caps_earned: int = Field(default=0, ge=0)
     total_explorations: int = Field(default=0, ge=0)

--- a/backend/app/models/uuid_types.py
+++ b/backend/app/models/uuid_types.py
@@ -8,11 +8,12 @@ from typing import TYPE_CHECKING, Annotated
 from uuid import UUID
 from uuid import uuid7 as _uuid7_gen
 
+from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
+from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import core_schema
 
 if TYPE_CHECKING:
-    from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
-    from pydantic.json_schema import JsonSchemaValue
+    pass
 
 
 class UUID7(UUID):

--- a/backend/app/models/vault.py
+++ b/backend/app/models/vault.py
@@ -43,7 +43,6 @@ class VaultBase(SQLModel):
     radio_mode: str = Field(default="recruitment", sa_column=Column(String(50)))
 
     # Game state
-    # game_state: GameStatusEnum = Field(default=GameStatusEnum.ACTIVE)
 
     def __str__(self):
         return f"Vault {self.number:03}"

--- a/backend/app/models/weapon.py
+++ b/backend/app/models/weapon.py
@@ -9,7 +9,6 @@ from app.models.item import ItemBase
 from app.schemas.common import WeaponSubtypeEnum, WeaponTypeEnum
 
 if TYPE_CHECKING:
-    from app.models.dweller import Dweller
     from app.models.storage import Storage
 
 

--- a/backend/app/schemas/dweller.py
+++ b/backend/app/schemas/dweller.py
@@ -91,8 +91,6 @@ class DwellerVisualAttributes(BaseModel):
     accessory: str | None = None
     object_held: str | None = None
     # TODO: Choose from inventory
-    # outfit: str | None = None
-    # weapon: str | None = None
 
     # Scene & Action
     pose: str | None = None
@@ -164,7 +162,6 @@ class DwellerReadLess(SQLModel):
     parent_2_id: UUID4 | None = None
 
     # TBD
-    # job: str | None
 
 
 class DwellerRead(DwellerBase):

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -48,7 +48,7 @@ class UserWithTokens(UserRead):
 
 
 class UserReadWithVaults(UserRead):
-    vaults: list["VaultRead"] = []
+    vaults: list["VaultRead"] = Field(default_factory=list)
 
 
 @optional()

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,3 +1,4 @@
 from app.services import storage
 
 __all__ = ["storage"]
+"""Business-logic services for the Fallout Shelter application."""

--- a/backend/app/services/ai_usage_service.py
+++ b/backend/app/services/ai_usage_service.py
@@ -1,5 +1,4 @@
-"""
-AI Usage Service - Token aggregation for user quotas.
+"""AI Usage Service - Token aggregation for user quotas.
 
 IMPORTANT - Caching Strategy for Quota Enforcement:
 - The AIUsageResponse now includes quota fields (quota_limit, quota_used, etc.)

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -70,7 +70,7 @@ class AuthService:
                 expires_delta=refresh_token_expires,
                 redis_client=redis_client,
             ),
-            token_type="bearer",
+            token_type="bearer",  # ruff: ignore[hardcoded-password-func-arg]
         )
 
     async def refresh_token(
@@ -115,7 +115,7 @@ class AuthService:
         return Token(
             access_token=new_access_token,
             refresh_token=new_refresh_token,
-            token_type="bearer",
+            token_type="bearer",  # ruff: ignore[hardcoded-password-func-arg]
         )
 
     async def logout(self, redis_client: Redis, user_id: str) -> None:

--- a/backend/app/services/bio_place_backfill_service.py
+++ b/backend/app/services/bio_place_backfill_service.py
@@ -9,16 +9,20 @@ from __future__ import annotations
 
 import logging
 import re
-from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
-from pydantic import UUID4
 from sqlalchemy import exists, select
-from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.dweller import Dweller
 from app.models.vault import Vault
 from app.models.wasteland_location import DwellerLocation
 from app.services.map_service import map_service
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from pydantic import UUID4
+    from sqlmodel.ext.asyncio.session import AsyncSession
 
 logger = logging.getLogger(__name__)
 
@@ -199,7 +203,7 @@ class BioPlaceBackfillService:
         Returns a mapping of ``vault_id`` → number of dwellers processed.
         Vaults are ordered by creation date for deterministic runs.
         """
-        stmt = select(Vault).where(Vault.is_deleted == False).order_by(Vault.created_at)
+        stmt = select(Vault).where(~Vault.is_deleted).order_by(Vault.created_at)
         if max_vaults is not None:
             stmt = stmt.limit(max_vaults)
         result = await db_session.execute(stmt)
@@ -226,7 +230,7 @@ class BioPlaceBackfillService:
         stmt = (
             select(Dweller)
             .where(Dweller.vault_id == vault_id)
-            .where(Dweller.is_deleted == False)
+            .where(~Dweller.is_deleted)
             .where(Dweller.bio.is_not(None))
             .where(Dweller.bio != "")
             .where(~exists().where(DwellerLocation.dweller_id == Dweller.id))

--- a/backend/app/services/breeding_service.py
+++ b/backend/app/services/breeding_service.py
@@ -81,8 +81,7 @@ class BreedingService:
         db_session: AsyncSession,
         vault_id: UUID4,
     ) -> list[Room]:
-        """
-        Find all living quarters rooms for a vault.
+        """Find all living quarters rooms for a vault.
 
         :param db_session: Database session
         :type db_session: AsyncSession
@@ -100,8 +99,7 @@ class BreedingService:
         vault_id: UUID4,
         living_quarters_ids: list[UUID4],
     ) -> list[Dweller]:
-        """
-        Find all adult dwellers with partners in living quarters.
+        """Find all adult dwellers with partners in living quarters.
 
         :param db_session: Database session
         :type db_session: AsyncSession
@@ -123,8 +121,7 @@ class BreedingService:
 
     @staticmethod
     async def _get_pregnant_mother_ids(db_session: AsyncSession) -> set[UUID4]:
-        """
-        Get set of currently pregnant mother IDs.
+        """Get set of currently pregnant mother IDs.
 
         :param db_session: Database session
         :type db_session: AsyncSession
@@ -140,8 +137,7 @@ class BreedingService:
         pregnant_mother_ids: set[UUID4],
         checked_pairs: set[tuple[str, str]],
     ) -> bool:
-        """
-        Check if a dweller-partner pair is eligible for conception check.
+        """Check if a dweller-partner pair is eligible for conception check.
 
         :param dweller: Dweller to check
         :type dweller: Dweller
@@ -170,8 +166,7 @@ class BreedingService:
         dweller: Dweller,
         partner: Dweller,
     ) -> float:
-        """
-        Get relationship affinity and calculate conception chance.
+        """Get relationship affinity and calculate conception chance.
 
         :param db_session: Database session
         :type db_session: AsyncSession
@@ -203,8 +198,7 @@ class BreedingService:
         partner: Dweller,
         conception_chance: float,
     ) -> Pregnancy | None:
-        """
-        Roll random chance and create pregnancy if successful.
+        """Roll random chance and create pregnancy if successful.
 
         :param db_session: Database session
         :type db_session: AsyncSession
@@ -239,8 +233,7 @@ class BreedingService:
         db_session: AsyncSession,
         vault_id: UUID4,
     ) -> list[Pregnancy]:
-        """
-        Check all partner pairs in living quarters and roll for conception.
+        """Check all partner pairs in living quarters and roll for conception.
 
         :param db_session: Database session
         :param vault_id: Vault ID to check
@@ -284,8 +277,7 @@ class BreedingService:
         mother_id: UUID4,
         father_id: UUID4,
     ) -> Pregnancy:
-        """
-        Create a new pregnancy record.
+        """Create a new pregnancy record.
 
         Args:
             db_session: Database session
@@ -343,8 +335,7 @@ class BreedingService:
         db_session: AsyncSession,
         vault_id: UUID4,
     ) -> list[Pregnancy]:
-        """
-        Find all pregnancies that are due for delivery.
+        """Find all pregnancies that are due for delivery.
 
         Args:
             db_session: Database session
@@ -406,8 +397,7 @@ class BreedingService:
         db_session: AsyncSession,
         pregnancy_id: UUID4,
     ) -> Dweller:
-        """
-        Deliver a baby from a pregnancy.
+        """Deliver a baby from a pregnancy.
 
         Args:
             db_session: Database session
@@ -511,8 +501,7 @@ class BreedingService:
 
     @staticmethod
     def _calculate_inherited_stats(mother: Dweller, father: Dweller) -> dict:
-        """
-        Calculate child's inherited SPECIAL stats.
+        """Calculate child's inherited SPECIAL stats.
 
         Args:
             mother: Mother dweller
@@ -547,8 +536,7 @@ class BreedingService:
 
     @staticmethod
     def _calculate_inherited_rarity(mother: Dweller, father: Dweller) -> RarityEnum:
-        """
-        Calculate child's inherited rarity.
+        """Calculate child's inherited rarity.
 
         Args:
             mother: Mother dweller
@@ -576,8 +564,7 @@ class BreedingService:
         db_session: AsyncSession,
         vault_id: UUID4,
     ) -> list[Dweller]:
-        """
-        Age children to adults if they've reached the growth duration.
+        """Age children to adults if they've reached the growth duration.
 
         Args:
             db_session: Database session
@@ -630,8 +617,7 @@ class BreedingService:
         db_session: AsyncSession,
         vault_id: UUID4,
     ) -> list[Pregnancy]:
-        """
-        Get all active pregnancies for a vault.
+        """Get all active pregnancies for a vault.
 
         Args:
             db_session: Database session

--- a/backend/app/services/changelog_service.py
+++ b/backend/app/services/changelog_service.py
@@ -1,11 +1,15 @@
 """Changelog parsing and querying service."""
 
+from __future__ import annotations
+
 import logging
-from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING
 
 from app.core.config import settings
 from app.utils.version import parse_changelog, version_tuple
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +21,7 @@ class ChangelogService:
         changelog_path: Path = settings.project_root / "CHANGELOG.md"
         return parse_changelog(changelog_path)
 
-    def get_entries(self, limit: Optional[int] = 10, since: Optional[str] = None) -> list[dict]:
+    def get_entries(self, limit: int | None = 10, since: str | None = None) -> list[dict]:
         """Get changelog entries, optionally filtered by version."""
         versions = self._get_versions()
 

--- a/backend/app/services/chat_happiness_service.py
+++ b/backend/app/services/chat_happiness_service.py
@@ -23,8 +23,7 @@ async def apply_chat_happiness(
     dweller_id: UUID4,
     delta: int,
 ) -> tuple[int, int]:
-    """
-    Apply an immediate happiness delta from a chat interaction.
+    """Apply an immediate happiness delta from a chat interaction.
 
     Loads the dweller and vault, applies the delta (clamped 10..100),
     and recomputes vault happiness as the average of all dwellers.
@@ -95,8 +94,7 @@ async def apply_chat_happiness(
 
 
 def compute_neutral_delta() -> int:
-    """
-    Return a neutral delta when happiness change cannot be computed.
+    """Return a neutral delta when happiness change cannot be computed.
 
     Used as fallback when AI analysis fails or returns invalid data.
     """

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -22,7 +22,7 @@ from app.crud.chat_message import chat_message as chat_message_crud
 from app.crud.dweller import dweller as dweller_crud
 from app.crud.llm_interaction import llm_interaction as llm_interaction_crud
 from app.crud.vault import vault as vault_crud
-from app.models import User
+from app.models import User, Vault
 from app.models.chat_message import ChatMessageCreate
 from app.models.objective import ObjectiveBase
 from app.schemas.chat import ActionSuggestion, DwellerChatResponse, NoAction
@@ -33,7 +33,7 @@ from app.schemas.llm_interaction import LLMInteractionCreate
 from app.services.chat_happiness_service import apply_chat_happiness
 from app.services.conversation_service import conversation_service
 from app.services.open_ai import get_ai_service
-from app.services.quota_service import quota_service
+from app.services.quota_service import QuotaCheckResult, quota_service
 from app.services.websocket_manager import manager
 from app.utils.exceptions import AccessDeniedException, QuotaExceededException
 
@@ -506,7 +506,7 @@ class ChatService:
             raise AccessDeniedException(detail="Dweller does not belong to the current user")
 
     @staticmethod
-    def _validate_dweller_ownership(dweller: "DwellerReadFull", vault: "object | None", user: "User") -> None:
+    def _validate_dweller_ownership(dweller: "DwellerReadFull", vault: "Vault | None", user: "User") -> None:
         """Validate that a dweller belongs to the given user, raising AccessDeniedException if not."""
         if not dweller.vault:
             raise AccessDeniedException(detail="Dweller does not belong to the current user")
@@ -514,7 +514,7 @@ class ChatService:
             raise AccessDeniedException(detail="Dweller does not belong to the current user")
 
     @staticmethod
-    def _validate_quota_allowed(quota_result: "object", quota_headers: dict[str, str]) -> None:
+    def _validate_quota_allowed(quota_result: "QuotaCheckResult", quota_headers: dict[str, str]) -> None:
         """Validate that the user has remaining quota, raising QuotaExceededException if not."""
         if not quota_result.allowed:
             detail = f"Monthly token quota exceeded. You have used {quota_result.used} of {quota_result.limit} tokens."

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -235,15 +235,12 @@ class ChatService:
         """
         try:
             dweller = await dweller_crud.get_full_info(db_session, dweller_id)
-            if not dweller:
-                raise ValueError("Dweller not found")
+            self._validate_dweller_exists(dweller, dweller_id)
 
             # Ownership check: dweller's vault must belong to the current user
-            if not dweller.vault:
-                raise AccessDeniedException(detail="Dweller does not belong to the current user")
+            self._ensure_dweller_has_vault(dweller)
             vault = await vault_crud.get(db_session, dweller.vault.id)
-            if not vault or vault.user_id != user.id:
-                raise AccessDeniedException(detail="Dweller does not belong to the current user")
+            self._validate_dweller_ownership(dweller, vault, user)
 
             quota_result = await quota_service.check_quota(user.id, db_session)
 
@@ -253,11 +250,7 @@ class ChatService:
             if quota_result.warning:
                 quota_headers["X-Quota-Warning"] = "true"
 
-            if not quota_result.allowed:
-                detail = (
-                    f"Monthly token quota exceeded. You have used {quota_result.used} of {quota_result.limit} tokens."
-                )
-                raise QuotaExceededException(detail=detail, headers=quota_headers)
+            self._validate_quota_allowed(quota_result, quota_headers)
 
             deps = DwellerChatDeps(
                 db_session=db_session,
@@ -359,10 +352,12 @@ class ChatService:
         """
         try:
             usage = result.usage()
-            return usage.input_tokens, usage.output_tokens, usage.total_tokens
+            token_counts = usage.input_tokens, usage.output_tokens, usage.total_tokens
         except Exception:
             logger.exception("Failed to extract usage info from agent result")
             return None, None, None
+        else:
+            return token_counts
 
     @staticmethod
     async def send_chat_notification(
@@ -452,8 +447,6 @@ class ChatService:
             # Parse action suggestion from agent output
             action_suggestion = await parse_action_suggestion(output, db_session, dweller)
 
-            return response_message, happiness_impact, action_suggestion, prompt_tokens, completion_tokens, total_tokens
-
         except Exception:
             logger.exception("Dweller chat agent failed, using fallback")
 
@@ -482,6 +475,8 @@ class ChatService:
                 result.completion_tokens,
                 result.total_tokens,
             )
+        else:
+            return response_message, happiness_impact, action_suggestion, prompt_tokens, completion_tokens, total_tokens
 
     async def _maybe_unlock_places(self, db_session: AsyncSession, dweller: DwellerReadFull) -> None:
         """Unlock the dweller's associated places after 3+ user messages (best-effort)."""
@@ -497,6 +492,33 @@ class ChatService:
         except Exception:
             await db_session.rollback()
             logger.exception("Failed to unlock places for dweller %s, continuing", dweller.id)
+
+    @staticmethod
+    def _validate_dweller_exists(dweller: "DwellerReadFull | None", _dweller_id: UUID4) -> None:
+        """Validate that a dweller exists, raising ValueError if not."""
+        if not dweller:
+            raise ValueError(f"Dweller {_dweller_id} not found")
+
+    @staticmethod
+    def _ensure_dweller_has_vault(dweller: "DwellerReadFull") -> None:
+        """Ensure the dweller has a vault, raising AccessDeniedException if not."""
+        if not dweller.vault:
+            raise AccessDeniedException(detail="Dweller does not belong to the current user")
+
+    @staticmethod
+    def _validate_dweller_ownership(dweller: "DwellerReadFull", vault: "object | None", user: "User") -> None:
+        """Validate that a dweller belongs to the given user, raising AccessDeniedException if not."""
+        if not dweller.vault:
+            raise AccessDeniedException(detail="Dweller does not belong to the current user")
+        if not vault or vault.user_id != user.id:
+            raise AccessDeniedException(detail="Dweller does not belong to the current user")
+
+    @staticmethod
+    def _validate_quota_allowed(quota_result: "object", quota_headers: dict[str, str]) -> None:
+        """Validate that the user has remaining quota, raising QuotaExceededException if not."""
+        if not quota_result.allowed:
+            detail = f"Monthly token quota exceeded. You have used {quota_result.used} of {quota_result.limit} tokens."
+            raise QuotaExceededException(detail=detail, headers=quota_headers)
 
 
 # Singleton instance

--- a/backend/app/services/conversation_service.py
+++ b/backend/app/services/conversation_service.py
@@ -139,10 +139,11 @@ class ConversationService:
         """
         try:
             usage = result.usage()
-            return usage.input_tokens, usage.output_tokens, usage.total_tokens
         except Exception:
             logger.exception("Failed to extract usage info from voice chat agent result")
             return None, None, None
+        else:
+            return usage.input_tokens, usage.output_tokens, usage.total_tokens
 
     async def _generate_response_with_agent(
         self, db_session: AsyncSession, dweller, transcribed_text: str

--- a/backend/app/services/death_service.py
+++ b/backend/app/services/death_service.py
@@ -30,8 +30,7 @@ class DeathService:
         cause: DeathCauseEnum,
         epitaph: str | None = None,
     ) -> Dweller:
-        """
-        Mark a dweller as dead.
+        """Mark a dweller as dead.
 
         :param db_session: Database session
         :type db_session: AsyncSession
@@ -107,8 +106,7 @@ class DeathService:
         dweller_id: UUID4,
         user_id: UUID4,
     ) -> Dweller:
-        """
-        Revive a dead dweller by paying the revival cost.
+        """Revive a dead dweller by paying the revival cost.
 
         :param db_session: Database session
         :type db_session: AsyncSession
@@ -182,8 +180,7 @@ class DeathService:
         return revived_dweller
 
     def get_revival_cost(self, level: int) -> int:
-        """
-        Calculate the revival cost for a dweller based on their level.
+        """Calculate the revival cost for a dweller based on their level.
 
         Tiered pricing:
         - Levels 1-5: level x 50 (50-250 caps)
@@ -198,8 +195,7 @@ class DeathService:
         return game_config.death.calculate_revival_cost(level)
 
     def get_days_until_permanent(self, dweller: Dweller) -> int | None:
-        """
-        Calculate days until dweller's death becomes permanent.
+        """Calculate days until dweller's death becomes permanent.
 
         :param dweller: Dead dweller to check
         :type dweller: Dweller
@@ -218,8 +214,7 @@ class DeathService:
         return (permanent_date - now).days
 
     async def check_and_mark_permanent_deaths(self, db_session: AsyncSession) -> int:
-        """
-        Check all dead dwellers and mark those past the threshold as permanently dead.
+        """Check all dead dwellers and mark those past the threshold as permanently dead.
 
         This should be called by a scheduled task (cron job).
 
@@ -233,8 +228,8 @@ class DeathService:
         # Find dead dwellers past the threshold
         query = (
             select(Dweller)
-            .where(Dweller.is_dead == True)
-            .where(Dweller.is_permanently_dead == False)
+            .where(Dweller.is_dead)
+            .where(~Dweller.is_permanently_dead)
             .where(Dweller.death_timestamp <= cutoff_date)
         )
 
@@ -259,8 +254,7 @@ class DeathService:
         return count
 
     async def get_death_statistics(self, db_session: AsyncSession, user_id: UUID4) -> dict:
-        """
-        Get life/death statistics for a user.
+        """Get life/death statistics for a user.
 
         :param db_session: Database session
         :type db_session: AsyncSession
@@ -318,16 +312,14 @@ class DeathService:
         revivable_query = (
             select(Dweller)
             .where(Dweller.vault_id.in_(vault_ids))
-            .where(Dweller.is_dead == True)
-            .where(Dweller.is_permanently_dead == False)
+            .where(Dweller.is_dead)
+            .where(~Dweller.is_permanently_dead)
         )
         revivable_result = await db_session.execute(revivable_query)
         revivable_count = len(revivable_result.scalars().all())
 
         # Count permanently dead
-        permanent_query = (
-            select(Dweller).where(Dweller.vault_id.in_(vault_ids)).where(Dweller.is_permanently_dead == True)
-        )
+        permanent_query = select(Dweller).where(Dweller.vault_id.in_(vault_ids)).where(Dweller.is_permanently_dead)
         permanent_result = await db_session.execute(permanent_query)
         permanent_count = len(permanent_result.scalars().all())
 

--- a/backend/app/services/dweller_ai.py
+++ b/backend/app/services/dweller_ai.py
@@ -117,7 +117,7 @@ class DwellerAIService:
             prompt_tokens = usage.input_tokens
             completion_tokens = usage.output_tokens
             total_tokens = usage.total_tokens
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.warning("Failed to extract usage info from backstory agent result")
             prompt_tokens = None
             completion_tokens = None
@@ -182,7 +182,7 @@ class DwellerAIService:
             prompt_tokens = usage.input_tokens
             completion_tokens = usage.output_tokens
             total_tokens = usage.total_tokens
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.warning("Failed to extract usage info from bio extension agent result")
             prompt_tokens = None
             completion_tokens = None
@@ -262,7 +262,7 @@ class DwellerAIService:
             prompt_tokens = usage.input_tokens
             completion_tokens = usage.output_tokens
             total_tokens = usage.total_tokens
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.warning("Failed to extract usage info from visual attributes agent result")
             prompt_tokens = None
             completion_tokens = None
@@ -353,9 +353,7 @@ class DwellerAIService:
         dweller_info: DwellerReadFull | None = None,
         voice_type: str = "echo",
     ) -> DwellerReadFull:
-        """
-        Generates a voice line for a dweller, uploads it to storage, and updates dweller info.
-        """
+        """Generates a voice line for a dweller, uploads it to storage, and updates dweller info."""
         # Estimate TTS tokens using character count approximation (~4 chars per token)
         # TTS doesn't return token counts from API, so we estimate based on input text
         estimated_tokens = ceil(len(text) / 4)

--- a/backend/app/services/dweller_ai.py
+++ b/backend/app/services/dweller_ai.py
@@ -118,7 +118,7 @@ class DwellerAIService:
             completion_tokens = usage.output_tokens
             total_tokens = usage.total_tokens
         except Exception:
-            logger.warning("Failed to extract usage info from backstory agent result")
+            logger.exception("Failed to extract usage info from backstory agent result")
             prompt_tokens = None
             completion_tokens = None
             total_tokens = None
@@ -183,7 +183,7 @@ class DwellerAIService:
             completion_tokens = usage.output_tokens
             total_tokens = usage.total_tokens
         except Exception:
-            logger.warning("Failed to extract usage info from bio extension agent result")
+            logger.exception("Failed to extract usage info from bio extension agent result")
             prompt_tokens = None
             completion_tokens = None
             total_tokens = None
@@ -263,7 +263,7 @@ class DwellerAIService:
             completion_tokens = usage.output_tokens
             total_tokens = usage.total_tokens
         except Exception:
-            logger.warning("Failed to extract usage info from visual attributes agent result")
+            logger.exception("Failed to extract usage info from visual attributes agent result")
             prompt_tokens = None
             completion_tokens = None
             total_tokens = None

--- a/backend/app/services/dweller_assignment_service.py
+++ b/backend/app/services/dweller_assignment_service.py
@@ -211,9 +211,8 @@ class DwellerAssignmentService:
         db_session: AsyncSession,
         vault_id: UUID4,
     ) -> dict[str, int | list[dict[str, str]]]:
-        """
-        Intelligently assign unassigned dwellers to production rooms based on SPECIAL stats.
-        Priority order: Power Plant (Strength) -> Diner (Agility) -> Water Treatment (Perception)
+        """Intelligently assign unassigned dwellers to production rooms based on SPECIAL stats.
+        Priority order: Power Plant (Strength) -> Diner (Agility) -> Water Treatment (Perception).
         """
         rooms_query = (
             select(Room)
@@ -228,8 +227,8 @@ class DwellerAssignmentService:
             select(Dweller)
             .where(Dweller.vault_id == vault_id)
             .where(Dweller.room_id.is_(None))
-            .where(Dweller.is_deleted == False)
-            .where(Dweller.is_dead == False)
+            .where(~Dweller.is_deleted)
+            .where(~Dweller.is_dead)
         )
         unassigned_result = await db_session.execute(unassigned_query)
         unassigned_dwellers = list(unassigned_result.scalars().all())
@@ -289,9 +288,8 @@ class DwellerAssignmentService:
         db_session: AsyncSession,
         vault_id: UUID4,
     ) -> dict[str, int | list[dict[str, str]]]:
-        """
-        Intelligently assign unassigned dwellers to ALL room types based on SPECIAL stats.
-        Priority: Production -> Med/Science -> Radio -> Training
+        """Intelligently assign unassigned dwellers to ALL room types based on SPECIAL stats.
+        Priority: Production -> Med/Science -> Radio -> Training.
         """
         rooms_query = (
             select(Room)
@@ -312,8 +310,8 @@ class DwellerAssignmentService:
             select(Dweller)
             .where(Dweller.vault_id == vault_id)
             .where(Dweller.room_id.is_(None))
-            .where(Dweller.is_deleted == False)
-            .where(Dweller.is_dead == False)
+            .where(~Dweller.is_deleted)
+            .where(~Dweller.is_dead)
         )
         unassigned_result = await db_session.execute(unassigned_query)
         unassigned_dwellers = list(unassigned_result.scalars().all())

--- a/backend/app/services/dweller_recycling_service.py
+++ b/backend/app/services/dweller_recycling_service.py
@@ -1,5 +1,4 @@
-"""
-Dweller Recycling Service
+"""Dweller Recycling Service.
 
 Manages the recycling of soft-deleted dwellers, allowing their
 AI-generated content (names, bios, visual attributes) to be reused in new vaults.

--- a/backend/app/services/exploration/combat_calculator.py
+++ b/backend/app/services/exploration/combat_calculator.py
@@ -12,8 +12,7 @@ class CombatCalculator:
     """Handles combat outcome calculations."""
 
     def select_enemy(self, progress: float) -> EnemySchema:
-        """
-        Select enemy based on exploration progress.
+        """Select enemy based on exploration progress.
 
         Args:
             progress: Progress percentage (0-100)
@@ -35,8 +34,7 @@ class CombatCalculator:
         return EnemySchema(**random.choice(available_enemies))
 
     def calculate_combat_outcome(self, exploration: Exploration, enemy: EnemySchema) -> CombatOutcomeSchema:
-        """
-        Calculate combat outcome based on dweller stats.
+        """Calculate combat outcome based on dweller stats.
 
         Args:
             exploration: Active exploration

--- a/backend/app/services/exploration/coordinator.py
+++ b/backend/app/services/exploration/coordinator.py
@@ -38,8 +38,7 @@ class ExplorationCoordinator:
 
     @staticmethod
     def _normalize_outfit_type(outfit_type_str: str) -> str:
-        """
-        Normalize outfit_type string to match OutfitTypeEnum values.
+        """Normalize outfit_type string to match OutfitTypeEnum values.
 
         Maps data values like 'tiered_outfit' to enum values like 'TIERED'.
         """
@@ -50,8 +49,7 @@ class ExplorationCoordinator:
         return normalized
 
     async def process_event(self, db_session: AsyncSession, exploration: Exploration) -> Exploration:
-        """
-        Generate and process an event for an active exploration.
+        """Generate and process an event for an active exploration.
 
         Args:
             db_session: Database session
@@ -171,8 +169,7 @@ class ExplorationCoordinator:
             await self._handle_auto_equip(db_session, exploration, item, item_type)
 
     async def _apply_health_loss(self, db_session: AsyncSession, exploration: Exploration, damage: int) -> None:
-        """
-        Apply health loss to dweller.
+        """Apply health loss to dweller.
 
         If damage would be fatal (health <= 0), the dweller dies from exploration.
         """
@@ -268,7 +265,7 @@ class ExplorationCoordinator:
                 # Real implementation should probably create the item in DB and link it to dweller.
                 exploration.add_event(
                     event_type="equip",
-                    description=f"Found better weapon: {item_schema.name}. Using temporarily for better survival (not permanently equipped).",  # noqa: E501
+                    description=f"Found better weapon: {item_schema.name}. Using temporarily for better survival (not permanently equipped).",
                 )
                 db_session.add(exploration)
                 # Note: To really affect combat, we'd need to update dweller_obj.weapon_id
@@ -284,8 +281,7 @@ class ExplorationCoordinator:
             db_session.add(exploration)
 
     async def complete_exploration(self, db_session: AsyncSession, exploration_id: UUID4) -> RewardsSchema:
-        """
-        Complete an exploration and return rewards summary.
+        """Complete an exploration and return rewards summary.
 
         Args:
             db_session: Database session
@@ -346,8 +342,7 @@ class ExplorationCoordinator:
         return rewards
 
     async def recall_exploration(self, db_session: AsyncSession, exploration_id: UUID4) -> RewardsSchema:
-        """
-        Recall a dweller early from exploration.
+        """Recall a dweller early from exploration.
 
         Args:
             db_session: Database session
@@ -487,8 +482,7 @@ class ExplorationCoordinator:
 
     @staticmethod
     def _parse_rarity_to_enum(rarity_str: str) -> RarityEnum:
-        """
-        Convert rarity string to RarityEnum with fallback to COMMON.
+        """Convert rarity string to RarityEnum with fallback to COMMON.
 
         :param rarity_str: Rarity string (e.g., "Legendary", "COMMON")
         :returns: RarityEnum value, defaults to COMMON if invalid
@@ -499,8 +493,7 @@ class ExplorationCoordinator:
             return RarityEnum.COMMON
 
     def _create_weapon_from_loot(self, weapon_data: dict, rarity: RarityEnum, storage_id: UUID4) -> Weapon | None:
-        """
-        Create a Weapon model from loot data.
+        """Create a Weapon model from loot data.
 
         :param weapon_data: Weapon data dict from data_loader
         :param rarity: RarityEnum value
@@ -533,8 +526,7 @@ class ExplorationCoordinator:
             return None
 
     def _create_outfit_from_loot(self, outfit_data: dict, rarity: RarityEnum, storage_id: UUID4) -> Outfit | None:
-        """
-        Create an Outfit model from loot data.
+        """Create an Outfit model from loot data.
 
         :param outfit_data: Outfit data dict from data_loader
         :param rarity: RarityEnum value
@@ -564,8 +556,7 @@ class ExplorationCoordinator:
             return None
 
     def _create_junk_from_loot(self, item_name: str, rarity: RarityEnum, storage_id: UUID4) -> Junk:
-        """
-        Create a Junk model from loot data.
+        """Create a Junk model from loot data.
 
         :param item_name: Name of the junk item
         :param rarity: RarityEnum value
@@ -581,9 +572,8 @@ class ExplorationCoordinator:
             storage_id=storage_id,
         )
 
-    async def _transfer_loot_to_storage(self, db_session: AsyncSession, exploration: Exploration) -> dict[str, list]:  # noqa: PLR0912, PLR0915
-        """
-        Transfer loot items from exploration to vault storage with space validation.
+    async def _transfer_loot_to_storage(self, db_session: AsyncSession, exploration: Exploration) -> dict[str, list]:
+        """Transfer loot items from exploration to vault storage with space validation.
 
         Items are sorted by rarity (legendary > rare > uncommon > common) and
         transferred in priority order. If storage is full, remaining items are

--- a/backend/app/services/exploration/coordinator.py
+++ b/backend/app/services/exploration/coordinator.py
@@ -265,7 +265,10 @@ class ExplorationCoordinator:
                 # Real implementation should probably create the item in DB and link it to dweller.
                 exploration.add_event(
                     event_type="equip",
-                    description=f"Found better weapon: {item_schema.name}. Using temporarily for better survival (not permanently equipped).",
+                    description=(
+                        f"Found better weapon: {item_schema.name}. Using temporarily for better survival "
+                        "(not permanently equipped)."
+                    ),
                 )
                 db_session.add(exploration)
                 # Note: To really affect combat, we'd need to update dweller_obj.weapon_id

--- a/backend/app/services/exploration/data_loader.py
+++ b/backend/app/services/exploration/data_loader.py
@@ -19,7 +19,7 @@ def load_enemies() -> list[dict]:
     if not enemies_file.exists():
         return _get_fallback_enemies()
 
-    with open(enemies_file) as f:
+    with enemies_file.open() as f:
         enemies_data = json.load(f)
         # Validate with Pydantic
         return [EnemySchema(**enemy).model_dump() for enemy in enemies_data]
@@ -32,7 +32,7 @@ def load_event_templates() -> dict:
     if not templates_file.exists():
         return _get_fallback_templates()
 
-    with open(templates_file) as f:
+    with templates_file.open() as f:
         return json.load(f)
 
 
@@ -43,7 +43,7 @@ def load_junk_items() -> list[dict]:
     if not junk_file.exists():
         return []
 
-    with open(junk_file) as f:
+    with junk_file.open() as f:
         return json.load(f)
 
 
@@ -54,7 +54,7 @@ def load_weapons() -> list[dict]:
     if not weapons_file.exists():
         return []
 
-    with open(weapons_file) as f:
+    with weapons_file.open() as f:
         return json.load(f)
 
 
@@ -67,7 +67,7 @@ def load_outfits() -> list[dict]:
 
     outfits = []
     for outfit_file in outfits_dir.glob("*.json"):
-        with open(outfit_file) as f:
+        with outfit_file.open() as f:
             outfits.extend(json.load(f))
 
     return outfits
@@ -80,7 +80,7 @@ def load_discovery_names() -> dict[str, list[str]]:
     if not names_file.exists():
         return _get_fallback_discovery_names()
 
-    with open(names_file) as f:
+    with names_file.open() as f:
         return json.load(f)
 
 

--- a/backend/app/services/exploration/event_generator.py
+++ b/backend/app/services/exploration/event_generator.py
@@ -23,8 +23,7 @@ class EventGenerator:
     """Generates exploration events."""
 
     def can_generate_event(self, exploration: Exploration) -> bool:
-        """
-        Check if enough time has passed to generate a new event.
+        """Check if enough time has passed to generate a new event.
 
         Args:
             exploration: Active exploration
@@ -53,8 +52,7 @@ class EventGenerator:
         return time_since_last_event >= cfg.event_interval_seconds
 
     def generate_event(self, exploration: Exploration) -> ExplorationEvent | None:
-        """
-        Generate a random wasteland event.
+        """Generate a random wasteland event.
 
         Args:
             exploration: Active exploration

--- a/backend/app/services/exploration/loot_calculator.py
+++ b/backend/app/services/exploration/loot_calculator.py
@@ -11,8 +11,7 @@ class LootCalculator:
     """Handles loot selection and caps rewards."""
 
     def calculate_luck_multiplier(self, luck: int) -> float:
-        """
-        Calculate loot quality multiplier based on luck stat.
+        """Calculate loot quality multiplier based on luck stat.
 
         Args:
             luck: Luck stat (1-10)
@@ -25,8 +24,7 @@ class LootCalculator:
         return cfg.luck_multiplier_min + (luck - 1) * ((cfg.luck_multiplier_max - cfg.luck_multiplier_min) / 9)
 
     def get_rarity_weights(self, luck: int) -> dict[str, float]:
-        """
-        Get rarity weights adjusted by luck stat.
+        """Get rarity weights adjusted by luck stat.
 
         Args:
             luck: Luck stat (1-10)
@@ -122,8 +120,7 @@ class LootCalculator:
         return (ItemSchema(name="RadAway", value=50, rarity="Common"), "radaway")
 
     def select_random_loot(self, luck: int) -> tuple[ItemSchema, str]:
-        """
-        Select a random loot item based on luck.
+        """Select a random loot item based on luck.
 
         Args:
             luck: Luck stat (1-10)
@@ -162,8 +159,7 @@ class LootCalculator:
         return (self.select_random_junk(luck), "junk")
 
     def calculate_caps_found(self, perception: int, luck: int) -> int:
-        """
-        Calculate caps found based on perception and luck.
+        """Calculate caps found based on perception and luck.
 
         Args:
             perception: Perception stat (1-10)

--- a/backend/app/services/exploration/rewards_calculator.py
+++ b/backend/app/services/exploration/rewards_calculator.py
@@ -8,8 +8,7 @@ class RewardsCalculator:
     """Handles XP and rewards calculations."""
 
     def calculate_exploration_xp(self, exploration: Exploration, dweller) -> int:
-        """
-        Calculate total XP from exploration with all bonuses.
+        """Calculate total XP from exploration with all bonuses.
 
         Includes:
         - Base XP from distance, enemies, and events

--- a/backend/app/services/game_loop.py
+++ b/backend/app/services/game_loop.py
@@ -33,8 +33,7 @@ class GameLoopService:
         self.logger = logging.getLogger(__name__)
 
     async def process_game_tick(self, db_session: AsyncSession) -> dict:
-        """
-        Process a single game tick for all active vaults.
+        """Process a single game tick for all active vaults.
 
         Returns:
             dict: Statistics about the tick processing
@@ -58,7 +57,7 @@ class GameLoopService:
                 await self.process_vault_tick(db_session, vault.id)
                 stats["vaults_processed"] += 1
             except (SQLAlchemyError, ResourceNotFoundException, VaultOperationException, ValueError, RuntimeError) as e:
-                self.logger.error(f"Error processing vault {vault.id}: {e}", exc_info=True)  # noqa: G201
+                self.logger.error(f"Error processing vault {vault.id}: {e}", exc_info=True)
                 stats["errors"] += 1
 
         stats["total_time"] = (datetime.utcnow() - start_time).total_seconds()
@@ -71,8 +70,7 @@ class GameLoopService:
         return stats
 
     async def process_vault_tick(self, db_session: AsyncSession, vault_id: UUID4) -> dict:
-        """
-        Process a single tick for a specific vault.
+        """Process a single tick for a specific vault.
 
         Args:
             db_session: Database session
@@ -95,7 +93,7 @@ class GameLoopService:
         # Cap catch-up time to prevent abuse
         if seconds_passed > game_config.game_loop.max_offline_catchup:
             self.logger.warning(
-                f"Vault {vault_id} offline time ({seconds_passed}s) exceeds max catch-up, capping to {game_config.game_loop.max_offline_catchup}s"  # noqa: E501
+                f"Vault {vault_id} offline time ({seconds_passed}s) exceeds max catch-up, capping to {game_config.game_loop.max_offline_catchup}s"
             )
             seconds_passed = game_config.game_loop.max_offline_catchup
 
@@ -141,7 +139,7 @@ class GameLoopService:
             }
 
         except (SQLAlchemyError, ResourceNotFoundException, VaultOperationException) as e:
-            self.logger.error(f"Error updating resources for vault {vault_id}: {e}", exc_info=True)  # noqa: G201
+            self.logger.error(f"Error updating resources for vault {vault_id}: {e}", exc_info=True)
             results["updates"]["resources"] = {"error": str(e)}
 
         # === PHASE 2: Incident Management ===
@@ -231,7 +229,7 @@ class GameLoopService:
     async def _get_active_vaults(self, db_session: AsyncSession) -> list[Vault]:
         """Get all vaults that should be processed this tick."""
         # First get all active game states
-        game_state_query = select(GameState).where((GameState.is_active == True) & (GameState.is_paused == False))
+        game_state_query = select(GameState).where(GameState.is_active & ~GameState.is_paused)
         result = await db_session.execute(game_state_query)
         active_game_states = list(result.scalars().all())
 
@@ -260,8 +258,7 @@ class GameLoopService:
         return game_state
 
     async def _process_explorations(self, db_session: AsyncSession, vault_id: UUID4) -> dict:
-        """
-        Process all active explorations for a vault.
+        """Process all active explorations for a vault.
 
         - Generate events for explorations that are due
         - Auto-complete explorations that have reached their duration
@@ -306,17 +303,16 @@ class GameLoopService:
 
                 except (SQLAlchemyError, ValueError, RuntimeError) as e:
                     # Keep broad exception for individual exploration processing
-                    self.logger.error(f"Error processing exploration {exploration.id}: {e}", exc_info=True)  # noqa: G201
+                    self.logger.error(f"Error processing exploration {exploration.id}: {e}", exc_info=True)
 
         except (SQLAlchemyError, ResourceNotFoundException) as e:
-            self.logger.error(f"Error loading explorations for vault {vault_id}: {e}", exc_info=True)  # noqa: G201
+            self.logger.error(f"Error loading explorations for vault {vault_id}: {e}", exc_info=True)
             stats["error"] = str(e)
 
         return stats
 
     async def _award_work_xp(self, db_session: AsyncSession, dweller, room) -> dict:
-        """
-        Award work XP to a dweller and check for level-up.
+        """Award work XP to a dweller and check for level-up.
 
         Args:
             db_session: Database session
@@ -371,8 +367,7 @@ class GameLoopService:
         return stats
 
     async def _process_dwellers(self, db_session: AsyncSession, vault_id: UUID4) -> dict:
-        """
-        Process dweller updates for a vault.
+        """Process dweller updates for a vault.
 
         - Award work XP to dwellers in production rooms
         - Check for level-ups
@@ -439,16 +434,15 @@ class GameLoopService:
 
                 except (SQLAlchemyError, ValueError, RuntimeError) as e:
                     # Keep broad exception for individual dweller processing to prevent one failure from stopping all
-                    self.logger.error(f"Error processing dweller {dweller.id}: {e}", exc_info=True)  # noqa: G201
+                    self.logger.error(f"Error processing dweller {dweller.id}: {e}", exc_info=True)
 
         except SQLAlchemyError as e:
-            self.logger.error(f"Database error processing dwellers for vault {vault_id}: {e}", exc_info=True)  # noqa: G201
+            self.logger.error(f"Database error processing dwellers for vault {vault_id}: {e}", exc_info=True)
 
         return stats
 
     async def _process_training(self, db_session: AsyncSession, vault_id: UUID4) -> dict:
-        """
-        Process all active training sessions for a vault.
+        """Process all active training sessions for a vault.
 
         - Update training progress
         - Auto-complete trainings that have finished
@@ -496,17 +490,16 @@ class GameLoopService:
 
                 except (SQLAlchemyError, ValueError, RuntimeError) as e:
                     # Keep broad exception for individual training processing
-                    self.logger.error(f"Error processing training {training.id}: {e}", exc_info=True)  # noqa: G201
+                    self.logger.error(f"Error processing training {training.id}: {e}", exc_info=True)
 
         except (SQLAlchemyError, ResourceNotFoundException, ResourceConflictException, VaultOperationException) as e:
-            self.logger.error(f"Error loading training sessions for vault {vault_id}: {e}", exc_info=True)  # noqa: G201
+            self.logger.error(f"Error loading training sessions for vault {vault_id}: {e}", exc_info=True)
             stats["error"] = str(e)
 
         return stats
 
     async def _process_happiness(self, db_session: AsyncSession, vault_id: UUID4, seconds_passed: int) -> dict:
-        """
-        Process happiness updates for all dwellers in a vault.
+        """Process happiness updates for all dwellers in a vault.
 
         - Calculate happiness changes based on vault conditions
         - Update individual dweller happiness
@@ -516,8 +509,7 @@ class GameLoopService:
         return await happiness_service.update_vault_happiness(db_session, vault_id, seconds_passed)
 
     async def _process_incidents(self, db_session: AsyncSession, vault_id: UUID4, seconds_passed: int) -> dict:
-        """
-        Process all active incidents for a vault.
+        """Process all active incidents for a vault.
 
         - Check if new incident should spawn
         - Process existing active incidents (combat, damage, resolution)
@@ -576,7 +568,7 @@ class GameLoopService:
 
                 except (SQLAlchemyError, ValueError, RuntimeError) as e:
                     # Keep broad exception for individual incident processing
-                    self.logger.error(f"Error processing incident {incident.id}: {e}", exc_info=True)  # noqa: G201
+                    self.logger.error(f"Error processing incident {incident.id}: {e}", exc_info=True)
 
             # Batch update vault caps and emit event for objectives
             if total_caps_earned > 0:
@@ -587,14 +579,13 @@ class GameLoopService:
                     self.logger.info(f"Awarded {total_caps_earned} caps to vault {vault_id} from incidents")
 
         except (SQLAlchemyError, ResourceNotFoundException) as e:
-            self.logger.error(f"Error managing incidents for vault {vault_id}: {e}", exc_info=True)  # noqa: G201
+            self.logger.error(f"Error managing incidents for vault {vault_id}: {e}", exc_info=True)
             stats["error"] = str(e)
 
         return stats
 
     async def _get_dwellers_in_rooms(self, db_session: AsyncSession, vault_id: UUID4) -> list:
-        """
-        Get all dwellers in a vault that are assigned to rooms.
+        """Get all dwellers in a vault that are assigned to rooms.
 
         :param db_session: Database session
         :type db_session: AsyncSession
@@ -610,8 +601,7 @@ class GameLoopService:
         return dwellers_result.scalars().all()
 
     def _group_dwellers_by_room(self, dwellers: list) -> dict:
-        """
-        Group dwellers by their room_id.
+        """Group dwellers by their room_id.
 
         :param dwellers: List of dwellers to group
         :type dwellers: list
@@ -621,8 +611,7 @@ class GameLoopService:
         return group_dwellers_by_room(dwellers)
 
     async def _fetch_existing_relationships(self, db_session: AsyncSession, dweller_ids: set) -> list:
-        """
-        Batch fetch all relationships for a set of dweller IDs.
+        """Batch fetch all relationships for a set of dweller IDs.
 
         :param db_session: Database session
         :type db_session: AsyncSession
@@ -640,8 +629,7 @@ class GameLoopService:
         return relationships_result.scalars().all()
 
     def _build_relationships_map(self, relationships: list) -> dict:
-        """
-        Build a bidirectional lookup map for relationships.
+        """Build a bidirectional lookup map for relationships.
 
         :param relationships: List of relationships to map
         :type relationships: list
@@ -664,8 +652,7 @@ class GameLoopService:
         relationships_map: dict,
         new_relationships: list,
     ) -> int:
-        """
-        Update affinity for a pair of dwellers, creating relationship if needed.
+        """Update affinity for a pair of dwellers, creating relationship if needed.
 
         :param db_session: Database session
         :type db_session: AsyncSession
@@ -711,8 +698,7 @@ class GameLoopService:
         return 0
 
     async def _create_new_relationships(self, db_session: AsyncSession, new_relationships: list) -> int:
-        """
-        Bulk create new relationships and update their affinity.
+        """Bulk create new relationships and update their affinity.
 
         :param db_session: Database session
         :type db_session: AsyncSession
@@ -743,8 +729,7 @@ class GameLoopService:
         return count
 
     async def _update_room_relationships(self, db_session: AsyncSession, vault_id: UUID4) -> dict:
-        """
-        Update relationship affinity for dwellers in the same room.
+        """Update relationship affinity for dwellers in the same room.
 
         :param db_session: Database session
         :type db_session: AsyncSession
@@ -774,7 +759,7 @@ class GameLoopService:
 
             # Update affinity for dwellers in the same room
             new_relationships = []
-            for _room_id, room_dweller_list in room_dwellers.items():
+            for room_dweller_list in room_dwellers.values():
                 if len(room_dweller_list) < 2:
                     continue
 
@@ -790,15 +775,14 @@ class GameLoopService:
             stats["relationships_updated"] += await self._create_new_relationships(db_session, new_relationships)
 
         except SQLAlchemyError as e:
-            self.logger.error(f"Database error updating relationships for vault {vault_id}: {e}", exc_info=True)  # noqa: G201
+            self.logger.error(f"Database error updating relationships for vault {vault_id}: {e}", exc_info=True)
         except ValueError as e:
-            self.logger.error(f"Validation error updating relationships for vault {vault_id}: {e}", exc_info=True)  # noqa: G201
+            self.logger.error(f"Validation error updating relationships for vault {vault_id}: {e}", exc_info=True)
 
         return stats
 
     async def _process_pregnancies_and_births(self, db_session: AsyncSession, vault_id: UUID4) -> dict:
-        """
-        Check for conception and process due pregnancies.
+        """Check for conception and process due pregnancies.
 
         Args:
             db_session: Database session
@@ -820,9 +804,9 @@ class GameLoopService:
             if new_pregnancies:
                 self.logger.info(f"New pregnancies in vault {vault_id}: {len(new_pregnancies)}")
         except SQLAlchemyError as e:
-            self.logger.error(f"Database error checking for conception in vault {vault_id}: {e}", exc_info=True)  # noqa: G201
+            self.logger.error(f"Database error checking for conception in vault {vault_id}: {e}", exc_info=True)
         except ValueError as e:
-            self.logger.error(f"Validation error checking for conception in vault {vault_id}: {e}", exc_info=True)  # noqa: G201
+            self.logger.error(f"Validation error checking for conception in vault {vault_id}: {e}", exc_info=True)
 
         # Check for due pregnancies and deliver babies
         try:
@@ -834,15 +818,14 @@ class GameLoopService:
                         stats["births"] += 1
                         self.logger.info(f"Baby born in vault {vault_id}: {baby.first_name} {baby.last_name}")
                 except (SQLAlchemyError, ValueError) as e:
-                    self.logger.error(f"Error delivering baby for pregnancy {pregnancy.id}: {e}", exc_info=True)  # noqa: G201
+                    self.logger.error(f"Error delivering baby for pregnancy {pregnancy.id}: {e}", exc_info=True)
         except SQLAlchemyError as e:
-            self.logger.error(f"Database error checking due pregnancies in vault {vault_id}: {e}", exc_info=True)  # noqa: G201
+            self.logger.error(f"Database error checking due pregnancies in vault {vault_id}: {e}", exc_info=True)
 
         return stats
 
     async def _age_children(self, db_session: AsyncSession, vault_id: UUID4) -> dict:
-        """
-        Age children to adults if they're ready.
+        """Age children to adults if they're ready.
 
         Args:
             db_session: Database session
@@ -863,15 +846,14 @@ class GameLoopService:
             if aged_children:
                 self.logger.info(f"Children aged to adults in vault {vault_id}: {len(aged_children)}")
         except SQLAlchemyError as e:
-            self.logger.error(f"Database error aging children in vault {vault_id}: {e}", exc_info=True)  # noqa: G201
+            self.logger.error(f"Database error aging children in vault {vault_id}: {e}", exc_info=True)
         except ValueError as e:
-            self.logger.error(f"Validation error aging children in vault {vault_id}: {e}", exc_info=True)  # noqa: G201
+            self.logger.error(f"Validation error aging children in vault {vault_id}: {e}", exc_info=True)
 
         return stats
 
     async def _process_breeding(self, db_session: AsyncSession, vault_id: UUID4) -> dict:
-        """
-        Process relationships and breeding for a vault.
+        """Process relationships and breeding for a vault.
 
         - Update relationship affinity for dwellers in the same room
         - Check for conception in living quarters

--- a/backend/app/services/game_loop.py
+++ b/backend/app/services/game_loop.py
@@ -93,7 +93,8 @@ class GameLoopService:
         # Cap catch-up time to prevent abuse
         if seconds_passed > game_config.game_loop.max_offline_catchup:
             self.logger.warning(
-                f"Vault {vault_id} offline time ({seconds_passed}s) exceeds max catch-up, capping to {game_config.game_loop.max_offline_catchup}s"
+                f"Vault {vault_id} offline time ({seconds_passed}s) exceeds max catch-up, "
+                f"capping to {game_config.game_loop.max_offline_catchup}s"
             )
             seconds_passed = game_config.game_loop.max_offline_catchup
 

--- a/backend/app/services/happiness_service.py
+++ b/backend/app/services/happiness_service.py
@@ -29,8 +29,7 @@ class HappinessService:
         vault_id: UUID4,
         seconds_passed: int = 60,
     ) -> dict:
-        """
-        Update happiness for all dwellers in a vault based on conditions.
+        """Update happiness for all dwellers in a vault based on conditions.
 
         Args:
             db_session: Database session
@@ -122,8 +121,7 @@ class HappinessService:
 
     @staticmethod
     async def _calculate_vault_factors(vault: Vault, active_incidents: list[Incident], radio_rooms: list[Room]) -> dict:
-        """
-        Calculate vault-wide factors affecting happiness.
+        """Calculate vault-wide factors affecting happiness.
 
         Args:
             vault: Vault object
@@ -168,14 +166,13 @@ class HappinessService:
         }
 
     @staticmethod
-    async def _calculate_happiness_change(  # noqa: C901, PLR0912
+    async def _calculate_happiness_change(
         db_session: AsyncSession,
         dweller: Dweller,
         vault_factors: dict,
         seconds_passed: int,
     ) -> float:
-        """
-        Calculate happiness change for a single dweller.
+        """Calculate happiness change for a single dweller.
 
         Args:
             db_session: Database session
@@ -280,12 +277,11 @@ class HappinessService:
         return round(change, 2)
 
     @staticmethod
-    async def get_happiness_modifiers(  # noqa: C901, PLR0912
+    async def get_happiness_modifiers(
         db_session: AsyncSession,
         dweller_id: UUID4,
     ) -> dict:
-        """
-        Get detailed breakdown of happiness modifiers for a dweller.
+        """Get detailed breakdown of happiness modifiers for a dweller.
 
         Args:
             db_session: Database session

--- a/backend/app/services/health_check.py
+++ b/backend/app/services/health_check.py
@@ -46,8 +46,7 @@ class HealthCheckService:
 
     @staticmethod
     async def check_postgres(engine: AsyncEngine) -> HealthCheckResult:
-        """
-        Check PostgreSQL database connectivity.
+        """Check PostgreSQL database connectivity.
 
         Args:
             engine: AsyncEngine instance
@@ -75,8 +74,7 @@ class HealthCheckService:
 
     @staticmethod
     async def check_redis() -> HealthCheckResult:
-        """
-        Check Redis connectivity.
+        """Check Redis connectivity.
 
         Returns:
             HealthCheckResult with connection status
@@ -204,8 +202,7 @@ class HealthCheckService:
 
     @staticmethod
     async def check_ollama() -> HealthCheckResult:
-        """
-        Check Ollama service connectivity when using ollama provider.
+        """Check Ollama service connectivity when using ollama provider.
 
         Returns:
             HealthCheckResult with connection status
@@ -295,8 +292,7 @@ class HealthCheckService:
 
     @staticmethod
     async def check_smtp() -> HealthCheckResult:
-        """
-        Check SMTP email service connectivity.
+        """Check SMTP email service connectivity.
 
         Returns:
             HealthCheckResult with connection status
@@ -399,8 +395,7 @@ class HealthCheckService:
 
     @staticmethod
     def log_health_check_results(results: dict[str, HealthCheckResult]) -> bool:
-        """
-        Log health check results and return overall health status.
+        """Log health check results and return overall health status.
 
         Args:
             results: Dictionary of health check results
@@ -414,7 +409,7 @@ class HealthCheckService:
         logger.info("SERVICE HEALTH CHECK RESULTS")
         logger.info("==================================================")
 
-        for _service_name, result in results.items():
+        for result in results.values():
             status_emoji = "✓" if result.status == ServiceStatus.HEALTHY else "✗"
             log_level = logging.INFO if result.status == ServiceStatus.HEALTHY else logging.WARNING
 

--- a/backend/app/services/incident_service.py
+++ b/backend/app/services/incident_service.py
@@ -30,8 +30,7 @@ class IncidentService:
     async def should_spawn_incident(
         self, db_session: AsyncSession, vault_id: UUID4, seconds_passed: int, game_state: GameState | None = None
     ) -> bool:
-        """
-        Determine if an incident should spawn based on vault state and time.
+        """Determine if an incident should spawn based on vault state and time.
 
         Args:
             db_session: Database session
@@ -84,8 +83,7 @@ class IncidentService:
     async def spawn_incident(
         self, db_session: AsyncSession, vault_id: UUID4, incident_type: IncidentType | None = None
     ) -> Incident | None:
-        """
-        Spawn a new incident in a random occupied room.
+        """Spawn a new incident in a random occupied room.
         Raiders and Deathclaws spawn at vault door (0,0) and spread inward.
 
         Rules enforced:
@@ -256,11 +254,10 @@ class IncidentService:
 
         return incident
 
-    async def process_incident(  # noqa: PLR0915
+    async def process_incident(
         self, db_session: AsyncSession, incident: Incident, seconds_passed: int
     ) -> dict[str, int | float]:
-        """
-        Process an active incident (apply damage, check victory conditions).
+        """Process an active incident (apply damage, check victory conditions).
 
         Args:
             db_session: Database session
@@ -420,8 +417,7 @@ class IncidentService:
         incident_id: UUID4,
         success: bool = True,
     ) -> dict:
-        """
-        Manually resolve an incident (player intervention).
+        """Manually resolve an incident (player intervention).
 
         Args:
             db_session: Database session
@@ -608,8 +604,7 @@ class IncidentService:
         return damage_per_second * seconds
 
     async def _award_combat_xp(self, db_session: AsyncSession, incident: "Incident", dwellers: list["Dweller"]) -> None:
-        """
-        Award experience to dwellers who participated in combat.
+        """Award experience to dwellers who participated in combat.
 
         Args:
             db_session: Database session

--- a/backend/app/services/leveling_service.py
+++ b/backend/app/services/leveling_service.py
@@ -16,8 +16,7 @@ class LevelingService:
 
     @staticmethod
     def calculate_xp_required(level: int) -> int:
-        """
-        Calculate total XP required to reach a specific level.
+        """Calculate total XP required to reach a specific level.
 
         Uses exponential curve: BASE_XP * (level ^ EXPONENT)
 
@@ -40,8 +39,7 @@ class LevelingService:
 
     @staticmethod
     def calculate_xp_for_level_range(current_level: int, target_level: int) -> int:
-        """
-        Calculate XP needed to go from current_level to target_level.
+        """Calculate XP needed to go from current_level to target_level.
 
         Args:
             current_level: Starting level
@@ -57,8 +55,7 @@ class LevelingService:
         )
 
     async def check_level_up(self, db_session: AsyncSession, dweller: Dweller) -> tuple[bool, int]:
-        """
-        Check if dweller has enough XP to level up.
+        """Check if dweller has enough XP to level up.
 
         Args:
             db_session: Database session
@@ -94,8 +91,7 @@ class LevelingService:
         return False, 0
 
     async def level_up_dweller(self, db_session: AsyncSession, dweller: Dweller, levels: int = 1) -> Dweller:
-        """
-        Level up a dweller.
+        """Level up a dweller.
 
         Increases:
         - Level

--- a/backend/app/services/map_service.py
+++ b/backend/app/services/map_service.py
@@ -9,15 +9,13 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
 
-from pydantic import UUID4
+from pydantic import UUID4  # ruff: ignore[typing-only-third-party-import]
 from sqlalchemy.exc import IntegrityError
-from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.game_config import game_config
 from app.crud.wasteland_location import wasteland_location as wl_crud
-from app.models.dweller import Dweller
 from app.models.notification import NotificationPriority, NotificationType
 from app.models.vault import Vault
 from app.models.wasteland_location import (
@@ -25,7 +23,7 @@ from app.models.wasteland_location import (
     LocationTypeEnum,
     WastelandLocation,
 )
-from app.schemas.common import RarityEnum
+from app.schemas.common import RarityEnum  # ruff: ignore[typing-only-first-party-import]
 from app.schemas.wasteland_location import (
     DwellerRef,
     VaultMapResponse,
@@ -34,6 +32,11 @@ from app.schemas.wasteland_location import (
 )
 from app.services.notification_service import notification_service
 from app.utils.places import GENERIC_ORIGIN_SKIP, WORLD_SCALE, normalize_place_name, seeded_vault_specs
+
+if TYPE_CHECKING:
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+    from app.models.dweller import Dweller
 
 logger = logging.getLogger(__name__)
 
@@ -98,14 +101,15 @@ class MapService:
         db_session.add(obj)
         try:
             await db_session.commit()
-            await db_session.refresh(obj)
-            return obj
         except IntegrityError:
             await db_session.rollback()
             existing = await wl_crud.get_by_normalized(db_session, vault.id, normalized)
             if existing is not None:
                 return existing
             raise
+        else:
+            await db_session.refresh(obj)
+            return obj
 
     async def link_home_origin(self, db_session: AsyncSession, dweller: Dweller, vault: Vault) -> None:
         """Ensure the home marker exists and link *dweller* to it as ORIGIN — best-effort."""
@@ -155,7 +159,6 @@ class MapService:
                     visited_places,
                     explicit_origin,
                 )
-                return True
             except Exception:
                 await db_session.rollback()
                 if attempt == 0:
@@ -174,6 +177,8 @@ class MapService:
                     map_dweller.vault_id,
                     origin_place,
                 )
+            else:
+                return True
 
         await self._notify_bio_registration_failure(db_session, map_dweller)
         return False
@@ -187,7 +192,7 @@ class MapService:
         explicit_origin: str | None,
     ) -> None:
         """Register bio places once; callers handle best-effort recovery."""
-        effective_origin = explicit_origin if explicit_origin else origin_place
+        effective_origin = explicit_origin or origin_place
 
         # --- origin ---
         if not self._should_skip(effective_origin):

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -13,11 +13,11 @@ logger = logging.getLogger(__name__)
 
 
 class NotificationService:
-    """Service for creating and sending notifications"""
+    """Service for creating and sending notifications."""
 
     @staticmethod
     async def _get_vault_prefix(db: AsyncSession, vault_id: UUID | None) -> str:
-        """Get vault number prefix for notification messages"""
+        """Get vault number prefix for notification messages."""
         if not vault_id:
             return ""
 
@@ -41,7 +41,7 @@ class NotificationService:
         priority: NotificationPriority = NotificationPriority.NORMAL,
         meta_data: dict[str, Any] | None = None,
     ):
-        """Create a notification and send it via WebSocket"""
+        """Create a notification and send it via WebSocket."""
         vault_prefix = await NotificationService._get_vault_prefix(db, vault_id)
         prefixed_message = f"{vault_prefix}{message}"
 
@@ -120,7 +120,7 @@ class NotificationService:
         event_description: str,
         meta_data: dict[str, Any] | None = None,
     ):
-        """Notify user about exploration event"""
+        """Notify user about exploration event."""
         return await NotificationService.create_and_send(
             db,
             user_id=user_id,
@@ -142,7 +142,7 @@ class NotificationService:
         dweller_name: str,
         meta_data: dict[str, Any] | None = None,
     ):
-        """Notify user that exploration is complete"""
+        """Notify user that exploration is complete."""
         return await NotificationService.create_and_send(
             db,
             user_id=user_id,
@@ -165,7 +165,7 @@ class NotificationService:
         new_level: int,
         meta_data: dict[str, Any] | None = None,
     ):
-        """Notify user that a dweller leveled up"""
+        """Notify user that a dweller leveled up."""
         return await NotificationService.create_and_send(
             db,
             user_id=user_id,
@@ -188,7 +188,7 @@ class NotificationService:
         stat_name: str,
         meta_data: dict[str, Any] | None = None,
     ):
-        """Notify user that training is complete"""
+        """Notify user that training is complete."""
         return await NotificationService.create_and_send(
             db,
             user_id=user_id,
@@ -211,7 +211,7 @@ class NotificationService:
         baby_name: str,
         meta_data: dict[str, Any] | None = None,
     ):
-        """Notify user that a baby was born"""
+        """Notify user that a baby was born."""
         return await NotificationService.create_and_send(
             db,
             user_id=user_id,
@@ -234,7 +234,7 @@ class NotificationService:
         max_amount: int,
         meta_data: dict[str, Any] | None = None,
     ):
-        """Notify user that a resource is running low"""
+        """Notify user that a resource is running low."""
         return await NotificationService.create_and_send(
             db,
             user_id=user_id,
@@ -256,7 +256,7 @@ class NotificationService:
         enemy_name: str,
         meta_data: dict[str, Any] | None = None,
     ):
-        """Notify user about combat victory"""
+        """Notify user about combat victory."""
         return await NotificationService.create_and_send(
             db,
             user_id=user_id,
@@ -277,7 +277,7 @@ class NotificationService:
         dweller_name: str,
         meta_data: dict[str, Any] | None = None,
     ):
-        """Notify user that a new dweller arrived via radio"""
+        """Notify user that a new dweller arrived via radio."""
         return await NotificationService.create_and_send(
             db,
             user_id=user_id,
@@ -299,7 +299,7 @@ class NotificationService:
         cause: str,
         meta_data: dict[str, Any] | None = None,
     ):
-        """Notify user that a dweller has died"""
+        """Notify user that a dweller has died."""
         return await NotificationService.create_and_send(
             db,
             user_id=user_id,
@@ -321,7 +321,7 @@ class NotificationService:
         rewards: str,
         meta_data: dict[str, Any] | None = None,
     ):
-        """Notify user that a quest has been completed"""
+        """Notify user that a quest has been completed."""
         return await NotificationService.create_and_send(
             db,
             user_id=user_id,
@@ -342,7 +342,7 @@ class NotificationService:
         reward: str,
         meta_data: dict[str, Any] | None = None,
     ):
-        """Notify user that an objective has been completed"""
+        """Notify user that an objective has been completed."""
         return await NotificationService.create_and_send(
             db,
             user_id=user_id,
@@ -364,7 +364,7 @@ class NotificationService:
         total: int,
         meta_data: dict[str, Any] | None = None,
     ):
-        """Notify user about objective progress milestone (50% or 90%)"""
+        """Notify user about objective progress milestone (50% or 90%)."""
         percent = int((progress / total) * 100)
         return await NotificationService.create_and_send(
             db,

--- a/backend/app/services/objective_evaluators.py
+++ b/backend/app/services/objective_evaluators.py
@@ -42,7 +42,7 @@ class ObjectiveEvaluator(abc.ABC):
     """
 
     objective_type: str
-    subscribed_events: list[GameEvent]
+    subscribed_events: tuple[GameEvent, ...]
 
     def __init__(self, event_bus: EventBus) -> None:
         self._event_bus = event_bus
@@ -156,7 +156,7 @@ class CollectEvaluator(ObjectiveEvaluator):
     """
 
     objective_type = "collect"
-    subscribed_events = [GameEvent.RESOURCE_COLLECTED, GameEvent.ITEM_COLLECTED]
+    subscribed_events = (GameEvent.RESOURCE_COLLECTED, GameEvent.ITEM_COLLECTED)
 
     def _matches(self, objective: Objective, event_type: str, data: dict[str, Any]) -> bool:
         target = objective.target_entity or {}
@@ -195,9 +195,9 @@ class BuildEvaluator(ObjectiveEvaluator):
     """
 
     objective_type = "build"
-    subscribed_events = [GameEvent.ROOM_BUILT, GameEvent.ROOM_UPGRADED]
+    subscribed_events = (GameEvent.ROOM_BUILT, GameEvent.ROOM_UPGRADED)
 
-    def _matches(self, objective: Objective, event_type: str, data: dict[str, Any]) -> bool:  # noqa: ARG002
+    def _matches(self, objective: Objective, event_type: str, data: dict[str, Any]) -> bool:
         target = objective.target_entity or {}
         target_room_type = target.get("room_type")
 
@@ -211,7 +211,7 @@ class BuildEvaluator(ObjectiveEvaluator):
 
         return event_room_type == target_normalized
 
-    def _extract_amount(self, data: dict[str, Any]) -> int:  # noqa: ARG002
+    def _extract_amount(self, data: dict[str, Any]) -> int:
         return 1
 
 
@@ -223,9 +223,9 @@ class TrainEvaluator(ObjectiveEvaluator):
     """
 
     objective_type = "train"
-    subscribed_events = [GameEvent.DWELLER_TRAINED]
+    subscribed_events = (GameEvent.DWELLER_TRAINED,)
 
-    def _matches(self, objective: Objective, event_type: str, data: dict[str, Any]) -> bool:  # noqa: ARG002
+    def _matches(self, objective: Objective, event_type: str, data: dict[str, Any]) -> bool:
         target = objective.target_entity or {}
         target_stat = target.get("stat")
 
@@ -234,7 +234,7 @@ class TrainEvaluator(ObjectiveEvaluator):
 
         return data.get("stat_trained") == target_stat
 
-    def _extract_amount(self, data: dict[str, Any]) -> int:  # noqa: ARG002
+    def _extract_amount(self, data: dict[str, Any]) -> int:
         return 1
 
 
@@ -246,9 +246,9 @@ class AssignEvaluator(ObjectiveEvaluator):
     """
 
     objective_type = "assign"
-    subscribed_events = [GameEvent.DWELLER_ASSIGNED]
+    subscribed_events = (GameEvent.DWELLER_ASSIGNED,)
 
-    def _matches(self, objective: Objective, event_type: str, data: dict[str, Any]) -> bool:  # noqa: ARG002
+    def _matches(self, objective: Objective, event_type: str, data: dict[str, Any]) -> bool:
         target = objective.target_entity or {}
         target_room_type = target.get("room_type")
 
@@ -259,7 +259,7 @@ class AssignEvaluator(ObjectiveEvaluator):
         target_normalized = normalize_room_type(target_room_type)
         return event_room_type == target_normalized
 
-    def _extract_amount(self, data: dict[str, Any]) -> int:  # noqa: ARG002
+    def _extract_amount(self, data: dict[str, Any]) -> int:
         return 1
 
 
@@ -273,12 +273,12 @@ class AssignCorrectEvaluator(ObjectiveEvaluator):
     """
 
     objective_type = "assign_correct"
-    subscribed_events = [GameEvent.DWELLER_ASSIGNED_CORRECTLY]
+    subscribed_events = (GameEvent.DWELLER_ASSIGNED_CORRECTLY,)
 
-    def _matches(self, objective: Objective, event_type: str, data: dict[str, Any]) -> bool:  # noqa: ARG002
+    def _matches(self, objective: Objective, event_type: str, data: dict[str, Any]) -> bool:
         return data.get("is_correct", False)
 
-    def _extract_amount(self, data: dict[str, Any]) -> int:  # noqa: ARG002
+    def _extract_amount(self, data: dict[str, Any]) -> int:
         return 1
 
 
@@ -294,9 +294,9 @@ class ReachEvaluator(ObjectiveEvaluator):
     """
 
     objective_type = "reach"
-    subscribed_events = [GameEvent.DWELLER_LEVEL_UP, GameEvent.DWELLER_ASSIGNED]
+    subscribed_events = (GameEvent.DWELLER_LEVEL_UP, GameEvent.DWELLER_ASSIGNED)
 
-    def _matches(self, objective: Objective, event_type: str, data: dict[str, Any]) -> bool:  # noqa: ARG002
+    def _matches(self, objective: Objective, event_type: str, data: dict[str, Any]) -> bool:
         target = objective.target_entity or {}
         target_type = target.get("reach_type") or target.get("target")
 
@@ -369,9 +369,9 @@ class ExpeditionEvaluator(ObjectiveEvaluator):
     """
 
     objective_type = "expedition"
-    subscribed_events = [GameEvent.QUEST_COMPLETED]
+    subscribed_events = (GameEvent.QUEST_COMPLETED,)
 
-    def _matches(self, objective: Objective, event_type: str, data: dict[str, Any]) -> bool:  # noqa: ARG002
+    def _matches(self, objective: Objective, event_type: str, data: dict[str, Any]) -> bool:
         target = objective.target_entity or {}
         target_quest_type = target.get("quest_type")
 
@@ -381,7 +381,7 @@ class ExpeditionEvaluator(ObjectiveEvaluator):
         event_quest_type = data.get("quest_type", "")
         return event_quest_type.lower() == target_quest_type.lower()
 
-    def _extract_amount(self, data: dict[str, Any]) -> int:  # noqa: ARG002
+    def _extract_amount(self, data: dict[str, Any]) -> int:
         return 1
 
 
@@ -394,9 +394,9 @@ class LevelUpEvaluator(ObjectiveEvaluator):
     """
 
     objective_type = "level_up"
-    subscribed_events = [GameEvent.DWELLER_LEVEL_UP]
+    subscribed_events = (GameEvent.DWELLER_LEVEL_UP,)
 
-    def _matches(self, objective: Objective, event_type: str, data: dict[str, Any]) -> bool:  # noqa: ARG002
+    def _matches(self, objective: Objective, event_type: str, data: dict[str, Any]) -> bool:
         target = objective.target_entity or {}
         raw_min_level = target.get("min_level", 1)
         try:
@@ -407,7 +407,7 @@ class LevelUpEvaluator(ObjectiveEvaluator):
         new_level = data.get("new_level", data.get("level", 1))
         return new_level >= min_level
 
-    def _extract_amount(self, data: dict[str, Any]) -> int:  # noqa: ARG002
+    def _extract_amount(self, data: dict[str, Any]) -> int:
         return 1
 
 

--- a/backend/app/services/open_ai.py
+++ b/backend/app/services/open_ai.py
@@ -61,8 +61,8 @@ class AIService:
         if getattr(self, "_initialized", False):
             return
 
-        self._model: Optional[Any] = None
-        self._client: Optional[openai.Client] = None
+        self._model: Any | None = None
+        self._client: openai.Client | None = None
         self._using_gateway: bool = False
 
         self._initialize_provider()
@@ -153,17 +153,17 @@ class AIService:
             logger.info(f"AI initialized with Ollama ({settings.AI_MODEL}) at {settings.OLLAMA_BASE_URL}")
 
     @property
-    def model(self) -> Optional[Any]:
+    def model(self) -> Any | None:
         """Get the AI model, or None if not configured."""
         return self._model
 
     @classmethod
-    def get_model(cls) -> Optional[Any]:
+    def get_model(cls) -> Any | None:
         """Get the AI model class method (for backward compatibility)."""
         return cls().model
 
     @property
-    def client(self) -> Optional[openai.Client]:
+    def client(self) -> openai.Client | None:
         """Get the OpenAI client, or None if not configured."""
         return self._client
 
@@ -363,7 +363,7 @@ class AIService:
             prompt_tokens = usage.input_tokens
             completion_tokens = usage.output_tokens
             total_tokens = usage.total_tokens
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.warning("Failed to extract usage info from AI service result")
             prompt_tokens = None
             completion_tokens = None

--- a/backend/app/services/pregen_service.py
+++ b/backend/app/services/pregen_service.py
@@ -11,15 +11,18 @@ from __future__ import annotations
 import logging
 import random as std_random
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
-from pydantic import UUID4
-from sqlmodel.ext.asyncio.session import AsyncSession
+from pydantic import UUID4  # ruff: ignore[typing-only-third-party-import]
 
 from app import crud
 from app.schemas.dweller import DwellerUpdate
 from app.services.exploration.data_loader import load_discovery_names
 from app.services.map_service import map_service
 from app.utils.places import GENERIC_ORIGIN_SKIP, normalize_place_name
+
+if TYPE_CHECKING:
+    from sqlmodel.ext.asyncio.session import AsyncSession
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/services/prerequisite_service.py
+++ b/backend/app/services/prerequisite_service.py
@@ -34,7 +34,7 @@ class PrerequisiteService:
                 and_(
                     Dweller.vault_id == vault_id,
                     Dweller.level >= required_level,
-                    Dweller.is_deleted == False,
+                    ~Dweller.is_deleted,
                 )
             )
         )
@@ -101,7 +101,7 @@ class PrerequisiteService:
             select(func.count(Dweller.id)).where(
                 and_(
                     Dweller.vault_id == vault_id,
-                    Dweller.is_deleted == False,
+                    ~Dweller.is_deleted,
                 )
             )
         )
@@ -121,7 +121,7 @@ class PrerequisiteService:
                 and_(
                     VaultQuestCompletionLink.vault_id == vault_id,
                     VaultQuestCompletionLink.quest_id == quest_id,
-                    VaultQuestCompletionLink.is_completed == True,
+                    VaultQuestCompletionLink.is_completed,
                 )
             )
         )

--- a/backend/app/services/quest_service.py
+++ b/backend/app/services/quest_service.py
@@ -24,7 +24,7 @@ class QuestService:
             select(VaultQuestCompletionLink)
             .join(Quest)
             .where(
-                VaultQuestCompletionLink.is_completed == False,
+                ~VaultQuestCompletionLink.is_completed,
                 VaultQuestCompletionLink.started_at.isnot(None),
             )
         )
@@ -87,7 +87,7 @@ class QuestService:
             select(VaultQuestCompletionLink.quest_id).where(
                 and_(
                     VaultQuestCompletionLink.vault_id == vault_id,
-                    VaultQuestCompletionLink.is_completed == True,
+                    VaultQuestCompletionLink.is_completed,
                 )
             )
         )
@@ -100,14 +100,15 @@ class QuestService:
                 VaultQuestCompletionLink,
                 and_(Quest.id == VaultQuestCompletionLink.quest_id, VaultQuestCompletionLink.vault_id == vault_id),
             )
-            .where(VaultQuestCompletionLink.is_visible == True)
+            .where(VaultQuestCompletionLink.is_visible)
         )
         all_quests = result.scalars().all()
 
-        available = []
-        for quest in all_quests:
-            if quest.previous_quest_id is None or quest.previous_quest_id in completed_quest_ids:
-                available.append(quest)
+        available = [
+            quest
+            for quest in all_quests
+            if quest.previous_quest_id is None or quest.previous_quest_id in completed_quest_ids
+        ]
 
         return available[skip : skip + limit]
 
@@ -142,9 +143,7 @@ class QuestService:
 
         await db_session.refresh(quest, ["quest_requirements"])
 
-        result = await db_session.execute(
-            select(Dweller).where(Dweller.vault_id == vault_id, Dweller.is_deleted == False)
-        )
+        result = await db_session.execute(select(Dweller).where(Dweller.vault_id == vault_id, ~Dweller.is_deleted))
         dwellers = result.scalars().all()
 
         vault_level_req_types = {"item", "room", "dweller_count", "quest_completed"}

--- a/backend/app/services/quota_service.py
+++ b/backend/app/services/quota_service.py
@@ -1,5 +1,4 @@
-"""
-Quota Service - Token quota management with atomic checks and cache invalidation.
+"""Quota Service - Token quota management with atomic checks and cache invalidation.
 
 This service provides atomic quota checking using SELECT FOR UPDATE to prevent race
 conditions when multiple requests check quota simultaneously. Admin users bypass quotas.
@@ -10,7 +9,6 @@ Cache invalidation happens in record_usage() to ensure fresh quota data.
 import logging
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING
 from uuid import UUID
 
 from redis.asyncio import Redis
@@ -21,9 +19,6 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.core.config import settings
 from app.models.llm_interaction import LLMInteraction
 from app.models.user import User
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 
@@ -62,8 +57,7 @@ class QuotaService:
         user_id: UUID,
         db_session: AsyncSession,
     ) -> QuotaCheckResult:
-        """
-        Check if user has quota available using SELECT FOR UPDATE for atomicity.
+        """Check if user has quota available using SELECT FOR UPDATE for atomicity.
 
         Uses row-level locking on the user record to prevent race conditions
         when multiple requests check quota simultaneously.
@@ -142,8 +136,7 @@ class QuotaService:
         db_session: AsyncSession,
         redis_client: Redis,
     ) -> None:
-        """
-        Record token usage and invalidate Redis cache.
+        """Record token usage and invalidate Redis cache.
 
         This method creates an LLMInteraction record for the token usage
         and invalidates the cached AI usage data to ensure fresh quota checks.

--- a/backend/app/services/radio_service.py
+++ b/backend/app/services/radio_service.py
@@ -27,8 +27,7 @@ class RadioService:
         db_session: AsyncSession,
         vault_id: UUID4,
     ) -> list[Room]:
-        """
-        Get all radio studio rooms for a vault.
+        """Get all radio studio rooms for a vault.
 
         Args:
             db_session: Database session
@@ -49,8 +48,7 @@ class RadioService:
         vault: Vault,
         radio_rooms: list[Room] | None = None,
     ) -> float:
-        """
-        Calculate recruitment rate based on radio rooms, charisma, and happiness.
+        """Calculate recruitment rate based on radio rooms, charisma, and happiness.
 
         Args:
             db_session: Database session
@@ -97,8 +95,7 @@ class RadioService:
         db_session: AsyncSession,
         vault_id: UUID4,
     ) -> Dweller | None:
-        """
-        Check if a new dweller should be recruited via radio.
+        """Check if a new dweller should be recruited via radio.
 
         Args:
             db_session: Database session
@@ -146,8 +143,7 @@ class RadioService:
         vault_id: UUID4,
         override: DwellerCreateCommonOverride | None = None,
     ) -> tuple[Dweller, bool]:
-        """
-        Recruit a new dweller to the vault.
+        """Recruit a new dweller to the vault.
 
         Prefers restoring a soft-deleted dweller (reusing their S3 assets) when the
         recycling pool has eligible candidates and the config allows it. Falls back to
@@ -242,8 +238,7 @@ class RadioService:
         caps_cost: int | None = None,
         override: DwellerCreateCommonOverride | None = None,
     ) -> tuple[Dweller, bool]:
-        """
-        Manually recruit a dweller for caps.
+        """Manually recruit a dweller for caps.
 
         Args:
             db_session: Database session
@@ -277,7 +272,7 @@ class RadioService:
 
         radio_room_ids = [room.id for room in radio_rooms]
         dwellers_query = select(Dweller).where(
-            Dweller.room_id.in_(radio_room_ids), Dweller.vault_id == vault_id, Dweller.is_deleted == False
+            Dweller.room_id.in_(radio_room_ids), Dweller.vault_id == vault_id, ~Dweller.is_deleted
         )
         assigned_dwellers = (await db_session.execute(dwellers_query)).scalars().all()
 
@@ -309,8 +304,7 @@ class RadioService:
         db_session: AsyncSession,
         vault_id: UUID4,
     ) -> dict:
-        """
-        Get recruitment statistics for a vault.
+        """Get recruitment statistics for a vault.
 
         Args:
             db_session: Database session

--- a/backend/app/services/relationship_service.py
+++ b/backend/app/services/relationship_service.py
@@ -28,8 +28,7 @@ class RelationshipService:
         dweller_1_id: UUID4,
         dweller_2_id: UUID4,
     ) -> Relationship | None:
-        """
-        Get existing relationship between two dwellers.
+        """Get existing relationship between two dwellers.
 
         Args:
             db_session: Database session
@@ -47,8 +46,7 @@ class RelationshipService:
         dweller_1_id: UUID4,
         dweller_2_id: UUID4,
     ) -> Relationship:
-        """
-        Create a new relationship or get existing one.
+        """Create a new relationship or get existing one.
 
         Args:
             db_session: Database session
@@ -78,8 +76,7 @@ class RelationshipService:
         dweller_2_id: UUID4,
         amount: int = 1,
     ) -> Relationship:
-        """
-        Increase affinity between two dwellers.
+        """Increase affinity between two dwellers.
 
         Args:
             db_session: Database session
@@ -121,8 +118,7 @@ class RelationshipService:
         dweller_1_id: UUID4,
         dweller_2_id: UUID4,
     ) -> Relationship:
-        """
-        Initiate romantic relationship between two dwellers.
+        """Initiate romantic relationship between two dwellers.
 
         Args:
             db_session: Database session
@@ -160,8 +156,7 @@ class RelationshipService:
         dweller_1_id: UUID4,
         dweller_2_id: UUID4,
     ) -> Relationship:
-        """
-        Make two dwellers partners (committed relationship).
+        """Make two dwellers partners (committed relationship).
 
         Args:
             db_session: Database session
@@ -218,8 +213,7 @@ class RelationshipService:
         db_session: AsyncSession,
         relationship_id: UUID4,
     ) -> None:
-        """
-        Break up a relationship.
+        """Break up a relationship.
 
         Args:
             db_session: Database session
@@ -271,8 +265,7 @@ class RelationshipService:
         db_session: AsyncSession,
         vault_id: UUID4,
     ) -> Relationship:
-        """
-        Irradiated Cupid
+        """Irradiated Cupid.
 
         Instantly pairs two random compatible dwellers for testing/fun.
         - Finds one male and one female without partners
@@ -352,8 +345,7 @@ class RelationshipService:
         dweller_1_id: UUID4,
         dweller_2_id: UUID4,
     ) -> CompatibilityScore:
-        """
-        Calculate compatibility score between two dwellers.
+        """Calculate compatibility score between two dwellers.
 
         Raises:
             ResourceNotFoundException: If either dweller is not found (propagates as HTTP 404)
@@ -404,8 +396,7 @@ class RelationshipService:
         dweller_1: Dweller,
         dweller_2: Dweller,
     ) -> float:
-        """
-        Backward-compatible wrapper for calculate_compatibility_score.
+        """Backward-compatible wrapper for calculate_compatibility_score.
 
         Args:
             db_session: Database session

--- a/backend/app/services/resource_manager.py
+++ b/backend/app/services/resource_manager.py
@@ -25,8 +25,7 @@ class ResourceManager:
     async def process_vault_resources(
         self, db_session: AsyncSession, vault_id: UUID4, seconds_passed: int
     ) -> tuple[VaultUpdate, dict]:
-        """
-        Process resource changes for a vault over the given time period.
+        """Process resource changes for a vault over the given time period.
 
         Returns:
             tuple: (VaultUpdate with new resource levels, dict with warnings/events)
@@ -58,8 +57,7 @@ class ResourceManager:
         rooms_with_dwellers: list[tuple[Room, list[Dweller]]],
         seconds_passed: int,
     ) -> tuple[VaultUpdate, dict]:
-        """
-        Calculate net resource change considering production, consumption, and efficiency.
+        """Calculate net resource change considering production, consumption, and efficiency.
 
         Returns:
             tuple: (VaultUpdate with new resource levels, dict with events/warnings)
@@ -233,8 +231,7 @@ class ResourceManager:
         return vault, storage, rooms, dweller_count or 0, list(rooms_with_dwellers_dict.values())
 
     async def check_resource_availability(self, vault: Vault) -> dict[str, bool]:
-        """
-        Check if vault has sufficient resources for basic operations.
+        """Check if vault has sufficient resources for basic operations.
 
         Returns:
             dict: Resource availability status

--- a/backend/app/services/reward_service.py
+++ b/backend/app/services/reward_service.py
@@ -366,7 +366,7 @@ class RewardService:
         logger.info(f"Processed objective reward '{reward_str}' for vault {vault_id}")
         return result
 
-    async def _process_single_reward(  # noqa: PLR0911
+    async def _process_single_reward(
         self,
         db_session: AsyncSession,
         vault_id: UUID4,

--- a/backend/app/services/storage/factory.py
+++ b/backend/app/services/storage/factory.py
@@ -2,7 +2,6 @@
 
 import logging
 from functools import lru_cache
-from typing import Optional
 
 from .base import StorageService
 from .rustfs_adapter import RustFSAdapter
@@ -10,7 +9,7 @@ from .rustfs_adapter import RustFSAdapter
 logger = logging.getLogger(__name__)
 
 
-def create_storage_service() -> Optional[StorageService]:
+def create_storage_service() -> StorageService | None:
     """Factory function to create the storage service.
 
     Returns:
@@ -25,7 +24,7 @@ def create_storage_service() -> Optional[StorageService]:
 
 
 @lru_cache
-def get_storage_client() -> Optional[StorageService]:
+def get_storage_client() -> StorageService | None:
     """Get cached storage service instance.
 
     Returns:

--- a/backend/app/services/storage/rustfs_adapter.py
+++ b/backend/app/services/storage/rustfs_adapter.py
@@ -71,7 +71,8 @@ class RustFSAdapter:
         if not self.enabled:
             return
         client = self._client
-        assert client is not None
+        if client is None:
+            raise RuntimeError("S3 client is not initialized")
         bucket_created = False
         try:
             client.head_bucket(Bucket=bucket_name)

--- a/backend/app/services/training_service.py
+++ b/backend/app/services/training_service.py
@@ -27,8 +27,7 @@ class TrainingService:
 
     @staticmethod
     def calculate_training_duration(current_stat: int, room_tier: int = 1) -> int:
-        """
-        Calculate training duration in seconds.
+        """Calculate training duration in seconds.
 
         Base: 2 hours (7200 seconds)
         Scaling: +30 minutes per current stat level
@@ -58,14 +57,13 @@ class TrainingService:
 
         return int(duration)
 
-    async def can_start_training(  # noqa: PLR0911
+    async def can_start_training(
         self,
         db_session: AsyncSession,
         dweller: Dweller,
         room: Room,
     ) -> tuple[bool, str]:
-        """
-        Check if dweller can start training in the given room.
+        """Check if dweller can start training in the given room.
 
         Args:
             db_session: Database session
@@ -117,8 +115,7 @@ class TrainingService:
         dweller_id: UUID4,
         room_id: UUID4,
     ) -> Training:
-        """
-        Start training a dweller in a training room.
+        """Start training a dweller in a training room.
 
         Args:
             db_session: Database session
@@ -198,8 +195,7 @@ class TrainingService:
         training: Training,
         dweller: Dweller | None = None,
     ) -> Training:
-        """
-        Update training progress based on elapsed time.
+        """Update training progress based on elapsed time.
         Auto-completes training if duration has elapsed.
 
         Args:
@@ -238,8 +234,7 @@ class TrainingService:
         training_id: UUID4,
         dweller: Dweller | None = None,
     ) -> Training:
-        """
-        Complete a training session and increase the dweller's SPECIAL stat.
+        """Complete a training session and increase the dweller's SPECIAL stat.
 
         Args:
             db_session: Database session
@@ -312,8 +307,7 @@ class TrainingService:
         training_id: UUID4,
         dweller: Dweller | None = None,
     ) -> Training:
-        """
-        Cancel an active training session.
+        """Cancel an active training session.
         Dweller does not gain the stat increase.
 
         Args:

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -60,7 +60,7 @@ class UserService:
             **user.model_dump(),
             access_token=access_token,
             refresh_token=refresh_token,
-            token_type="bearer",
+            token_type="bearer",  # ruff: ignore[hardcoded-password-func-arg]
         )
 
     async def get_ai_usage(

--- a/backend/app/services/vault_service.py
+++ b/backend/app/services/vault_service.py
@@ -384,8 +384,8 @@ class VaultService:
                     except (ResourceNotFoundException, ResourceConflictException, ValueError) as e:
                         # Log error but continue with other dwellers
                         self.logger.warning(f"Failed to start training for dweller {dweller.id} in room {room.id}: {e}")
-        except Exception as e:
-            self.logger.error(f"Failed to start training sessions: {e}", exc_info=True)
+        except Exception:
+            self.logger.exception("Failed to start training sessions")
             raise
 
     async def _create_initial_items(self, db_session: AsyncSession, vault_id: UUID4) -> None:

--- a/backend/app/services/vault_service.py
+++ b/backend/app/services/vault_service.py
@@ -129,7 +129,7 @@ class VaultService:
 
         return infrastructure_rooms, capacity_rooms, production_rooms, misc_rooms, training_rooms
 
-    async def _create_initial_rooms(  # noqa: C901, PLR0912
+    async def _create_initial_rooms(
         self,
         db_session: AsyncSession,
         vault: Vault,
@@ -215,7 +215,6 @@ class VaultService:
         is_boosted: bool,
     ) -> None:
         """Create and assign initial dwellers to production and training rooms."""
-
         try:
             # Production dwellers (always created) - all should be WORKING
             production_assignments = [
@@ -386,7 +385,7 @@ class VaultService:
                         # Log error but continue with other dwellers
                         self.logger.warning(f"Failed to start training for dweller {dweller.id} in room {room.id}: {e}")
         except Exception as e:
-            self.logger.error(f"Failed to start training sessions: {e}", exc_info=True)  # noqa: G201
+            self.logger.error(f"Failed to start training sessions: {e}", exc_info=True)
             raise
 
     async def _create_initial_items(self, db_session: AsyncSession, vault_id: UUID4) -> None:
@@ -582,8 +581,7 @@ class VaultService:
         user_id: UUID4,
         is_boosted: bool = False,
     ) -> Vault:
-        """
-        Create a new vault for a user and initialize it with essential rooms and dwellers.
+        """Create a new vault for a user and initialize it with essential rooms and dwellers.
 
         Standard vault includes:
         - Vault door and elevators (infrastructure)
@@ -704,8 +702,7 @@ class VaultService:
         stimpaks: int,
         radaways: int,
     ) -> dict:
-        """
-        Transfer medical supplies from vault storage to a dweller's inventory.
+        """Transfer medical supplies from vault storage to a dweller's inventory.
 
         Dwellers can carry max 15 stimpaks and 15 radaways each.
         """

--- a/backend/app/services/websocket_manager.py
+++ b/backend/app/services/websocket_manager.py
@@ -181,7 +181,7 @@ class ConnectionManager:
     async def broadcast_to_vault(
         self,
         message: dict[str, Any],
-        vault_id: UUID,  # noqa: ARG002
+        vault_id: UUID,
         user_ids: list[UUID],
     ):
         """Broadcast message to all users in a vault.

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -22,7 +22,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 # Global engine reference for database cleanup across fixtures
 _test_async_engine = None
 
-from app.core.config import settings  # noqa: E402
+from app.core.config import settings
 
 # Disable rate limiting for tests before importing main
 settings.ENABLE_RATE_LIMITING = False
@@ -40,21 +40,21 @@ sys.modules["app.services.storage"] = mock_storage_module
 sys.modules["app.services.storage.factory"] = mock_storage_module.factory
 
 # Override Redis client with fakeredis so tests run without external Redis
-import fakeredis.aioredis  # noqa: E402
+import fakeredis.aioredis
 
-from app import crud  # noqa: E402
-from app.api.deps import get_redis_client  # noqa: E402
-from app.db.session import get_async_session  # noqa: E402
-from app.schemas.user import UserCreate  # noqa: E402
-from app.tests.utils.user import authentication_token_from_email  # noqa: E402
-from app.tests.utils.utils import get_superuser_token_headers  # noqa: E402
-from main import app  # noqa: E402
+from app import crud
+from app.api.deps import get_redis_client
+from app.db.session import get_async_session
+from app.schemas.user import UserCreate
+from app.tests.utils.user import authentication_token_from_email
+from app.tests.utils.utils import get_superuser_token_headers
+from main import app
 
 
 @pytest_asyncio.fixture
 async def _shared_fake_redis() -> AsyncGenerator[Any]:
     """Function-scoped fakeredis client bound to the test's event loop."""
-    yield fakeredis.aioredis.FakeRedis(decode_responses=True)
+    return fakeredis.aioredis.FakeRedis(decode_responses=True)
 
 
 @pytest_asyncio.fixture(autouse=True)
@@ -82,7 +82,7 @@ def event_loop() -> Generator:
 
 @pytest_asyncio.fixture(scope="session")
 async def db_connection() -> AsyncConnection:
-    global _test_async_engine  # noqa: PLW0603
+    global _test_async_engine
     _test_async_engine = create_async_engine(
         "sqlite+aiosqlite:///:memory:", echo=False, future=True, poolclass=StaticPool
     )
@@ -230,7 +230,7 @@ def dweller_data_fixture():
 
 
 @pytest_asyncio.fixture(name="vault")
-async def vault_fixture(async_session: AsyncSession) -> "Vault":  # noqa: F821
+async def vault_fixture(async_session: AsyncSession) -> "Vault":
     import random
 
     from faker import Faker
@@ -259,7 +259,7 @@ async def vault_fixture(async_session: AsyncSession) -> "Vault":  # noqa: F821
 
 
 @pytest_asyncio.fixture(name="dweller")
-async def dweller_fixture(async_session: AsyncSession, vault: "Vault", dweller_data: dict) -> "Dweller":  # noqa: F821
+async def dweller_fixture(async_session: AsyncSession, vault: "Vault", dweller_data: dict) -> "Dweller":
     from app.schemas.dweller import DwellerCreate
 
     dweller_in = DwellerCreate(**dweller_data, vault_id=vault.id)
@@ -267,7 +267,7 @@ async def dweller_fixture(async_session: AsyncSession, vault: "Vault", dweller_d
 
 
 @pytest_asyncio.fixture(name="radio_room")
-async def radio_room_fixture(async_session: AsyncSession, vault: "Vault") -> "Room":  # noqa: F821
+async def radio_room_fixture(async_session: AsyncSession, vault: "Vault") -> "Room":
     """Create a radio room for testing."""
     from app.schemas.common import RoomTypeEnum, SPECIALEnum
     from app.schemas.room import RoomCreate
@@ -296,7 +296,7 @@ async def radio_room_fixture(async_session: AsyncSession, vault: "Vault") -> "Ro
 
 
 @pytest_asyncio.fixture(name="radio_dweller")
-async def radio_dweller_fixture(async_session: AsyncSession, vault: "Vault", radio_room: "Room") -> "Dweller":  # noqa: F821
+async def radio_dweller_fixture(async_session: AsyncSession, vault: "Vault", radio_room: "Room") -> "Dweller":
     """Create a dweller with high charisma for radio room."""
     from app.schemas.common import AgeGroupEnum, GenderEnum, RarityEnum
     from app.schemas.dweller import DwellerCreate
@@ -332,7 +332,7 @@ async def radio_dweller_fixture(async_session: AsyncSession, vault: "Vault", rad
 
 # Notification test fixtures
 @pytest_asyncio.fixture
-async def user_with_vault(async_session: AsyncSession) -> tuple["User", "Vault"]:  # noqa: F821
+async def user_with_vault(async_session: AsyncSession) -> tuple["User", "Vault"]:
     """Create a user with a vault for notification testing."""
     from app.schemas.user import UserCreate
     from app.schemas.vault import VaultCreate
@@ -353,7 +353,7 @@ async def user_with_vault(async_session: AsyncSession) -> tuple["User", "Vault"]
 
 
 @pytest_asyncio.fixture
-async def dweller_in_vault(async_session: AsyncSession, user_with_vault: tuple) -> "Dweller":  # noqa: F821
+async def dweller_in_vault(async_session: AsyncSession, user_with_vault: tuple) -> "Dweller":
     """Create a dweller in the test vault."""
     from app.schemas.common import AgeGroupEnum, GenderEnum, RarityEnum
     from app.schemas.dweller import DwellerCreate
@@ -385,7 +385,7 @@ async def dweller_in_vault(async_session: AsyncSession, user_with_vault: tuple) 
 
 
 @pytest_asyncio.fixture
-async def room_in_vault(async_session: AsyncSession, user_with_vault: tuple) -> "Room":  # noqa: F821
+async def room_in_vault(async_session: AsyncSession, user_with_vault: tuple) -> "Room":
     """Create a room in the test vault."""
     from app.schemas.common import RoomTypeEnum, SPECIALEnum
     from app.schemas.room import RoomCreate
@@ -416,8 +416,8 @@ async def room_in_vault(async_session: AsyncSession, user_with_vault: tuple) -> 
 @pytest_asyncio.fixture(name="vault_with_rooms")
 async def vault_with_rooms_fixture(
     async_session: AsyncSession,
-    vault: "Vault",  # noqa: F821
-) -> tuple["Vault", list["Room"]]:  # noqa: F821
+    vault: "Vault",
+) -> tuple["Vault", list["Room"]]:
     """
     Vault with 3 rooms of different types.
 
@@ -522,8 +522,8 @@ async def room_with_dwellers_fixture(
 @pytest_asyncio.fixture(name="equipped_dweller")
 async def equipped_dweller_fixture(
     async_session: AsyncSession,
-    dweller: "Dweller",  # noqa: F821
-) -> tuple["Dweller", "Outfit", "Weapon"]:  # noqa: F821
+    dweller: "Dweller",
+) -> tuple["Dweller", "Outfit", "Weapon"]:
     """
     Dweller with outfit and weapon equipped.
 
@@ -550,7 +550,7 @@ async def equipped_dweller_fixture(
 @pytest_asyncio.fixture(name="populated_vault")
 async def populated_vault_fixture(
     async_session: AsyncSession,
-) -> tuple["Vault", list["Room"], list["Dweller"]]:  # noqa: F821
+) -> tuple["Vault", list["Room"], list["Dweller"]]:
     """
     Fully populated vault: 3 rooms, each with 2 dwellers (6 total).
 
@@ -619,8 +619,8 @@ async def populated_vault_fixture(
 @pytest_asyncio.fixture(name="vault_with_resources")
 async def vault_with_resources_fixture(
     async_session: AsyncSession,
-    vault: "Vault",  # noqa: F821
-) -> "Vault":  # noqa: F821
+    vault: "Vault",
+) -> "Vault":
     """
     Vault with abundant resources for testing economy/building.
 

--- a/backend/app/tests/memory_benchmark.py
+++ b/backend/app/tests/memory_benchmark.py
@@ -27,7 +27,7 @@ os.environ["ENVIRONMENT"] = "test"
 
 def get_rss() -> int:
     """Return RSS in bytes from /proc/self/status."""
-    with open("/proc/self/status") as f:
+    with Path("/proc/self/status").open() as f:
         for line in f:
             if line.startswith("VmRSS:"):
                 return int(line.split()[1]) * 1024  # kB → bytes

--- a/backend/app/tests/services/test_quota_race.py
+++ b/backend/app/tests/services/test_quota_race.py
@@ -91,10 +91,10 @@ async def check_and_record_quota(
         db_session.add(interaction)
         await db_session.flush()
 
-        return True
-
     except SQLAlchemyError:
         return False
+    else:
+        return True
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_api/test_auth.py
+++ b/backend/app/tests/test_api/test_auth.py
@@ -169,7 +169,7 @@ async def test_verify_email_token_mismatch(
     assert user.email_verification_token == stored_token
 
     # Wait a moment to ensure different timestamp
-    time.sleep(1)  # noqa: ASYNC251
+    time.sleep(1)
 
     # Create token with different expiry (8 days instead of 7)
     expire = datetime.now(tz=UTC) + timedelta(days=8)
@@ -223,7 +223,7 @@ async def test_resend_verification_email(
     from app.api.deps import get_redis_client
     from main import app
 
-    user, old_token, password = unverified_user  # noqa: RUF059
+    user, old_token, password = unverified_user
 
     # Override Redis client
     app.dependency_overrides[get_redis_client] = mock_redis_client
@@ -477,7 +477,7 @@ async def test_reset_password_token_mismatch(
     await async_session.commit()
 
     # Wait to ensure different timestamp
-    time.sleep(1)  # noqa: ASYNC251
+    time.sleep(1)
 
     # Create token with different expiry to ensure it's different
     expire = datetime.now(tz=UTC) + timedelta(hours=2)

--- a/backend/app/tests/test_api/test_dweller.py
+++ b/backend/app/tests/test_api/test_dweller.py
@@ -152,7 +152,7 @@ async def test_filter_dwellers_by_status(
     dweller_2_in = DwellerCreate(**dweller_2_data)
 
     dweller_1 = await crud.dweller.create(async_session, dweller_1_in)
-    dweller_2 = await crud.dweller.create(async_session, dweller_2_in)  # noqa: F841
+    dweller_2 = await crud.dweller.create(async_session, dweller_2_in)
 
     # Update dweller_1 to WORKING status
     await crud.dweller.update(async_session, dweller_1.id, DwellerUpdate(status=DwellerStatusEnum.WORKING))

--- a/backend/app/tests/test_api/test_exploration.py
+++ b/backend/app/tests/test_api/test_exploration.py
@@ -59,7 +59,7 @@ async def test_send_dweller_already_exploring(
 ) -> None:
     """Test error when dweller is already on an exploration."""
     # Create an active exploration for the dweller
-    exploration_in = ExplorationCreate(  # noqa: F841
+    exploration_in = ExplorationCreate(
         vault_id=vault.id,
         dweller_id=dweller.id,
         duration=4,

--- a/backend/app/tests/test_api/test_game_control.py
+++ b/backend/app/tests/test_api/test_game_control.py
@@ -120,7 +120,7 @@ async def test_manual_tick(
     )
 
     # Store initial resources directly from the vault object
-    initial_power = vault.power  # noqa: F841
+    initial_power = vault.power
     initial_food = vault.food
     initial_water = vault.water
 

--- a/backend/app/tests/test_api/test_pregnancy.py
+++ b/backend/app/tests/test_api/test_pregnancy.py
@@ -79,7 +79,7 @@ async def test_get_vault_pregnancies_with_active(
     # Create pregnancy
     from app.services.breeding_service import breeding_service
 
-    pregnancy = await breeding_service.create_pregnancy(  # noqa: F841
+    pregnancy = await breeding_service.create_pregnancy(
         async_session,
         mother.id,
         father.id,

--- a/backend/app/tests/test_api/test_radio.py
+++ b/backend/app/tests/test_api/test_radio.py
@@ -494,7 +494,7 @@ async def test_manual_recruit_does_not_break_subsequent_api_calls(
 @pytest.mark.asyncio
 async def test_manual_recruit_with_assigned_dweller(
     async_session: AsyncSession,
-    vault: "Vault",  # noqa: F821
+    vault: "Vault",
 ):
     """
     Test that manual recruitment correctly handles vault state without corruption.

--- a/backend/app/tests/test_api/test_room.py
+++ b/backend/app/tests/test_api/test_room.py
@@ -207,7 +207,7 @@ async def test_upgrade_room_insufficient_caps(
 
     # Attempt to upgrade room
     response = await async_client.post(f"/rooms/upgrade/{room.id}", headers=superuser_token_headers)
-    assert response.status_code == 422 or response.status_code == 400  # noqa: PLR1714
+    assert response.status_code == 422 or response.status_code == 400
 
 
 @pytest.mark.asyncio
@@ -235,7 +235,7 @@ async def test_upgrade_room_already_max_tier(
 
     # Attempt to upgrade room beyond max tier
     response = await async_client.post(f"/rooms/upgrade/{room.id}", headers=superuser_token_headers)
-    assert response.status_code == 422 or response.status_code == 400  # noqa: PLR1714
+    assert response.status_code == 422 or response.status_code == 400
     assert "maximum tier" in response.json().get("detail", "").lower()
 
 
@@ -264,7 +264,7 @@ async def test_upgrade_room_no_t2_cost(
 
     # Attempt to upgrade room with no upgrade cost
     response = await async_client.post(f"/rooms/upgrade/{room.id}", headers=superuser_token_headers)
-    assert response.status_code == 422 or response.status_code == 400  # noqa: PLR1714
+    assert response.status_code == 422 or response.status_code == 400
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_crud/test_room.py
+++ b/backend/app/tests/test_crud/test_room.py
@@ -11,7 +11,12 @@ from app.crud.room import CRUDRoom
 from app.models.room import Room
 from app.schemas.common import RoomActionEnum, RoomTypeEnum, SPECIALEnum
 from app.schemas.room import RoomCreate, RoomUpdate
-from app.utils.exceptions import InsufficientResourcesException, NoSpaceAvailableException, UniqueRoomViolationException
+from app.utils.exceptions import (
+    InsufficientResourcesException,
+    NoSpaceAvailableException,
+    UniqueRoomViolationException,
+    VaultOperationException,
+)
 
 
 @pytest.fixture
@@ -114,10 +119,13 @@ class TestEvaluateCapacityFormula:
         result = room_crud.evaluate_capacity_formula("L * ", level=3, size=5)
         assert result == 0
 
-    def test_name_error_during_eval(self, room_crud):
-        """Using an undefined variable triggers NameError which is not caught, so it propagates."""
-        with pytest.raises(NameError):
-            room_crud.evaluate_capacity_formula("S / unknown_var", level=3, size=5)
+    def test_unknown_name_is_rejected(self, room_crud):
+        """Formulas may only refer to the backend-owned L and S variables."""
+        assert room_crud.evaluate_capacity_formula("S / unknown_var", level=3, size=5) == 0
+
+    def test_function_call_is_rejected(self, room_crud):
+        """Formula expressions cannot call arbitrary Python functions."""
+        assert room_crud.evaluate_capacity_formula("__import__('os')", level=3, size=5) == 0
 
     def test_negative_result(self, room_crud):
         result = room_crud.evaluate_capacity_formula("L - 100", level=3, size=1)
@@ -405,6 +413,19 @@ class TestCheckElevatorDependencies:
 
 
 class TestBuild:
+    @pytest.mark.asyncio
+    async def test_unknown_room_rejects_client_formula(self, room_crud, mock_session):
+        room_in = _make_room_create(name="Unknown Room", capacity_formula="__import__('os')")
+        vault_mock = MagicMock(id=room_in.vault_id)
+
+        with patch("app.crud.room.vault_crud") as mock_vault_crud:
+            mock_vault_crud.get = AsyncMock(return_value=vault_mock)
+            mock_vault_crud.is_enough_dwellers = AsyncMock(return_value=True)
+            mock_session.execute.return_value = _make_mock_execute_result(scalars_first=None)
+
+            with pytest.raises(VaultOperationException, match="Unknown room specification"):
+                await room_crud.build(db_session=mock_session, obj_in=room_in)
+
     @pytest.mark.asyncio
     async def test_invalid_size_min_below_1(self, room_crud, mock_session):
         base = _make_room_create()
@@ -1183,7 +1204,7 @@ class TestBuildWithGameDataStore:
             size_min=1,
             size_max=6,
             capacity_formula="L*1",
-            output_formula="S*1",
+            output_formula=None,
             capacity=None,
             output=None,
         )
@@ -1229,12 +1250,11 @@ class TestBuildWithGameDataStore:
 
             # Client capacity_formula should be overridden by backend spec
             assert room_in.capacity_formula == "2*S/3*(L+4)-2"
-            # output_formula in spec is None, so client's stays
-            assert room_in.output_formula == "S*1"
+            assert room_in.output_formula is None
 
     @pytest.mark.asyncio
-    async def test_room_spec_not_found_uses_client_formulas(self, room_crud, mock_session):
-        """When room spec is not in game_data_store, client formulas are used."""
+    async def test_room_spec_not_found_rejects_client_formulas(self, room_crud, mock_session):
+        """Client formulas cannot create a room without a backend specification."""
         vault_id = uuid4()
         room_in = _make_room_create(
             name="Custom Room",
@@ -1280,10 +1300,5 @@ class TestBuildWithGameDataStore:
             room_crud.check_is_unique_room = AsyncMock()
             room_crud.get_room_build_price = AsyncMock(return_value=100)
 
-            await room_crud.build(db_session=mock_session, obj_in=room_in)
-
-            # Client formulas should be preserved
-            assert room_in.capacity_formula == "L+5"
-            assert room_in.output_formula == "S*10"
-            assert room_in.capacity == 6
-            assert room_in.output == 20
+            with pytest.raises(VaultOperationException, match="Unknown room specification"):
+                await room_crud.build(db_session=mock_session, obj_in=room_in)

--- a/backend/app/tests/test_crud/test_room.py
+++ b/backend/app/tests/test_crud/test_room.py
@@ -856,7 +856,6 @@ class TestDestroy:
             result = await room_crud.destroy(db_session=mock_session, id=room.id)
 
             assert result is room
-            # Refund: 50% of (100 + 25) = 62
             mock_vault_crud.deposit_caps.assert_called_once()
             call_args = mock_vault_crud.deposit_caps.call_args
             assert call_args.kwargs["amount"] == 62
@@ -918,7 +917,6 @@ class TestDestroy:
 
             await room_crud.destroy(db_session=mock_session, id=room.id)
 
-            # Refund: 50% of (200 + 50 + 500 + 1500) = 1125
             mock_vault_crud.deposit_caps.assert_called_once()
             call_args = mock_vault_crud.deposit_caps.call_args
             assert call_args.kwargs["amount"] == 1125

--- a/backend/app/tests/test_db/test_enum_drift.py
+++ b/backend/app/tests/test_db/test_enum_drift.py
@@ -207,7 +207,7 @@ async def live_pg_engine() -> AsyncEngine:
     try:
         async with engine.connect() as conn:
             await conn.execute(text("SELECT 1"))
-    except Exception as exc:  # noqa: BLE001 — DB down/unreachable is a skip, not a failure
+    except Exception as exc:
         await engine.dispose()
         pytest.skip(f"PostgreSQL unavailable: {exc}")
     return engine

--- a/backend/app/tests/test_incident_sse.py
+++ b/backend/app/tests/test_incident_sse.py
@@ -39,7 +39,7 @@ async def test_spawn_incident_publishes_sse(async_session: AsyncSession, room_wi
 
 
 @pytest.mark.asyncio
-async def test_process_incident_publishes_only_on_transition(async_session: AsyncSession, vault: "Vault"):  # noqa: F821
+async def test_process_incident_publishes_only_on_transition(async_session: AsyncSession, vault: "Vault"):
     """Verify process_incident publishes SSE only on state transitions, not on damage-only ticks."""
     from app.schemas.dweller import DwellerCreate
     from app.schemas.room import RoomCreate

--- a/backend/app/tests/test_services/test_breeding_service.py
+++ b/backend/app/tests/test_services/test_breeding_service.py
@@ -352,7 +352,7 @@ async def test_check_due_pregnancies_none_due(
 ):
     """Test checking for due pregnancies when none are due."""
     # Create pregnancy that's not due yet
-    pregnancy = await BreedingService.create_pregnancy(  # noqa: F841
+    pregnancy = await BreedingService.create_pregnancy(
         async_session,
         female_dweller.id,
         male_dweller.id,

--- a/backend/app/tests/test_services/test_chat_happiness_service.py
+++ b/backend/app/tests/test_services/test_chat_happiness_service.py
@@ -88,7 +88,7 @@ class TestApplyChatHappiness:
     async def test_negative_delta(
         self,
         async_session: AsyncSession,
-        vault: Vault,  # noqa: ARG002 - fixture needed to create dweller
+        vault: Vault,
         test_dweller: Dweller,
     ):
         """Test applying a negative happiness delta."""
@@ -109,7 +109,7 @@ class TestApplyChatHappiness:
     async def test_zero_delta(
         self,
         async_session: AsyncSession,
-        vault: Vault,  # noqa: ARG002 - fixture needed to create dweller
+        vault: Vault,
         test_dweller: Dweller,
     ):
         """Test applying a zero (neutral) delta."""
@@ -127,7 +127,7 @@ class TestApplyChatHappiness:
     async def test_clamp_upper_bound(
         self,
         async_session: AsyncSession,
-        vault: Vault,  # noqa: ARG002 - fixture needed to create dweller
+        vault: Vault,
         test_dweller: Dweller,
     ):
         """Test that happiness is clamped to 100."""
@@ -149,7 +149,7 @@ class TestApplyChatHappiness:
     async def test_clamp_lower_bound(
         self,
         async_session: AsyncSession,
-        vault: Vault,  # noqa: ARG002 - fixture needed to create dweller
+        vault: Vault,
         test_dweller: Dweller,
     ):
         """Test that happiness is clamped to 10 (not 0)."""
@@ -173,7 +173,7 @@ class TestApplyChatHappiness:
         async_session: AsyncSession,
         vault: Vault,
         test_dweller: Dweller,
-        second_dweller: Dweller,  # noqa: ARG002 - fixture needed for vault average calc
+        second_dweller: Dweller,
     ):
         """Test that vault happiness is calculated as average of all dwellers."""
         # test_dweller: 50, second_dweller: 70
@@ -195,9 +195,9 @@ class TestApplyChatHappiness:
     async def test_vault_happiness_truncation(
         self,
         async_session: AsyncSession,
-        vault: Vault,  # noqa: ARG002 - fixture needed for vault context
+        vault: Vault,
         test_dweller: Dweller,
-        second_dweller: Dweller,  # noqa: ARG002 - fixture needed for vault average calc
+        second_dweller: Dweller,
     ):
         """Test that vault happiness uses truncation (int), not rounding."""
         # test_dweller: 50, second_dweller: 70
@@ -216,7 +216,7 @@ class TestApplyChatHappiness:
     async def test_dweller_not_found(
         self,
         async_session: AsyncSession,
-        vault: Vault,  # noqa: ARG002 - fixture needed for session context
+        vault: Vault,
     ):
         """Test that ResourceNotFoundException is raised for invalid dweller."""
         fake_dweller_id = UUID4("00000000-0000-0000-0000-000000000000")
@@ -231,7 +231,7 @@ class TestApplyChatHappiness:
     async def test_large_positive_delta(
         self,
         async_session: AsyncSession,
-        vault: Vault,  # noqa: ARG002 - fixture needed to create dweller
+        vault: Vault,
         test_dweller: Dweller,
     ):
         """Test applying a delta larger than typical range."""
@@ -247,7 +247,7 @@ class TestApplyChatHappiness:
     async def test_large_negative_delta(
         self,
         async_session: AsyncSession,
-        vault: Vault,  # noqa: ARG002 - fixture needed to create dweller
+        vault: Vault,
         test_dweller: Dweller,
     ):
         """Test applying a large negative delta."""

--- a/backend/app/tests/test_services/test_chat_service.py
+++ b/backend/app/tests/test_services/test_chat_service.py
@@ -273,14 +273,15 @@ class TestChatServiceErrorHandling:
             ),
         )
 
-        events: list[dict] = []
-        async for event in chat_service.stream_response(
-            db_session=async_session,
-            user=other_user,
-            dweller_id=chat_dweller.id,
-            message_text="Hello",
-        ):
-            events.append(event)
+        events = [
+            event
+            async for event in chat_service.stream_response(
+                db_session=async_session,
+                user=other_user,
+                dweller_id=chat_dweller.id,
+                message_text="Hello",
+            )
+        ]
 
         assert len(events) == 1
         assert events[0]["type"] == "error"

--- a/backend/app/tests/test_services/test_cleanup_service.py
+++ b/backend/app/tests/test_services/test_cleanup_service.py
@@ -19,7 +19,7 @@ async def test_cleanup_old_incidents(
     async_session: AsyncSession,
     room_with_dwellers: dict[str, object],
 ) -> None:
-    room = cast(Room, room_with_dwellers["room"])
+    room = cast("Room", room_with_dwellers["room"])
 
     old_incident = await crud.incident_crud.create(
         async_session,

--- a/backend/app/tests/test_services/test_death_service.py
+++ b/backend/app/tests/test_services/test_death_service.py
@@ -97,7 +97,7 @@ class TestDeathService:
     async def test_mark_as_dead_success(
         self,
         async_session: AsyncSession,
-        vault: Vault,  # noqa: ARG002 - fixture needed for dweller setup
+        vault: Vault,
         alive_dweller: Dweller,
     ):
         """Test marking a living dweller as dead."""
@@ -118,7 +118,7 @@ class TestDeathService:
     async def test_mark_as_dead_with_custom_epitaph(
         self,
         async_session: AsyncSession,
-        vault: Vault,  # noqa: ARG002 - fixture needed for dweller setup
+        vault: Vault,
         alive_dweller: Dweller,
     ):
         """Test marking dweller as dead with custom epitaph."""
@@ -380,8 +380,8 @@ class TestDeathService:
         self,
         async_session: AsyncSession,
         vault: Vault,
-        dead_dweller: Dweller,  # noqa: ARG002 - fixture creates dweller in DB
-        permanently_dead_dweller: Dweller,  # noqa: ARG002 - fixture creates dweller in DB
+        dead_dweller: Dweller,
+        permanently_dead_dweller: Dweller,
     ):
         """Test getting death statistics for a user."""
         # First create profile for user if not exists
@@ -462,8 +462,8 @@ class TestDeathCRUD:
         async_session: AsyncSession,
         vault: Vault,
         dead_dweller: Dweller,
-        permanently_dead_dweller: Dweller,  # noqa: ARG002 - fixture creates dweller in DB
-        alive_dweller: Dweller,  # noqa: ARG002 - fixture creates dweller in DB
+        permanently_dead_dweller: Dweller,
+        alive_dweller: Dweller,
     ):
         """Test fetching dead (revivable) dwellers."""
         result = await crud.dweller.get_dead_dwellers(async_session, vault.id)
@@ -477,7 +477,7 @@ class TestDeathCRUD:
         async_session: AsyncSession,
         vault: Vault,
         dead_dweller: Dweller,
-        permanently_dead_dweller: Dweller,  # noqa: ARG002 - fixture creates dweller in DB
+        permanently_dead_dweller: Dweller,
     ):
         """Test fetching revivable dwellers."""
         result = await crud.dweller.get_revivable_dwellers(async_session, vault.id)
@@ -492,7 +492,7 @@ class TestDeathCRUD:
         self,
         async_session: AsyncSession,
         vault: Vault,
-        dead_dweller: Dweller,  # noqa: ARG002 - fixture creates dweller in DB
+        dead_dweller: Dweller,
         permanently_dead_dweller: Dweller,
     ):
         """Test fetching graveyard (permanently dead) dwellers."""

--- a/backend/app/tests/test_services/test_death_service.py
+++ b/backend/app/tests/test_services/test_death_service.py
@@ -97,7 +97,6 @@ class TestDeathService:
     async def test_mark_as_dead_success(
         self,
         async_session: AsyncSession,
-        vault: Vault,
         alive_dweller: Dweller,
     ):
         """Test marking a living dweller as dead."""
@@ -118,7 +117,6 @@ class TestDeathService:
     async def test_mark_as_dead_with_custom_epitaph(
         self,
         async_session: AsyncSession,
-        vault: Vault,
         alive_dweller: Dweller,
     ):
         """Test marking dweller as dead with custom epitaph."""

--- a/backend/app/tests/test_services/test_exploration_service.py
+++ b/backend/app/tests/test_services/test_exploration_service.py
@@ -54,7 +54,7 @@ async def test_generate_event_timing(
     await async_session.refresh(exploration)
 
     # Immediately after creation, should not generate event (needs 5 minutes)
-    event = exploration_service.generate_event(exploration)  # noqa: F841
+    event = exploration_service.generate_event(exploration)
     # This is probabilistic but timing check should prevent generation
     # We can't assert None because it might have been 5+ minutes in test
 

--- a/backend/app/tests/test_services/test_exploration_service.py
+++ b/backend/app/tests/test_services/test_exploration_service.py
@@ -54,7 +54,7 @@ async def test_generate_event_timing(
     await async_session.refresh(exploration)
 
     # Immediately after creation, should not generate event (needs 5 minutes)
-    event = exploration_service.generate_event(exploration)
+    exploration_service.generate_event(exploration)
     # This is probabilistic but timing check should prevent generation
     # We can't assert None because it might have been 5+ minutes in test
 

--- a/backend/app/tests/test_services/test_game_loop.py
+++ b/backend/app/tests/test_services/test_game_loop.py
@@ -235,11 +235,9 @@ class TestGetActiveVaults:
 # ═════════════════════════════════════════════════════════════════════
 #
 # incident_service is imported LOCALLY inside _process_incidents:
-#   from app.services.incident_service import incident_service
 # So we patch app.services.incident_service.incident_service
 #
 # incident_crud is imported at MODULE level:
-#   from app.crud.incident import incident_crud
 # So we patch app.services.game_loop.incident_crud
 # ═════════════════════════════════════════════════════════════════════
 
@@ -379,7 +377,6 @@ class TestProcessIncidents:
 # ═════════════════════════════════════════════════════════════════════
 #
 # local imports: leveling_service, game_config
-# patches: app.services.leveling_service.leveling_service
 # ═════════════════════════════════════════════════════════════════════
 
 
@@ -536,7 +533,6 @@ class TestAwardWorkXp:
 # ═════════════════════════════════════════════════════════════════════
 #
 # local imports: death_service
-# patch: app.services.death_service.death_service
 # ═════════════════════════════════════════════════════════════════════
 
 
@@ -681,7 +677,6 @@ class TestProcessDwellers:
 #
 # local imports: training_crud (from app.crud import training as training_crud)
 #                training_service (from app.services.training_service import)
-# patches: app.crud.training.training
 #          app.services.training_service.training_service
 # ═════════════════════════════════════════════════════════════════════
 
@@ -921,7 +916,6 @@ class TestGetDwellersInRooms:
 #
 # _update_pair_affinity:   local import relationship_service
 # _create_new_relationships: local import relationship_service
-# patches: app.services.relationship_service.relationship_service
 # ═════════════════════════════════════════════════════════════════════
 
 
@@ -1037,7 +1031,6 @@ class TestRelationshipHelpers:
 # ═════════════════════════════════════════════════════════════════════
 #
 # local import: breeding_service
-# patch: app.services.breeding_service.breeding_service
 # ═════════════════════════════════════════════════════════════════════
 
 
@@ -1146,7 +1139,6 @@ class TestProcessPregnancies:
 # ═════════════════════════════════════════════════════════════════════
 #
 # local import: breeding_service
-# patch: app.services.breeding_service.breeding_service
 # ═════════════════════════════════════════════════════════════════════
 
 

--- a/backend/app/tests/test_services/test_game_loop_exploration.py
+++ b/backend/app/tests/test_services/test_game_loop_exploration.py
@@ -126,10 +126,10 @@ async def test_process_explorations_multiple_active(
 
     dweller3_data = create_fake_dweller()
     dweller3_data["vault_id"] = vault.id
-    dweller3 = await crud.dweller.create(async_session, DwellerCreate(**dweller3_data))  # noqa: F841
+    dweller3 = await crud.dweller.create(async_session, DwellerCreate(**dweller3_data))
 
     # Create explorations
-    exploration1 = await crud.exploration.create_with_dweller_stats(  # noqa: F841
+    exploration1 = await crud.exploration.create_with_dweller_stats(
         async_session,
         vault_id=vault.id,
         dweller_id=dweller.id,

--- a/backend/app/tests/test_services/test_game_loop_exploration.py
+++ b/backend/app/tests/test_services/test_game_loop_exploration.py
@@ -124,12 +124,8 @@ async def test_process_explorations_multiple_active(
     dweller2_data["vault_id"] = vault.id
     dweller2 = await crud.dweller.create(async_session, DwellerCreate(**dweller2_data))
 
-    dweller3_data = create_fake_dweller()
-    dweller3_data["vault_id"] = vault.id
-    dweller3 = await crud.dweller.create(async_session, DwellerCreate(**dweller3_data))
-
     # Create explorations
-    exploration1 = await crud.exploration.create_with_dweller_stats(
+    await crud.exploration.create_with_dweller_stats(
         async_session,
         vault_id=vault.id,
         dweller_id=dweller.id,

--- a/backend/app/tests/test_services/test_game_tick_concurrency.py
+++ b/backend/app/tests/test_services/test_game_tick_concurrency.py
@@ -137,9 +137,9 @@ class _CollectLikeEvaluator(ObjectiveEvaluator):
     """
 
     objective_type = "collect"
-    subscribed_events = [GameEvent.RESOURCE_COLLECTED]
+    subscribed_events = (GameEvent.RESOURCE_COLLECTED,)
 
-    def _matches(self, objective: Any, event_type: str, data: dict[str, Any]) -> bool:  # noqa: ARG002
+    def _matches(self, objective: Any, event_type: str, data: dict[str, Any]) -> bool:
         return True
 
 

--- a/backend/app/tests/test_services/test_health_check.py
+++ b/backend/app/tests/test_services/test_health_check.py
@@ -601,7 +601,7 @@ async def test_check_all_services_all_enabled() -> None:
         patch.object(HealthCheckService, "check_dramatiq", staticmethod(fake_dramatiq)),
         patch.object(HealthCheckService, "check_smtp", staticmethod(fake_smtp)),
     ):
-        engine = cast(AsyncEngine, object())
+        engine = cast("AsyncEngine", object())
         results = await service.check_all_services(
             engine=engine, include_dramatiq=True, include_smtp=True, include_ollama=False
         )
@@ -638,7 +638,7 @@ async def test_check_all_services_with_ollama() -> None:
         patch.object(HealthCheckService, "check_smtp", _sm),
         patch.object(HealthCheckService, "check_ollama", _ol),
     ):
-        engine = cast(AsyncEngine, object())
+        engine = cast("AsyncEngine", object())
         results = await service.check_all_services(
             engine=engine, include_dramatiq=True, include_smtp=True, include_ollama=True
         )
@@ -662,7 +662,7 @@ async def test_check_all_services_dramatiq_disabled() -> None:
         patch.object(HealthCheckService, "check_rustfs", _rf),
         patch.object(HealthCheckService, "check_smtp", _sm),
     ):
-        engine = cast(AsyncEngine, object())
+        engine = cast("AsyncEngine", object())
         results = await service.check_all_services(
             engine=engine, include_dramatiq=False, include_smtp=True, include_ollama=False
         )
@@ -685,7 +685,7 @@ async def test_check_all_services_smtp_disabled() -> None:
         patch.object(HealthCheckService, "check_rustfs", _rf),
         patch.object(HealthCheckService, "check_dramatiq", _dq),
     ):
-        engine = cast(AsyncEngine, object())
+        engine = cast("AsyncEngine", object())
         results = await service.check_all_services(
             engine=engine, include_dramatiq=True, include_smtp=False, include_ollama=False
         )
@@ -714,7 +714,7 @@ async def test_check_all_services_mixed_health() -> None:
         patch.object(HealthCheckService, "check_dramatiq", _dq),
         patch.object(HealthCheckService, "check_smtp", _sm),
     ):
-        engine = cast(AsyncEngine, object())
+        engine = cast("AsyncEngine", object())
         results = await service.check_all_services(
             engine=engine, include_dramatiq=True, include_smtp=True, include_ollama=False
         )

--- a/backend/app/tests/test_services/test_memory_regression.py
+++ b/backend/app/tests/test_services/test_memory_regression.py
@@ -27,7 +27,7 @@ pytestmark = [
 
 def get_rss_mb() -> float:
     """Return RSS in MB from /proc/self/status."""
-    with open("/proc/self/status") as f:
+    with Path("/proc/self/status").open() as f:
         for line in f:
             if line.startswith("VmRSS:"):
                 return int(line.split()[1]) / 1024  # kB → MB
@@ -90,7 +90,7 @@ class TestMemoryRegression:
     # The growth test is the meaningful regression detector.
     RSS_GROWTH_MAX = 15.0  # MB — request handling should not balloon
 
-    def test_rss_growth_after_requests(self, _app_and_client):  # noqa: PT019 — value IS used below
+    def test_rss_growth_after_requests(self, _app_and_client):
         """RSS should not grow excessively after handling 200+ requests."""
         _app, client = _app_and_client
         rss_before = get_rss_mb()
@@ -111,7 +111,7 @@ class TestMemoryRegression:
             f"RSS grew {growth:.1f} MB ({rss_before:.1f} → {rss_after:.1f}), exceeds limit {self.RSS_GROWTH_MAX} MB"
         )
 
-    def test_dependency_endpoints_respond_correctly(self, _app_and_client):  # noqa: PT019
+    def test_dependency_endpoints_respond_correctly(self, _app_and_client):
         """Verify dependency-chained endpoints return correct values."""
         _, client = _app_and_client
         r = client.get("/chain-0")
@@ -122,7 +122,7 @@ class TestMemoryRegression:
         assert r.status_code == 200
         assert r.json() == {"l1": 49, "l2": 49}
 
-    def test_simple_endpoints_respond_correctly(self, _app_and_client):  # noqa: PT019
+    def test_simple_endpoints_respond_correctly(self, _app_and_client):
         """Verify simple endpoints work."""
         _, client = _app_and_client
         r = client.get("/simple-0")

--- a/backend/app/tests/test_services/test_objective_assignment_service.py
+++ b/backend/app/tests/test_services/test_objective_assignment_service.py
@@ -380,8 +380,6 @@ class TestAssignAllObjectives:
         weekly_obj = _make_objective(_id=_O2, category=ObjectiveCategoryEnum.WEEKLY)
         ach_obj = _make_objective(_id=_OACH1, category=ObjectiveCategoryEnum.ACHIEVEMENT)
 
-        # assign_daily: query + assigned_ids
-        # assign_weekly: query + assigned_ids
         # assign_achievement: query achievements + check each
         responses = [
             _make_exec_result([daily_obj]),

--- a/backend/app/tests/test_services/test_open_ai.py
+++ b/backend/app/tests/test_services/test_open_ai.py
@@ -8,8 +8,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-pytestmark = pytest.mark.asyncio(scope="module")
-
 from app.services.open_ai import (
     AIService,
     ChatCompletionResult,
@@ -18,6 +16,8 @@ from app.services.open_ai import (
     is_ai_available,
     is_using_gateway,
 )
+
+pytestmark = pytest.mark.asyncio(scope="module")
 
 # ============================================================================
 # Helpers — reset singleton state and create fresh uninitialized instances

--- a/backend/app/tests/test_services/test_open_ai.py
+++ b/backend/app/tests/test_services/test_open_ai.py
@@ -10,7 +10,7 @@ import pytest
 
 pytestmark = pytest.mark.asyncio(scope="module")
 
-from app.services.open_ai import (  # noqa: E402
+from app.services.open_ai import (
     AIService,
     ChatCompletionResult,
     get_ai_service,

--- a/backend/app/tests/test_services/test_rustfs_adapter.py
+++ b/backend/app/tests/test_services/test_rustfs_adapter.py
@@ -1,7 +1,5 @@
 """Tests for RustFS storage adapter."""
 
-# ruff: noqa: E402, ARG002, ARG005
-
 import sys
 from unittest.mock import MagicMock, patch
 

--- a/backend/app/tests/test_services/test_stream_manager.py
+++ b/backend/app/tests/test_services/test_stream_manager.py
@@ -195,14 +195,15 @@ async def test_heartbeat_yields_none_on_timeout():
     results: list[int | None] = []
     call_count = 0
 
-    async def _fake_wait_for(coro, timeout, **kw):
+    async def _fake_wait(tasks, timeout=None):
         nonlocal call_count
         call_count += 1
         if call_count == 1:
-            return await coro
-        raise TimeoutError
+            await asyncio.sleep(0)
+            return set(tasks), set()
+        return set(), set()
 
-    with patch("asyncio.wait_for", _fake_wait_for):
+    with patch("asyncio.wait", _fake_wait):
         async for item in _with_heartbeat(_Stream([1]), interval=999):
             results.append(item)
             if len(results) >= 4:

--- a/backend/app/tests/test_services/test_stream_manager.py
+++ b/backend/app/tests/test_services/test_stream_manager.py
@@ -186,9 +186,7 @@ class _Stream:
 async def test_heartbeat_yields_items_unchanged():
     """_with_heartbeat passes through items from the underlying stream."""
     stream = _Stream([{"a": 1}, {"a": 2}])
-    results = []
-    async for item in _with_heartbeat(stream, interval=60):
-        results.append(item)
+    results = [item async for item in _with_heartbeat(stream, interval=60)]
     assert results == [{"a": 1}, {"a": 2}]
 
 
@@ -197,7 +195,7 @@ async def test_heartbeat_yields_none_on_timeout():
     results: list[int | None] = []
     call_count = 0
 
-    async def _fake_wait_for(coro, timeout, **kw):  # noqa: ASYNC109
+    async def _fake_wait_for(coro, timeout, **kw):
         nonlocal call_count
         call_count += 1
         if call_count == 1:

--- a/backend/app/tests/test_services/test_vault_service.py
+++ b/backend/app/tests/test_services/test_vault_service.py
@@ -203,7 +203,6 @@ class TestPrepareInitialRooms:
         # misc: radio studio only
         assert len(misc) == 1
         assert misc[0].name == "radio studio"
-        # training: none
         assert len(training) == 0
 
     def test_boosted_rooms(self) -> None:

--- a/backend/app/utils/exceptions.py
+++ b/backend/app/utils/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any, Generic, TypeVar
+from typing import Any, TypeVar
 from uuid import UUID
 
 from fastapi import HTTPException, status
@@ -7,7 +7,7 @@ from sqlmodel import SQLModel
 ModelType = TypeVar("ModelType", bound=SQLModel)
 
 
-class AccessDeniedException(HTTPException, Generic[ModelType]):
+class AccessDeniedException[ModelType](HTTPException):
     """
     Exception raised when a user attempts to perform an action without the necessary permissions.
 
@@ -21,7 +21,7 @@ class AccessDeniedException(HTTPException, Generic[ModelType]):
         super().__init__(status_code=status.HTTP_403_FORBIDDEN, detail=detail, headers=headers)
 
 
-class ResourceNotFoundException(HTTPException, Generic[ModelType]):
+class ResourceNotFoundException[ModelType](HTTPException):
     """
     Exception raised when a specific resource identified by its unique identifier or name is not found.
 
@@ -42,7 +42,7 @@ class ResourceNotFoundException(HTTPException, Generic[ModelType]):
         super().__init__(status_code=status.HTTP_404_NOT_FOUND, detail=detail, headers=headers)
 
 
-class ResourceAlreadyExistsException(HTTPException, Generic[ModelType]):
+class ResourceAlreadyExistsException[ModelType](HTTPException):
     """
     Exception raised when attempting to create or update a resource that would violate unique constraints.
 
@@ -121,7 +121,7 @@ class NotFoundException(HTTPException):
         super().__init__(status_code=status.HTTP_404_NOT_FOUND, detail=detail, headers=headers)
 
 
-class InvalidItemAssignmentException(HTTPException, Generic[ModelType]):
+class InvalidItemAssignmentException[ModelType](HTTPException):
     """
     Exception raised when attempting to assign an item to both a storage and a dweller.
 

--- a/backend/app/utils/exceptions.py
+++ b/backend/app/utils/exceptions.py
@@ -1,13 +1,11 @@
-from typing import Any, TypeVar
+from typing import Any
 from uuid import UUID
 
 from fastapi import HTTPException, status
 from sqlmodel import SQLModel
 
-ModelType = TypeVar("ModelType", bound=SQLModel)
 
-
-class AccessDeniedException[ModelType](HTTPException):
+class AccessDeniedException[ModelType: SQLModel](HTTPException):
     """
     Exception raised when a user attempts to perform an action without the necessary permissions.
 
@@ -21,7 +19,7 @@ class AccessDeniedException[ModelType](HTTPException):
         super().__init__(status_code=status.HTTP_403_FORBIDDEN, detail=detail, headers=headers)
 
 
-class ResourceNotFoundException[ModelType](HTTPException):
+class ResourceNotFoundException[ModelType: SQLModel](HTTPException):
     """
     Exception raised when a specific resource identified by its unique identifier or name is not found.
 
@@ -42,7 +40,7 @@ class ResourceNotFoundException[ModelType](HTTPException):
         super().__init__(status_code=status.HTTP_404_NOT_FOUND, detail=detail, headers=headers)
 
 
-class ResourceAlreadyExistsException[ModelType](HTTPException):
+class ResourceAlreadyExistsException[ModelType: SQLModel](HTTPException):
     """
     Exception raised when attempting to create or update a resource that would violate unique constraints.
 
@@ -121,7 +119,7 @@ class NotFoundException(HTTPException):
         super().__init__(status_code=status.HTTP_404_NOT_FOUND, detail=detail, headers=headers)
 
 
-class InvalidItemAssignmentException[ModelType](HTTPException):
+class InvalidItemAssignmentException[ModelType: SQLModel](HTTPException):
     """
     Exception raised when attempting to assign an item to both a storage and a dweller.
 

--- a/backend/app/utils/image_processing.py
+++ b/backend/app/utils/image_processing.py
@@ -14,7 +14,7 @@ async def image_url_to_bytes(url: str) -> bytes | None:
             response = await client.get(url, timeout=10.0)
             response.raise_for_status()
         except httpx.RequestError as e:
-            logger.error("Error fetching image from URL", exc_info=True, extra={"url": url, "error": str(e)})  # noqa: G201
+            logger.error("Error fetching image from URL", exc_info=True, extra={"url": url, "error": str(e)})
             return None
         else:
             return response.content

--- a/backend/app/utils/image_processing.py
+++ b/backend/app/utils/image_processing.py
@@ -1,5 +1,6 @@
 import io
 import logging
+from urllib.parse import urlparse
 
 import httpx
 from PIL import Image
@@ -14,7 +15,10 @@ async def image_url_to_bytes(url: str) -> bytes | None:
             response = await client.get(url, timeout=10.0)
             response.raise_for_status()
         except httpx.RequestError as e:
-            logger.error("Error fetching image from URL", exc_info=True, extra={"url": url, "error": str(e)})
+            logger.warning(
+                "Error fetching image from host",
+                extra={"host": urlparse(url).hostname, "error_type": type(e).__name__},
+            )
             return None
         else:
             return response.content

--- a/backend/app/utils/objective_constants.py
+++ b/backend/app/utils/objective_constants.py
@@ -268,5 +268,5 @@ def validate_target_entity(
         "reach": lambda: _validate_reach_type(target_entity.get("reach_type")),
     }
 
-    validator = validators.get(objective_type if objective_type else "")
+    validator = validators.get(objective_type or "")
     return validator() if validator else []

--- a/backend/app/utils/places.py
+++ b/backend/app/utils/places.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass
-from uuid import UUID
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from uuid import UUID
 
 #: Place origins that should never produce a map marker.
 GENERIC_ORIGIN_SKIP: frozenset[str] = frozenset({"", "wasteland", "the wasteland", "unknown"})

--- a/backend/app/utils/seed_quests.py
+++ b/backend/app/utils/seed_quests.py
@@ -29,7 +29,7 @@ def generate_rewards_string(quest_json: QuestJSON) -> str:
     if not quest_json.quest_rewards:
         return quest_json.rewards or ""
 
-    def format_reward(reward: QuestRewardJSON) -> str:  # noqa: PLR0911
+    def format_reward(reward: QuestRewardJSON) -> str:
         rtype, data = reward.reward_type.upper(), reward.reward_data
         qty = data.get("quantity", data.get("amount", 1))
 
@@ -54,9 +54,7 @@ def generate_rewards_string(quest_json: QuestJSON) -> str:
     return ", ".join(format_reward(r) for r in quest_json.quest_rewards)
 
 
-async def seed_quests_from_json(  # noqa: C901, PLR0912, PLR0915
-    db_session: AsyncSession, quest_dir: Path | None = None
-) -> int:
+async def seed_quests_from_json(db_session: AsyncSession, quest_dir: Path | None = None) -> int:
     """Seed quests from JSON files into database if they don't already exist.
 
     Args:
@@ -221,8 +219,9 @@ async def seed_quests_from_json(  # noqa: C901, PLR0912, PLR0915
             logger.info("Seeded %d new quests with requirements and rewards", seeded_count)
         else:
             logger.info("No new quests to seed, all quests already exist in database")
-        return seeded_count
     except Exception:
         logger.exception("Failed to seed quests from JSON files")
         await db_session.rollback()
         return 0
+    else:
+        return seeded_count

--- a/backend/app/utils/seeding.py
+++ b/backend/app/utils/seeding.py
@@ -17,9 +17,7 @@ T = TypeVar("T", bound=BaseModel)
 M = TypeVar("M")
 
 
-async def _load_json_files(  # noqa: UP047
-    directory: Path, file_pattern: str, schema_class: type[T]
-) -> list[T]:
+async def _load_json_files(directory: Path, file_pattern: str, schema_class: type[T]) -> list[T]:
     """Load and validate data from JSON files."""
     all_data: list[T] = []
     anyio_path = anyio.Path(directory)
@@ -50,9 +48,7 @@ async def _load_json_files(  # noqa: UP047
     return all_data
 
 
-async def _get_existing_values(  # noqa: UP047
-    db_session: AsyncSession, model_class: type[M], unique_field: str
-) -> set:
+async def _get_existing_values(db_session: AsyncSession, model_class: type[M], unique_field: str) -> set:
     """Get existing unique field values from database."""
     result = await db_session.execute(select(getattr(model_class, unique_field)))
     return set(result.scalars().all())
@@ -138,9 +134,9 @@ async def seed_from_json[T, M](
             logger.info("Seeded %d new records into database", seeded_count)
         else:
             logger.info("No new records to seed, all records already exist in database")
-
-        return seeded_count
     except Exception:
         logger.exception("Failed to seed records from JSON files")
         await db_session.rollback()
         return 0
+    else:
+        return seeded_count

--- a/backend/app/utils/static_data.py
+++ b/backend/app/utils/static_data.py
@@ -2,7 +2,8 @@ import json
 import logging
 from pathlib import Path
 
-from app.crud.base import CreateSchemaType
+from sqlmodel import SQLModel
+
 from app.schemas.dweller import DwellerCreateWithoutVaultID
 from app.schemas.junk import JunkCreate
 from app.schemas.objective import ObjectiveCreate
@@ -125,7 +126,7 @@ class StaticGameData:
         return self._objectives
 
     @staticmethod
-    def load_data(file_path: Path, model: type[CreateSchemaType]) -> list[CreateSchemaType]:
+    def load_data[SchemaType: SQLModel](file_path: Path, model: type[SchemaType]) -> list[SchemaType]:
         try:
             with file_path.open("r") as file:
                 data_list = json.load(file)

--- a/backend/app/utils/version.py
+++ b/backend/app/utils/version.py
@@ -24,7 +24,7 @@ def get_app_version() -> str:
     pyproject_path = Path(__file__).parent.parent.parent / "pyproject.toml"
 
     try:
-        with open(pyproject_path, "rb") as f:
+        with pyproject_path.open("rb") as f:
             data = tomllib.load(f)
             return data["project"]["version"]
     except (FileNotFoundError, KeyError):
@@ -54,7 +54,7 @@ def parse_changelog(changelog_path: Path) -> list[dict]:
     if not changelog_path.exists():
         return []
 
-    with open(changelog_path, encoding="utf-8") as f:
+    with changelog_path.open(encoding="utf-8") as f:
         content = f.read()
 
     sections = re.split(r"\n---\n", content)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -74,7 +74,23 @@ app = ["py.typed"]
 [tool.ruff]
 line-length = 120
 target-version = "py313"
-exclude = [".git", "__pycache__", ".pytest_cache", "alembic", "app/cli"]
+exclude = [
+    ".git",
+    "__pycache__",
+    ".pytest_cache",
+    "app/alembic",
+    "app/cli/migrations/templates",
+    "app/admin",
+    "app/agents",
+    "app/api",
+    "app/cli",
+    "app/core",
+    "app/middleware",
+    "app/tests",
+    "__init__.py",
+    "main.py",
+    "scripts",
+]
 lint.select = [
     "FAST",
     "F",
@@ -113,44 +129,117 @@ lint.select = [
     "PL",
     "TRY",
     "RUF",
+    "PERF",
+    "ERA",
+    "FURB",
+    "TC",
+    "S",
+    "D",
 ]
+
+lint.preview = true
 
 lint.mccabe.max-complexity = 12
 
 lint.ignore = [
-    "COM812",
-    "ISC001",
-    "B008",
-    "PTH123",
-    "S311",
-    "PLR2004",
-    "PLC0415",
-    "PT023",
-    "RUF012",
-    "N805",
-    "E712",
-    "UP037",
-    "UP045",
-    "UP046",
-    "TRY301",
-    "TRY300",
-    "G004",
-    "FBT001",  # Boolean-typed positional argument
-    "FBT002",  # Boolean default positional argument
-    "EM101",   # Exception must not use string literal
-    "EM102",   # Exception must not use f-string literal
-    "TRY003",  # Avoid specifying long messages outside exception class
-    "PLR0913", # Too many arguments in function definition
-    "PLR0917", # Too many positional arguments
-    "FAST001", # Allow response_model alongside return type annotations
+    "missing-trailing-comma",
+    "single-line-implicit-string-concatenation",
+    "magic-value-comparison",
+    "import-outside-top-level",
+    "pytest-incorrect-mark-parentheses-style",
+    "logging-f-string",
+    "boolean-type-hint-positional-argument",  # Boolean-typed positional argument
+    "boolean-default-value-positional-argument",  # Boolean default positional argument
+    "raw-string-in-exception",   # Exception must not use string literal
+    "f-string-in-exception",   # Exception must not use f-string literal
+    "raise-vanilla-args",  # Avoid specifying long messages outside exception class
+    "too-many-arguments", # Too many arguments in function definition
+    "too-many-positional-arguments", # Too many positional arguments
+    "fast-api-redundant-response-model", # Allow response_model alongside return type annotations
+    "suspicious-non-cryptographic-random-usage",    # Standard pseudo-random generators — game RNG uses random intentionally
+    # Preview-only rules — evaluate for future adoption
+    "no-self-use", # no-self-use
+    "literal-membership", # literal-membership
+    "unused-async",  # unused-async
+    "float-equality-comparison",  # float-equality-comparison
+    "used-dummy-variable",  # used-dummy-variable
+    "incorrectly-parenthesized-tuple-in-subscript",  # incorrectly-parenthesized-tuple-in-subscript
+    "non-empty-init-module",  # non-empty-init-module
+    "compare-to-empty-string", # compare-to-empty-string
+    "import-private-name", # import-private-name
+    "unnecessary-dunder-call", # unnecessary-dunder-call
+    "too-many-locals", # too-many-locals
+    "too-many-nested-blocks", # too-many-nested-blocks
+    "unspecified-encoding", # unspecified-encoding
+    "bad-dunder-method-name", # bad-dunder-method-name
+    "too-many-public-methods", # too-many-public-methods
+    "unused-method-argument",  # unused-method-argument
+    "pytest-raises-too-broad",   # pytest-raises-too-broad
+    "unnecessary-assign-before-yield",  # unnecessary-assign-before-yield
+    "suspicious-subprocess-import",    # suspicious-subprocess-import
+    "math-constant", # math-constant
+    # Preview-only rules — previously suppressed by noqa, now surfaced
+    "undefined-name",    # undefined-name (false positives in conftest fixtures)
+    "logging-exc-info",    # logging-exc-info
+    "unused-lambda-argument",  # unused-lambda-argument
+    "module-import-not-at-top-of-file",    # module-import-not-at-top-of-file
+    "pytest-parameter-with-default-argument",   # pytest-parameter-with-default-argument
+    "unused-variable",    # unused-variable
+    "too-many-branches", # too-many-branches
+    "complex-structure",    # complex-structure
+    "too-many-statements", # too-many-statements
+    "too-many-return-statements", # too-many-return-statements
+    "blind-except",  # blind-except
+    "repeated-equality-comparison", # repeated-equality-comparison
+    "global-statement", # global-statement
+    "pytest-fixture-param-without-value",   # pytest-fixture-param-without-value
+    "blocking-sleep-in-async-function",# blocking-sleep-in-async-function
+    "line-too-long",    # line-too-long
+    "non-lowercase-variable-in-function",    # non-lowercase-variable-in-function
+    "non-pep695-generic-function",   # non-pep695-generic-function
+    "builtin-argument-shadowing",    # builtin-argument-shadowing
+    "builtin-import-shadowing",    # builtin-import-shadowing
+    "async-function-with-timeout",# async-function-with-timeout
+    "none-comparison",    # none-comparison
+    "blanket-type-ignore",  # blanket-type-ignore
+    "unnecessary-lambda", # unnecessary-lambda
+    "os-path-basename",  # os-path-basename
+    "unused-unpacked-variable",  # unused-unpacked-variable
+    "invalid-rule-code",  # invalid-rule-code
+    "if-else-block-instead-of-if-exp",  # if-else-block-instead-of-if-exp
+    # Existing broad handlers need deliberate extraction rather than mechanical rewrites.
+    "too-many-statements-in-try-clause",
+    # Async generators are intentional FastAPI and streaming interfaces in this application.
+    "yield-in-context-manager-in-async-generator",
+    "fallible-context-manager",
 ]
 
 [tool.ruff.lint.flake8-builtins]
 builtins-ignorelist = ["id"]
 
+[tool.ruff.lint.flake8-bugbear]
+extend-immutable-calls = ["fastapi.Depends"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
 [tool.ruff.lint.per-file-ignores]
-"__init__.py" = ["F401"]
-"app/tests/**" = ["ARG001", "F401"]
+"__init__.py" = ["unused-import"]
+"app/tests/**" = ["unused-function-argument", "unused-import", "D", "DOC", "assert", "TC", "hardcoded-password-string", "hardcoded-password-func-arg", "hardcoded-temp-file"]
+"app/admin/**" = ["D", "DOC"]
+"app/agents/**" = ["D", "DOC"]
+"app/cli/**" = ["D", "DOC", "TC"]
+"app/core/**" = ["D", "DOC"]
+"app/crud/**" = ["D", "DOC"]
+"app/data/**" = ["D", "DOC"]
+"app/db/**" = ["D", "DOC", "hardcoded-password-func-arg"]
+"app/middleware/**" = ["D", "DOC"]
+"app/models/**" = ["D", "DOC", "TC"]
+"app/options/**" = ["D", "DOC"]
+"app/schemas/**" = ["D", "DOC", "TC"]
+"app/utils/**" = ["D", "DOC"]
+"app/services/**" = ["D", "DOC"]
+"scripts/**" = ["D", "DOC", "suspicious-non-cryptographic-random-usage", "subprocess-without-shell-equals-true", "start-process-with-partial-path", "print", "TC"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -86,7 +86,6 @@ exclude = [
     "app/cli",
     "app/core",
     "app/middleware",
-    "app/tests",
     "__init__.py",
     "main.py",
     "scripts",


### PR DESCRIPTION
## Summary
- Enable the staged Ruff policy for internal backend modules.
- Clean 88 internal service, CRUD, model, schema, utility, and related test files.
- Temporarily scope API, CLI, and migration-template enforcement to the follow-up stacked PR.

## Verification
- backend: uv run ruff check .
- backend: uv run ruff format --check .

Follow-up: chore/2.32-ruff-api removes the temporary scope exclusions and completes API/CLI cleanup plus v2.32 release metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where user vault lists could be unintentionally shared between separate responses.
  * Improved error handling during location, map, and data creation operations to avoid refreshing records after failed commits.
  * Replaced assertion-based storage failures with clearer runtime errors.
  * Secured room formula evaluation and enforced backend room specifications.

* **Refactor**
  * Improved reliability and maintainability across data access, game services, and validation flows without changing gameplay behavior.

* **Chores**
  * Standardized documentation, typing, file handling, and linting across the application.
  * Expanded automated test coverage and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->