### PR TITLE
fix(dweller): restrict child and explorer activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ---
 
+## [2.34.2] - 2026-08-13
+
+### Fixed
+
+- **Dweller activity safety** — generated recruits are adults; children cannot fight incidents, explore the wasteland,
+  or join quest parties
+- **Explorer activity safety** — active explorers cannot be reassigned to rooms or quest parties until they return
+- **Quest party validation** — validate replacement parties before unassigning the current party, preventing invalid
+  child or explorer requests from changing existing assignments
+
+### Changed
+
+- **Version alignment** — backend and frontend are both v2.34.2
+
+---
+
 ## [2.34.1] - 2026-08-13
 
 ### Fixed

--- a/backend/app/crud/dweller.py
+++ b/backend/app/crud/dweller.py
@@ -251,6 +251,9 @@ class CRUDDweller(CRUDBase[Dweller, DwellerCreate, DwellerUpdate]):
         """Move dweller to a different room."""
         dweller_obj = await self.get(db_session, dweller_id)
 
+        if dweller_obj.status == DwellerStatusEnum.EXPLORING:
+            raise ResourceConflictException(detail="Dweller is exploring and cannot be assigned to a room")
+
         # Validate room transfer (can't move to same room)
         if dweller_obj.room_id == room_id:
             raise ResourceConflictException(detail="Dweller is already in the room")

--- a/backend/app/crud/quest_party.py
+++ b/backend/app/crud/quest_party.py
@@ -44,6 +44,8 @@ class CRUDQuestParty(CRUDBase[QuestParty, None, None]):
             dweller = await db_session.get(Dweller, dweller_id)
             if not dweller:
                 raise ValueError(f"Dweller {dweller_id} not found")
+            if dweller.is_deleted:
+                raise ValueError(f"Deleted dweller {dweller_id} cannot join a quest")
             if dweller.vault_id != vault_id:
                 raise ValueError(f"Dweller {dweller_id} does not belong to vault {vault_id}")
             if not dweller.is_adult or dweller.age_group != AgeGroupEnum.ADULT:

--- a/backend/app/crud/quest_party.py
+++ b/backend/app/crud/quest_party.py
@@ -9,6 +9,7 @@ from app.models.dweller import Dweller
 from app.models.quest import Quest
 from app.models.quest_party import QuestParty
 from app.models.vault import Vault
+from app.schemas.common import AgeGroupEnum, DwellerStatusEnum
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +36,22 @@ class CRUDQuestParty(CRUDBase[QuestParty, None, None]):
         )
         existing_result = await db_session.execute(existing_query)
         existing_party = existing_result.scalars().all()
+        existing_dweller_ids = {member.dweller_id for member in existing_party}
+
+        # Validate the full replacement party before clearing the current one,
+        # so an invalid request cannot silently unassign valid quest members.
+        for dweller_id in dweller_ids:
+            dweller = await db_session.get(Dweller, dweller_id)
+            if not dweller:
+                raise ValueError(f"Dweller {dweller_id} not found")
+            if dweller.vault_id != vault_id:
+                raise ValueError(f"Dweller {dweller_id} does not belong to vault {vault_id}")
+            if not dweller.is_adult or dweller.age_group != AgeGroupEnum.ADULT:
+                raise ValueError(f"Child dweller {dweller_id} cannot join a quest")
+            if dweller.status == DwellerStatusEnum.EXPLORING:
+                raise ValueError(f"Dweller {dweller_id} is exploring and cannot join a quest")
+            if dweller.status == DwellerStatusEnum.QUESTING and dweller_id not in existing_dweller_ids:
+                raise ValueError(f"Dweller {dweller_id} is already on a quest")
 
         for member in existing_party:
             dweller = await db_session.get(Dweller, member.dweller_id)
@@ -47,14 +64,7 @@ class CRUDQuestParty(CRUDBase[QuestParty, None, None]):
         party_members = []
         for i, dweller_id in enumerate(dweller_ids):
             dweller = await db_session.get(Dweller, dweller_id)
