### PR TITLE
fix(exploration): preserve supplies and enforce completion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,6 +309,9 @@ When cutting a release branch or version bump:
 2. After backend API changes: regenerate frontend API types: `cd frontend && pnpm run types:generate`.
 3. Prefer small, test-backed changes; follow existing patterns (don't introduce new architectures).
 4. Commit messages: `feat:`, `fix:`, `chore:`; branch prefixes: `feat/`, `fix/`, `chore/`.
+5. Starting with v2.35, every update must have a negative net source-LOC change. When a feature needs new code, first
+   compact or remove existing code by applying DRY and extracting reusable common behavior; validate retained behavior
+   with relevant tests. Do not count generated files, lockfiles, or formatting-only changes toward the reduction.
 
 ## Frontend Simplification Heuristic
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ---
 
+## [2.34.1] - 2026-08-13
+
+### Fixed
+
+- **Exploration supplies** — preserve supplies funded by vault storage instead of deducting them from the explorer a
+  second time
+- **Exploration completion** — expeditions can only complete after their timer expires; early returns use recall
+
+### Changed
+
+- **Version alignment** — backend and frontend are both v2.34.1
+
+---
+
 ## [2.34.0] - 2026-08-13
 
 ### Added

--- a/backend/app/crud/exploration.py
+++ b/backend/app/crud/exploration.py
@@ -57,23 +57,17 @@ class CRUDExploration(CRUDBase[Exploration, ExplorationCreate, ExplorationUpdate
         )
         db_session.add(db_obj)
 
-        # Update dweller status to EXPLORING with safe non-negative values
+        # Supply deductions are handled by ExplorationService, which knows whether
+        # each item came from vault storage or the dweller's own inventory.
+        # This CRUD helper only records the departure status.
         from app.crud.dweller import dweller as dweller_crud
         from app.schemas.common import DwellerStatusEnum
         from app.schemas.dweller import DwellerUpdate
 
-        # Compute safe values to prevent negative inventory
-        safe_stimpack = max(0, dweller.stimpack - stimpaks)
-        safe_radaway = max(0, dweller.radaway - radaways)
-
         await dweller_crud.update(
             db_session,
             dweller_id,
-            DwellerUpdate(
-                status=DwellerStatusEnum.EXPLORING,
-                stimpack=safe_stimpack,
-                radaway=safe_radaway,
-            ),
+            DwellerUpdate(status=DwellerStatusEnum.EXPLORING),
         )
 
         await db_session.commit()

--- a/backend/app/services/exploration/coordinator.py
+++ b/backend/app/services/exploration/coordinator.py
@@ -297,6 +297,8 @@ class ExplorationCoordinator:
 
         if not exploration.is_active():
             raise ValueError(ERROR_NOT_ACTIVE)
+        if exploration.time_remaining_seconds() > 0:
+            raise ValueError("Exploration has not finished yet; recall the dweller to end it early")
 
         # Mark as completed
         await crud_exploration.complete_exploration(db_session, exploration_id=exploration_id)

--- a/backend/app/services/exploration_service.py
+++ b/backend/app/services/exploration_service.py
@@ -119,6 +119,8 @@ class ExplorationService:
 
         # Get total available (vault + dweller)
         dweller = await dweller_crud.get(db_session, dweller_id)
+        if dweller.vault_id != vault_id:
+            raise ValueError("Dweller does not belong to this vault")
         dweller_stimpaks = dweller.stimpack or 0
         dweller_radaways = dweller.radaway or 0
         total_stimpaks = vault_stimpaks + dweller_stimpaks

--- a/backend/app/tests/test_api/test_exploration.py
+++ b/backend/app/tests/test_api/test_exploration.py
@@ -1,5 +1,7 @@
 """Tests for exploration API endpoints."""
 
+from datetime import datetime, timedelta
+
 import pytest
 from httpx import AsyncClient
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -331,6 +333,10 @@ async def test_complete_exploration_success(
 
     # The CRUD methods already commit and refresh, so data should be persisted
 
+    exploration.start_time = datetime.utcnow() - timedelta(hours=exploration.duration)
+    async_session.add(exploration)
+    await async_session.commit()
+
     initial_caps = vault.bottle_caps
 
     response = await async_client.post(
@@ -356,6 +362,32 @@ async def test_complete_exploration_success(
     # Verify caps transferred to vault
     await async_session.refresh(vault)
     assert vault.bottle_caps == initial_caps + 100
+
+
+@pytest.mark.asyncio
+async def test_complete_exploration_before_duration_is_rejected(
+    async_client: AsyncClient,
+    superuser_token_headers: dict[str, str],
+    async_session: AsyncSession,
+    vault: Vault,
+    dweller: Dweller,
+) -> None:
+    """Only recall may end an active expedition before its duration elapses."""
+    exploration = await crud.exploration.create_with_dweller_stats(
+        async_session,
+        vault_id=vault.id,
+        dweller_id=dweller.id,
+        duration=4,
+    )
+
+    response = await async_client.post(
+        f"/explorations/{exploration.id}/complete",
+        json={},
+        headers=superuser_token_headers,
+    )
+
+    assert response.status_code == 400
+    assert "has not finished yet" in response.json()["detail"]
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_crud/test_exploration_status.py
+++ b/backend/app/tests/test_crud/test_exploration_status.py
@@ -1,5 +1,7 @@
 """Tests for dweller status changes during exploration lifecycle."""
 
+from datetime import datetime, timedelta
+
 import pytest
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -14,6 +16,13 @@ from app.tests.factory.dwellers import create_fake_dweller
 from app.tests.factory.rooms import create_fake_room
 from app.tests.factory.users import create_fake_user
 from app.tests.factory.vaults import create_fake_vault
+
+
+async def _finish_exploration(async_session: AsyncSession, exploration) -> None:
+    exploration.start_time = datetime.utcnow() - timedelta(hours=exploration.duration)
+    async_session.add(exploration)
+    await async_session.commit()
+    await async_session.refresh(exploration)
 
 
 @pytest.mark.asyncio
@@ -77,6 +86,7 @@ async def test_dweller_status_idle_on_exploration_complete_no_room(async_session
     assert dweller.status == DwellerStatusEnum.EXPLORING
 
     # Complete exploration
+    await _finish_exploration(async_session, exploration)
     await exploration_service.complete_exploration(async_session, exploration.id)
 
     # Refresh dweller and check status is now IDLE (no room assigned)
@@ -123,6 +133,7 @@ async def test_dweller_status_working_on_exploration_complete_with_room(async_se
     assert dweller.status == DwellerStatusEnum.EXPLORING
 
     # Complete exploration
+    await _finish_exploration(async_session, exploration)
     await exploration_service.complete_exploration(async_session, exploration.id)
 
     # Refresh dweller and check status is back to WORKING
@@ -169,6 +180,7 @@ async def test_dweller_status_training_on_exploration_complete_with_training_roo
     assert dweller.status == DwellerStatusEnum.EXPLORING
 
     # Complete exploration
+    await _finish_exploration(async_session, exploration)
     await exploration_service.complete_exploration(async_session, exploration.id)
 
     # Refresh dweller and check status is back to TRAINING

--- a/backend/app/tests/test_services/test_exploration_coordinator.py
+++ b/backend/app/tests/test_services/test_exploration_coordinator.py
@@ -299,8 +299,8 @@ async def test_complete_exploration_includes_overflow_items(
         duration=4,
     )
 
-    # Make exploration active and add loot
-    exploration.start_time = datetime.utcnow() - timedelta(hours=1)
+    # Complete only after the configured duration has elapsed.
+    exploration.start_time = datetime.utcnow() - timedelta(hours=exploration.duration)
     exploration.add_loot(item_name="Kept Item", quantity=1, rarity="Legendary", item_type="junk")
     exploration.add_loot(item_name="Dropped Item", quantity=1, rarity="Common", item_type="junk")
     async_session.add(exploration)

--- a/backend/app/tests/test_services/test_exploration_service.py
+++ b/backend/app/tests/test_services/test_exploration_service.py
@@ -9,6 +9,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app import crud
 from app.models.dweller import Dweller
 from app.models.exploration import ExplorationStatus
+from app.models.storage import Storage
 from app.models.vault import Vault
 from app.schemas.exploration_event import CombatEventSchema, ItemSchema, LootEventSchema, LootSchema
 from app.services.exploration.event_generator import event_generator
@@ -16,6 +17,51 @@ from app.services.exploration_service import exploration_service
 
 # Note: Detailed SPECIAL stat calculation tests removed for simplicity
 # These are tested implicitly through integration tests
+
+
+@pytest.mark.asyncio
+async def test_send_dweller_deducts_vault_supplies_only_once(
+    async_session: AsyncSession,
+    vault: Vault,
+    dweller: Dweller,
+) -> None:
+    """Supplies taken from storage must not also be removed from the dweller."""
+    dweller.stimpack = 2
+    dweller.radaway = 1
+    storage = Storage(vault_id=vault.id, stimpack=5, radaway=3)
+    async_session.add_all([dweller, storage])
+    await async_session.commit()
+
+    exploration = await exploration_service.send_dweller(
+        async_session,
+        vault.id,
+        dweller.id,
+        duration=4,
+        stimpaks=4,
+        radaways=2,
+    )
+
+    await async_session.refresh(dweller)
+    await async_session.refresh(storage)
+
+    assert exploration.stimpaks == 4
+    assert exploration.radaways == 2
+    assert storage.stimpack == 1
+    assert storage.radaway == 1
+    assert dweller.stimpack == 2
+    assert dweller.radaway == 1
+
+
+@pytest.mark.asyncio
+async def test_send_dweller_rejects_a_dweller_from_another_vault(
+    async_session: AsyncSession,
+    dweller: Dweller,
+) -> None:
+    """The requested vault cannot send a dweller it does not own."""
+    from uuid import uuid4
+
+    with pytest.raises(ValueError, match="does not belong to this vault"):
+        await exploration_service.send_dweller(async_session, uuid4(), dweller.id, duration=4)
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_services/test_exploration_service.py
+++ b/backend/app/tests/test_services/test_exploration_service.py
@@ -19,6 +19,13 @@ from app.services.exploration_service import exploration_service
 # These are tested implicitly through integration tests
 
 
+async def _finish_exploration(async_session: AsyncSession, exploration) -> None:
+    exploration.start_time = datetime.utcnow() - timedelta(hours=exploration.duration)
+    async_session.add(exploration)
+    await async_session.commit()
+    await async_session.refresh(exploration)
+
+
 @pytest.mark.asyncio
 async def test_send_dweller_deducts_vault_supplies_only_once(
     async_session: AsyncSession,
@@ -286,6 +293,7 @@ async def test_complete_exploration_transfers_caps(
     expected_xp += int(base_xp * (exploration.dweller_luck * 0.02))
 
     # Complete exploration — returns RewardsSchema (Pydantic model)
+    await _finish_exploration(async_session, exploration)
     rewards = await exploration_service.complete_exploration(async_session, exploration.id)
 
     # Verify rewards via attribute access (RewardsSchema is a Pydantic model)
@@ -321,6 +329,24 @@ async def test_complete_exploration_not_active_raises_error(
     await crud.exploration.complete_exploration(async_session, exploration_id=exploration.id)
 
     with pytest.raises(ValueError, match="not active"):
+        await exploration_service.complete_exploration(async_session, exploration.id)
+
+
+@pytest.mark.asyncio
+async def test_complete_exploration_before_duration_raises_error(
+    async_session: AsyncSession,
+    vault: Vault,
+    dweller: Dweller,
+) -> None:
+    """Full completion is unavailable until the expedition duration has elapsed."""
+    exploration = await crud.exploration.create_with_dweller_stats(
+        async_session,
+        vault_id=vault.id,
+        dweller_id=dweller.id,
+        duration=4,
+    )
+
+    with pytest.raises(ValueError, match="has not finished yet"):
         await exploration_service.complete_exploration(async_session, exploration.id)
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fallout-shelter-fast-api"
-version = "2.34.0"
+version = "2.34.1"
 authors = [{ name = "ElderEvil", email = "elder.evil.dev@proton.me" }, ]
 description = "Fallout Shelter FastAPI Game is a web-based simulation game where the player manages a vault full of dwellers, balancing their needs and resources to keep the vault thriving."
 requires-python = ">=3.12,<3.14"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -606,7 +606,7 @@ lua = [
 
 [[package]]
 name = "fallout-shelter-fast-api"
-version = "2.34.0"
+version = "2.34.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosmtplib" },

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -64,6 +64,11 @@ output and gameplay actions. Keep this as one backend/AI release instead of spli
 **Focus**: Make the SemVer Git tag the single release authority. Eliminate manual, separately committed backend and
 frontend version bumps, and make release eligibility deterministic from validated Conventional Commit metadata.
 
+**Engineering constraint (v2.35 onward):** Every update must reduce net source LOC. Features that require new code
+must first offset it by removing or compacting existing code, favoring DRY reusable extraction over duplication. The
+reduction excludes generated files, lockfiles, and formatting-only changes, and must retain behavior under relevant
+tests.
+
 **Planned:**
 
 - 🔄 **One automated release version**

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "2.34.0",
+  "version": "2.34.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- preserve supplies funded from vault storage when dispatching an explorer
- require a completed timer before expedition completion; use recall for early returns
- align backend/frontend version metadata at 2.34.1
- record the v2.35 net-source-LOC reduction guardrail in the roadmap and agent guidance

## Validation

- `uv run pytest app/tests/test_api/test_exploration.py app/tests/test_services/test_exploration_service.py app/tests/test_services/test_game_loop_exploration.py` (36 passed)