-            if not dweller:
-                raise ValueError(f"Dweller {dweller_id} not found")
-            if dweller.vault_id != vault_id:
-                raise ValueError(f"Dweller {dweller_id} does not belong to vault {vault_id}")
-            if dweller.status == "questing":
-                raise ValueError(f"Dweller {dweller_id} is already on a quest")
-
-            dweller.status = "questing"
+            dweller.status = DwellerStatusEnum.QUESTING
             db_session.add(dweller)
 
             party = QuestParty(
@@ -88,7 +98,10 @@ class CRUDQuestParty(CRUDBase[QuestParty, None, None]):
         query = (
             select(Dweller)
             .where(Dweller.vault_id == vault_id)
-            .where(Dweller.status != "questing")
+            .where(~Dweller.is_deleted)
+            .where(Dweller.is_adult)
+            .where(Dweller.age_group == AgeGroupEnum.ADULT)
+            .where(Dweller.status.notin_([DwellerStatusEnum.QUESTING, DwellerStatusEnum.EXPLORING]))
             .where(
                 Dweller.id.notin_(
                     select(QuestParty.dweller_id).where(

--- a/backend/app/services/exploration_service.py
+++ b/backend/app/services/exploration_service.py
@@ -12,6 +12,7 @@ from app.crud import exploration as crud_exploration
 from app.crud.dweller import dweller as dweller_crud
 from app.models import Storage
 from app.models.exploration import Exploration
+from app.schemas.common import AgeGroupEnum
 from app.schemas.exploration import ExplorationProgress
 from app.schemas.exploration_event import RewardsSchema
 from app.services.exploration.coordinator import exploration_coordinator
@@ -121,6 +122,8 @@ class ExplorationService:
         dweller = await dweller_crud.get(db_session, dweller_id)
         if dweller.vault_id != vault_id:
             raise ValueError("Dweller does not belong to this vault")
+        if not dweller.is_adult or dweller.age_group != AgeGroupEnum.ADULT:
+            raise ValueError("Children cannot be sent on exploration")
         dweller_stimpaks = dweller.stimpack or 0
         dweller_radaways = dweller.radaway or 0
         total_stimpaks = vault_stimpaks + dweller_stimpaks

--- a/backend/app/services/incident_service.py
+++ b/backend/app/services/incident_service.py
@@ -452,20 +452,17 @@ class IncidentService:
             if vault and caps_earned > 0:
                 await vault_crud.deposit_caps(db_session=db_session, vault_obj=vault, amount=caps_earned)
 
-            # Award XP to dwellers in the room
+            # Award XP only to the adult dwellers who could have fought.
             if incident.room_id:
-                from sqlalchemy.orm import selectinload
-                from sqlmodel import select
-
-                from app.models.room import Room
-
-                # Load room with dwellers relationship
-                query = select(Room).where(Room.id == incident.room_id).options(selectinload(Room.dwellers))
+                query = select(Dweller).where(
+                    Dweller.room_id == incident.room_id,
+                    Dweller.health > 0,
+                    Dweller.is_adult,
+                    Dweller.age_group == AgeGroupEnum.ADULT,
+                )
                 result = await db_session.execute(query)
-                room = result.scalar_one_or_none()
-
-                if room and room.dwellers:
-                    await self._award_combat_xp(db_session, incident, room.dwellers)
+                dwellers = list(result.scalars().all())
+                await self._award_combat_xp(db_session, incident, dwellers)
 
         incident.loot = loot
         incident.resolve(success=success)

--- a/backend/app/services/incident_service.py
+++ b/backend/app/services/incident_service.py
@@ -14,6 +14,7 @@ from app.models.dweller import Dweller
 from app.models.game_state import GameState
 from app.models.incident import Incident, IncidentStatus, IncidentType
 from app.models.room import Room
+from app.schemas.common import AgeGroupEnum
 from app.schemas.incident_sse import IncidentSseEvent
 from app.services.notification_service import notification_service
 from app.services.stream_manager import sse_manager
@@ -281,7 +282,12 @@ class IncidentService:
                 selectinload(Dweller.weapon),
                 selectinload(Dweller.outfit),
             )
-            .where((Dweller.room_id == incident.room_id) & (Dweller.health > 0))  # Only alive dwellers
+            .where(
+                (Dweller.room_id == incident.room_id)
+                & (Dweller.health > 0)
+                & Dweller.is_adult
+                & (Dweller.age_group == AgeGroupEnum.ADULT)
+            )
         )
         dwellers_result = await db_session.execute(dwellers_query)
         dwellers = list(dwellers_result.scalars().all())

--- a/backend/app/services/quest_service.py
+++ b/backend/app/services/quest_service.py
@@ -11,6 +11,7 @@ from app import crud
 from app.models.dweller import Dweller
 from app.models.quest import Quest
 from app.models.vault_quest import VaultQuestCompletionLink
+from app.schemas.common import AgeGroupEnum, DwellerStatusEnum
 
 logger = logging.getLogger(__name__)
 
@@ -143,7 +144,15 @@ class QuestService:
 
         await db_session.refresh(quest, ["quest_requirements"])
 
-        result = await db_session.execute(select(Dweller).where(Dweller.vault_id == vault_id, ~Dweller.is_deleted))
+        result = await db_session.execute(
+            select(Dweller).where(
+                Dweller.vault_id == vault_id,
+                ~Dweller.is_deleted,
+                Dweller.is_adult,
+                Dweller.age_group == AgeGroupEnum.ADULT,
+                Dweller.status.notin_([DwellerStatusEnum.QUESTING, DwellerStatusEnum.EXPLORING]),
+            )
+        )
         dwellers = result.scalars().all()
 
         vault_level_req_types = {"item", "room", "dweller_count", "quest_completed"}

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -200,7 +200,7 @@ def dweller_data_fixture():
 
     from faker import Faker
 
-    from app.schemas.common import GenderEnum, RarityEnum
+    from app.schemas.common import AgeGroupEnum, GenderEnum, RarityEnum
     from app.tests.utils.utils import get_gender_based_name, get_stats_by_rarity
 
     fake = Faker()
@@ -215,7 +215,8 @@ def dweller_data_fixture():
     return stats | {
         "first_name": get_gender_based_name(gender),
         "last_name": fake.last_name(),
-        "is_adult": random.choice([True, False]),
+        "is_adult": True,
+        "age_group": AgeGroupEnum.ADULT,
         "gender": gender,
         "rarity": rarity.value,
         "level": random.randint(1, 50),

--- a/backend/app/tests/test_api/conftest.py
+++ b/backend/app/tests/test_api/conftest.py
@@ -13,6 +13,7 @@ from app.models.room import Room
 from app.models.user import User
 from app.models.vault import Vault
 from app.schemas.common import (
+    AgeGroupEnum,
     GenderEnum,
     JunkTypeEnum,
     OutfitTypeEnum,
@@ -84,7 +85,8 @@ def dweller_data_fixture():
     return stats | {
         "first_name": get_gender_based_name(gender),
         "last_name": fake.last_name(),
-        "is_adult": random.choice([True, False]),
+        "is_adult": True,
+        "age_group": AgeGroupEnum.ADULT,
         "gender": gender,
         "rarity": rarity.value,
         "level": random.randint(1, 50),

--- a/backend/app/tests/test_api/test_exploration.py
+++ b/backend/app/tests/test_api/test_exploration.py
@@ -10,6 +10,7 @@ from app import crud
 from app.models.dweller import Dweller
 from app.models.exploration import ExplorationStatus
 from app.models.vault import Vault
+from app.schemas.common import AgeGroupEnum
 from app.schemas.exploration import ExplorationCreate
 
 
@@ -81,6 +82,30 @@ async def test_send_dweller_already_exploring(
     )
     assert response.status_code == 400
     assert "already on an exploration" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_send_child_dweller_to_wasteland_is_rejected(
+    async_client: AsyncClient,
+    superuser_token_headers: dict[str, str],
+    async_session: AsyncSession,
+    vault: Vault,
+    dweller: Dweller,
+) -> None:
+    """Children cannot start wasteland explorations."""
+    dweller.is_adult = False
+    dweller.age_group = AgeGroupEnum.CHILD
+    async_session.add(dweller)
+    await async_session.commit()
+
+    response = await async_client.post(
+        f"/explorations/send?vault_id={vault.id}",
+        json={"dweller_id": str(dweller.id), "duration": 4},
+        headers=superuser_token_headers,
+    )
+
+    assert response.status_code == 400
+    assert "Children cannot be sent on exploration" in response.json()["detail"]
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_crud/test_dweller.py
+++ b/backend/app/tests/test_crud/test_dweller.py
@@ -1,5 +1,5 @@
 import random
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -127,14 +127,14 @@ async def test_create_random_common_dweller_seed_deterministic(async_session: As
 @pytest.mark.asyncio
 async def test_create_random_common_dweller_age_fields_coherent(async_session: AsyncSession):
     """Procedurally generated dwellers are adult recruits with coherent age fields."""
-    from app.utils.dwellers import create_random_common_dweller
+    from app.utils.dwellers import _calendar_years_ago, create_random_common_dweller
 
     for _ in range(40):
         data = create_random_common_dweller()
         assert data["is_adult"] is True
         assert data["age_group"] == AgeGroupEnum.ADULT
         assert data["birth_date"] is not None
-        assert data["birth_date"] <= datetime.utcnow()
+        assert data["birth_date"] <= _calendar_years_ago(datetime.now(UTC).replace(tzinfo=None), 18)
         assert data["max_health"] == 100
         assert data["health"] == 100
 
@@ -149,12 +149,15 @@ async def test_create_random_common_dweller_persisted_age_coherent(async_session
     vault_in = VaultCreateWithUserID(**vault_data, user_id=user.id)
     vault = await crud.vault.create(async_session, obj_in=vault_in)
 
+    from app.utils.dwellers import _calendar_years_ago
+
+    adult_cutoff = _calendar_years_ago(datetime(2000, 1, 1), 18)
     for seed in range(10):
         dweller = await crud.dweller.create_random(db_session=async_session, vault_id=vault.id, seed=seed)
         assert dweller.is_adult is True
         assert dweller.age_group == AgeGroupEnum.ADULT
         assert dweller.birth_date is not None
-        assert dweller.birth_date <= datetime.utcnow()
+        assert dweller.birth_date <= adult_cutoff
         assert dweller.max_health == 100
         assert dweller.health == 100
 

--- a/backend/app/tests/test_crud/test_dweller.py
+++ b/backend/app/tests/test_crud/test_dweller.py
@@ -1,5 +1,5 @@
 import random
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -126,38 +126,17 @@ async def test_create_random_common_dweller_seed_deterministic(async_session: As
 
 @pytest.mark.asyncio
 async def test_create_random_common_dweller_age_fields_coherent(async_session: AsyncSession):
-    """Regression: random common dwellers must have coherent age fields.
-
-    Bug (Andrea Freeman, vault 444): ``create_random_common_dweller`` rolled
-    ``is_adult`` randomly but never set ``age_group`` (fell back to the ADULT
-    model default) or ``birth_date`` (stayed NULL), so a dweller could be
-    ``is_adult=false`` while ``age_group=ADULT`` with no birth date. It also
-    hardcoded ``max_health=50`` (the model default / child-level baseline)
-    instead of the 100 used by every other creation path.
-    """
+    """Procedurally generated dwellers are adult recruits with coherent age fields."""
     from app.utils.dwellers import create_random_common_dweller
 
-    adult_seen = False
-    child_seen = False
     for _ in range(40):
         data = create_random_common_dweller()
-        if data["is_adult"]:
-            adult_seen = True
-            assert data["age_group"] == AgeGroupEnum.ADULT
-            assert data["birth_date"] is not None
-            assert data["birth_date"] <= datetime.utcnow()
-        else:
-            child_seen = True
-            assert data["age_group"] == AgeGroupEnum.CHILD
-            assert data["birth_date"] is not None
-            # Child must be too young to be aged up on the next tick
-            growth_window = timedelta(hours=game_config.breeding.child_growth_duration_hours)
-            assert data["birth_date"] >= datetime.utcnow() - growth_window
+        assert data["is_adult"] is True
+        assert data["age_group"] == AgeGroupEnum.ADULT
+        assert data["birth_date"] is not None
+        assert data["birth_date"] <= datetime.utcnow()
         assert data["max_health"] == 100
         assert data["health"] == 100
-
-    assert adult_seen
-    assert child_seen
 
 
 @pytest.mark.asyncio
@@ -172,13 +151,10 @@ async def test_create_random_common_dweller_persisted_age_coherent(async_session
 
     for seed in range(10):
         dweller = await crud.dweller.create_random(db_session=async_session, vault_id=vault.id, seed=seed)
-        if dweller.is_adult:
-            assert dweller.age_group == AgeGroupEnum.ADULT
-            assert dweller.birth_date is not None
-            assert dweller.birth_date <= datetime.utcnow()
-        else:
-            assert dweller.age_group == AgeGroupEnum.CHILD
-            assert dweller.birth_date is not None
+        assert dweller.is_adult is True
+        assert dweller.age_group == AgeGroupEnum.ADULT
+        assert dweller.birth_date is not None
+        assert dweller.birth_date <= datetime.utcnow()
         assert dweller.max_health == 100
         assert dweller.health == 100
 

--- a/backend/app/tests/test_crud/test_exploration_status.py
+++ b/backend/app/tests/test_crud/test_exploration_status.py
@@ -16,6 +16,7 @@ from app.tests.factory.dwellers import create_fake_dweller
 from app.tests.factory.rooms import create_fake_room
 from app.tests.factory.users import create_fake_user
 from app.tests.factory.vaults import create_fake_vault
+from app.utils.exceptions import ResourceConflictException
 
 
 async def _finish_exploration(async_session: AsyncSession, exploration) -> None:
@@ -56,6 +57,33 @@ async def test_dweller_status_exploring_on_send(async_session: AsyncSession):
     await async_session.refresh(dweller)
     assert dweller.status == DwellerStatusEnum.EXPLORING
     assert exploration is not None
+
+
+@pytest.mark.asyncio
+async def test_exploring_dweller_cannot_be_assigned_to_room(async_session: AsyncSession):
+    """An active explorer must return before being assigned to a vault room."""
+    user = await crud.user.create(async_session, obj_in=UserCreate(**create_fake_user()))
+    vault = await crud.vault.create(
+        async_session,
+        obj_in=VaultCreateWithUserID(**create_fake_vault(), user_id=user.id),
+    )
+    dweller = await crud.dweller.create(
+        async_session,
+        obj_in=DwellerCreate(**create_fake_dweller(), vault_id=str(vault.id)),
+    )
+    room_data = create_fake_room()
+    room_data["category"] = RoomTypeEnum.PRODUCTION
+    room = await crud.room.create(async_session, obj_in=RoomCreate(**room_data, vault_id=vault.id))
+
+    await crud.exploration.create_with_dweller_stats(
+        async_session,
+        vault_id=vault.id,
+        dweller_id=dweller.id,
+        duration=4,
+    )
+
+    with pytest.raises(ResourceConflictException, match="exploring"):
+        await crud.dweller.move_to_room(async_session, dweller.id, room.id)
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_crud/test_quest.py
+++ b/backend/app/tests/test_crud/test_quest.py
@@ -4,6 +4,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import crud
+from app.schemas.common import AgeGroupEnum, DwellerStatusEnum
 from app.schemas.quest import QuestCreate, QuestUpdate
 from app.schemas.user import UserCreate
 from app.schemas.vault import VaultCreateWithUserID
@@ -309,10 +310,12 @@ async def test_assign_party_to_quest(async_session: AsyncSession) -> None:
     )
 
     dweller1_data = create_fake_dweller()
+    dweller1_data.update(is_adult=True, age_group=AgeGroupEnum.ADULT)
     dweller1 = Dweller(**dweller1_data, vault_id=vault.id)
     async_session.add(dweller1)
 
     dweller2_data = create_fake_dweller()
+    dweller2_data.update(is_adult=True, age_group=AgeGroupEnum.ADULT)
     dweller2 = Dweller(**dweller2_data, vault_id=vault.id)
     async_session.add(dweller2)
     await async_session.commit()
@@ -325,6 +328,48 @@ async def test_assign_party_to_quest(async_session: AsyncSession) -> None:
     assert party[0].status == "assigned"
     assert party[0].dweller_id == dweller1.id
     assert party[1].dweller_id == dweller2.id
+
+
+@pytest.mark.asyncio
+async def test_assign_party_rejects_children_and_explorers(async_session: AsyncSession) -> None:
+    """Quest parties cannot include children or dwellers currently exploring."""
+    from app.crud.quest_party import quest_party_crud
+    from app.models.dweller import Dweller
+    from app.tests.factory.dwellers import create_fake_dweller
+
+    user = await crud.user.create(async_session, obj_in=UserCreate(**create_fake_user()))
+    vault = await crud.vault.create(
+        async_session,
+        obj_in=VaultCreateWithUserID(**create_fake_vault(), user_id=user.id),
+    )
+    quest = await crud.quest_crud.create(
+        async_session,
+        obj_in=QuestCreate(
+            title="Restricted Party Quest",
+            short_description="Test restrictions",
+            long_description="Test restrictions",
+            requirements="1 dweller",
+            rewards="100 caps",
+        ),
+    )
+    child_data = create_fake_dweller()
+    child_data.update(is_adult=False, age_group=AgeGroupEnum.CHILD)
+    child = Dweller(**child_data, vault_id=vault.id)
+    explorer_data = create_fake_dweller()
+    explorer_data.update(
+        is_adult=True,
+        age_group=AgeGroupEnum.ADULT,
+        status=DwellerStatusEnum.EXPLORING,
+    )
+    explorer = Dweller(**explorer_data, vault_id=vault.id)
+    async_session.add(child)
+    async_session.add(explorer)
+    await async_session.commit()
+
+    with pytest.raises(ValueError, match="Child dweller"):
+        await quest_party_crud.assign_party(async_session, quest.id, vault.id, [child.id])
+    with pytest.raises(ValueError, match="exploring"):
+        await quest_party_crud.assign_party(async_session, quest.id, vault.id, [explorer.id])
 
 
 @pytest.mark.asyncio
@@ -473,14 +518,17 @@ async def test_assign_party_replaces_existing(async_session: AsyncSession) -> No
     )
 
     dweller1_data = create_fake_dweller()
+    dweller1_data.update(is_adult=True, age_group=AgeGroupEnum.ADULT)
     dweller1 = Dweller(**dweller1_data, vault_id=vault.id)
     async_session.add(dweller1)
 
     dweller2_data = create_fake_dweller()
+    dweller2_data.update(is_adult=True, age_group=AgeGroupEnum.ADULT)
     dweller2 = Dweller(**dweller2_data, vault_id=vault.id)
     async_session.add(dweller2)
 
     dweller3_data = create_fake_dweller()
+    dweller3_data.update(is_adult=True, age_group=AgeGroupEnum.ADULT)
     dweller3 = Dweller(**dweller3_data, vault_id=vault.id)
     async_session.add(dweller3)
     await async_session.commit()
@@ -522,6 +570,7 @@ async def test_get_party_for_quest_returns_dicts(async_session: AsyncSession) ->
     )
 
     dweller_data = create_fake_dweller()
+    dweller_data.update(is_adult=True, age_group=AgeGroupEnum.ADULT)
     dweller = Dweller(**dweller_data, vault_id=vault.id)
     async_session.add(dweller)
     await async_session.commit()

--- a/backend/app/tests/test_crud/test_quest.py
+++ b/backend/app/tests/test_crud/test_quest.py
@@ -331,8 +331,8 @@ async def test_assign_party_to_quest(async_session: AsyncSession) -> None:
 
 
 @pytest.mark.asyncio
-async def test_assign_party_rejects_children_and_explorers(async_session: AsyncSession) -> None:
-    """Quest parties cannot include children or dwellers currently exploring."""
+async def test_assign_party_rejects_ineligible_dwellers(async_session: AsyncSession) -> None:
+    """Quest parties reject children, explorers, and deleted dwellers without changing the current party."""
     from app.crud.quest_party import quest_party_crud
     from app.models.dweller import Dweller
     from app.tests.factory.dwellers import create_fake_dweller
@@ -362,14 +362,28 @@ async def test_assign_party_rejects_children_and_explorers(async_session: AsyncS
         status=DwellerStatusEnum.EXPLORING,
     )
     explorer = Dweller(**explorer_data, vault_id=vault.id)
+    assigned_data = create_fake_dweller()
+    assigned_data.update(is_adult=True, age_group=AgeGroupEnum.ADULT)
+    assigned = Dweller(**assigned_data, vault_id=vault.id)
+    deleted_data = create_fake_dweller()
+    deleted_data.update(is_adult=True, age_group=AgeGroupEnum.ADULT, is_deleted=True)
+    deleted = Dweller(**deleted_data, vault_id=vault.id)
     async_session.add(child)
     async_session.add(explorer)
+    async_session.add(assigned)
+    async_session.add(deleted)
     await async_session.commit()
 
+    await quest_party_crud.assign_party(async_session, quest.id, vault.id, [assigned.id])
     with pytest.raises(ValueError, match="Child dweller"):
         await quest_party_crud.assign_party(async_session, quest.id, vault.id, [child.id])
     with pytest.raises(ValueError, match="exploring"):
         await quest_party_crud.assign_party(async_session, quest.id, vault.id, [explorer.id])
+    with pytest.raises(ValueError, match="Deleted dweller"):
+        await quest_party_crud.assign_party(async_session, quest.id, vault.id, [deleted.id])
+
+    party = await quest_party_crud.get_party_for_quest(async_session, quest.id, vault.id)
+    assert [member.dweller_id for member in party] == [assigned.id]
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_services/test_incident_service.py
+++ b/backend/app/tests/test_services/test_incident_service.py
@@ -10,6 +10,8 @@ from app import crud
 from app.models.incident import IncidentStatus, IncidentType
 from app.models.room import Room
 from app.models.vault import Vault
+from app.schemas.common import AgeGroupEnum
+from app.schemas.dweller import DwellerCreate
 from app.services.incident_service import incident_service
 from app.tests.factory.rooms import create_fake_room
 
@@ -86,6 +88,33 @@ async def test_process_incident_combat(async_session: AsyncSession, room_with_dw
     # Verify incident was updated
     await async_session.refresh(incident)
     assert incident.damage_dealt >= 0
+
+
+@pytest.mark.asyncio
+async def test_process_incident_does_not_damage_child(
+    async_session: AsyncSession, room_with_dwellers: dict, dweller_data: dict
+):
+    """Children in an incident room do not join combat or receive combat damage."""
+    room = room_with_dwellers["room"]
+    child_data = {
+        **dweller_data,
+        "is_adult": False,
+        "age_group": AgeGroupEnum.CHILD,
+        "health": 100,
+        "max_health": 100,
+    }
+    child = await crud.dweller.create(
+        async_session,
+        obj_in=DwellerCreate(**child_data, vault_id=room.vault_id, room_id=room.id),
+    )
+    await async_session.commit()
+
+    incident = await incident_service.spawn_incident(async_session, room.vault_id, IncidentType.FIRE)
+    assert incident is not None
+    await incident_service.process_incident(async_session, incident, 60)
+
+    await async_session.refresh(child)
+    assert child.health == 100
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_services/test_incident_service.py
+++ b/backend/app/tests/test_services/test_incident_service.py
@@ -202,6 +202,31 @@ async def test_resolve_incident_manually_success(async_session: AsyncSession, ro
 
 
 @pytest.mark.asyncio
+async def test_resolve_incident_manually_does_not_award_child_combat_xp(
+    async_session: AsyncSession, room_with_dwellers: dict
+):
+    """Children present in the incident room do not receive manual-resolution combat XP."""
+    from app.tests.factory.dwellers import create_random_common_dweller
+
+    room = room_with_dwellers["room"]
+    child_data = create_random_common_dweller()
+    child_data.update(is_adult=False, age_group=AgeGroupEnum.CHILD, experience=0)
+    child = await crud.dweller.create(
+        async_session,
+        obj_in=DwellerCreate(**child_data, vault_id=room.vault_id),
+    )
+    await crud.dweller.move_to_room(async_session, child.id, room.id)
+    await async_session.commit()
+
+    incident = await incident_service.spawn_incident(async_session, room.vault_id, IncidentType.FIRE)
+    assert incident is not None
+    await incident_service.resolve_incident_manually(async_session, incident.id, success=True)
+
+    await async_session.refresh(child)
+    assert child.experience == 0
+
+
+@pytest.mark.asyncio
 async def test_resolve_incident_manually_failure(async_session: AsyncSession, room_with_dwellers: dict):
     """Test manual incident resolution with failure."""
     room = room_with_dwellers["room"]

--- a/backend/app/tests/test_utils/test_dwellers.py
+++ b/backend/app/tests/test_utils/test_dwellers.py
@@ -7,6 +7,7 @@ from app.core.game_config import game_config
 from app.schemas.common import AgeGroupEnum, RarityEnum
 from app.utils.dwellers import (
     _PLACE_POOL,
+    _calendar_years_ago,
     _procedural_bio_places,
     _render_template_bio,
     create_random_common_dweller,
@@ -89,4 +90,4 @@ def test_create_random_common_dweller_age_fields_coherent() -> None:
     data = create_random_common_dweller(seed=7)
     assert data["is_adult"] is True
     assert data["age_group"] == AgeGroupEnum.ADULT
-    assert data["birth_date"] < datetime(2000, 1, 1)
+    assert data["birth_date"] <= _calendar_years_ago(datetime(2000, 1, 1), 18)

--- a/backend/app/tests/test_utils/test_dwellers.py
+++ b/backend/app/tests/test_utils/test_dwellers.py
@@ -87,9 +87,6 @@ def test_create_random_common_dweller_rarity_scales_bio() -> None:
 def test_create_random_common_dweller_age_fields_coherent() -> None:
     """Seeded dweller keeps deterministic age fields (regression for the Andrea Freeman bug)."""
     data = create_random_common_dweller(seed=7)
-    if data["is_adult"]:
-        assert data["age_group"] == AgeGroupEnum.ADULT
-        assert data["birth_date"] < datetime(2000, 1, 1)
-    else:
-        assert data["age_group"] == AgeGroupEnum.CHILD
-        assert data["birth_date"] == datetime(2000, 1, 1)
+    assert data["is_adult"] is True
+    assert data["age_group"] == AgeGroupEnum.ADULT
+    assert data["birth_date"] < datetime(2000, 1, 1)

--- a/backend/app/utils/dwellers.py
+++ b/backend/app/utils/dwellers.py
@@ -83,10 +83,12 @@ def create_random_common_dweller(
 
     gender = gender or rng.choice(list(GenderEnum))
     stats = get_stats_by_rarity(rarity, rng)
-    age_group = rng.choice([AgeGroupEnum.ADULT, AgeGroupEnum.CHILD])
-    is_adult = age_group == AgeGroupEnum.ADULT
+    # Procedurally generated dwellers represent wasteland recruits. Children
+    # enter the vault only through the breeding lifecycle.
+    age_group = AgeGroupEnum.ADULT
+    is_adult = True
     now = datetime.now(UTC).replace(tzinfo=None) if seed is None else datetime(2000, 1, 1)
-    birth_date = now - timedelta(days=rng.randint(18 * 365, 80 * 365)) if is_adult else now
+    birth_date = now - timedelta(days=rng.randint(18 * 365, 80 * 365))
     origin, visited = _procedural_bio_places(rng, rarity)
     return {
         "first_name": get_gender_based_name(gender, faker),

--- a/backend/app/utils/dwellers.py
+++ b/backend/app/utils/dwellers.py
@@ -68,6 +68,14 @@ def get_stats_by_rarity(rarity: RarityEnum, rng: random.Random | None = None) ->
     return {stat_name: source.randint(stats_range[0], stats_range[1]) for stat_name in LETTER_TO_STAT.values()}
 
 
+def _calendar_years_ago(value: datetime, years: int) -> datetime:
+    """Return a calendar-year offset, handling leap-day birthdays."""
+    try:
+        return value.replace(year=value.year - years)
+    except ValueError:
+        return value.replace(year=value.year - years, month=2, day=28)
+
+
 def create_random_common_dweller(
     gender: GenderEnum | None = None, seed: int | None = None, rarity: RarityEnum = RarityEnum.COMMON
 ) -> dict[str, Any]:
@@ -88,7 +96,9 @@ def create_random_common_dweller(
     age_group = AgeGroupEnum.ADULT
     is_adult = True
     now = datetime.now(UTC).replace(tzinfo=None) if seed is None else datetime(2000, 1, 1)
-    birth_date = now - timedelta(days=rng.randint(18 * 365, 80 * 365))
+    oldest_birth_date = _calendar_years_ago(now, 80)
+    youngest_birth_date = _calendar_years_ago(now, 18)
+    birth_date = oldest_birth_date + timedelta(days=rng.randint(0, (youngest_birth_date - oldest_birth_date).days))
     origin, visited = _procedural_bio_places(rng, rarity)
     return {
         "first_name": get_gender_based_name(gender, faker),

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fallout-shelter-fast-api"
-version = "2.34.1"
+version = "2.34.2"
 authors = [{ name = "ElderEvil", email = "elder.evil.dev@proton.me" }, ]
 description = "Fallout Shelter FastAPI Game is a web-based simulation game where the player manages a vault full of dwellers, balancing their needs and resources to keep the vault thriving."
 requires-python = ">=3.12,<3.14"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -606,7 +606,7 @@ lua = [
 
 [[package]]
 name = "fallout-shelter-fast-api"
-version = "2.34.1"
+version = "2.34.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosmtplib" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "2.34.1",
+  "version": "2.34.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- generated recruits are adults; children cannot explore, fight incidents, or join quest parties
- block active explorers from room and quest assignment
- validate quest-party replacements before changing the existing party
- align backend/frontend version metadata at 2.34.2

## Validation

- `uv run ruff check app` (passed)
- focused dweller/exploration/quest/incident suite (79 passed)
- exploration lifecycle suite (36 passed)
- `uv run pytest app/tests/test_api/test_chat.py -q` (25 passed)

Stacked on #426.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented children and exploring dwellers from starting expeditions or joining quests.
  * Prevented exploring dwellers from being assigned to production rooms.
  * Restricted incident combat participation to living adults.
  * Improved quest party validation and availability filtering.

* **Chores**
  * Updated the application version to 2.34.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->