### PR TITLE
fix(quests): make Show All filter locked chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ---
 
+## [2.34.3] - 2026-08-13
+
+### Fixed
+
+- **Quest Show All filter** — vault quest responses now include prerequisite links, so the default list hides locked
+  chain quests and Show All reveals them
+
+### Changed
+
+- **Version alignment** — backend and frontend are both v2.34.3
+
+---
+
 ## [2.34.2] - 2026-08-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Fixed
 
-- **Quest Show All filter** — vault quest responses now include prerequisite links, so the default list hides locked
-  chain quests and Show All reveals them
+- **Quest chain visibility** — vault quest responses now derive prerequisite links from their requirements, hiding
+  locked chain quests by default while Show All reveals them; existing quest chains are backfilled by migration
 
 ### Changed
 

--- a/backend/app/alembic/versions/2026_08_13_2200-3f13e2c5a7d9_backfill_quest_chain_visibility.py
+++ b/backend/app/alembic/versions/2026_08_13_2200-3f13e2c5a7d9_backfill_quest_chain_visibility.py
@@ -1,0 +1,48 @@
+"""Backfill quest chain visibility.
+
+Revision ID: 3f13e2c5a7d9
+Revises: 2d31a1e4b5c6
+Create Date: 2026-08-13 22:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "3f13e2c5a7d9"
+down_revision: str | None = "2d31a1e4b5c6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Backfill chain predecessors used to calculate quest-chain visibility."""
+    op.execute(
+        """
+        WITH prerequisites AS (
+            SELECT DISTINCT ON (requirement.quest_id)
+                requirement.quest_id,
+                previous_quest.id AS previous_quest_id
+            FROM questrequirement AS requirement
+            CROSS JOIN LATERAL (
+                SELECT (requirement.requirement_data ->> 'quest_id')::uuid AS id
+                WHERE requirement.requirement_data ->> 'quest_id'
+                    ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+            ) AS prerequisite
+            JOIN quest AS previous_quest ON previous_quest.id = prerequisite.id
+            WHERE requirement.requirement_type = 'QUEST_COMPLETED'
+              AND requirement.is_mandatory
+            ORDER BY requirement.quest_id, requirement.id
+        )
+        UPDATE quest
+        SET previous_quest_id = prerequisites.previous_quest_id
+        FROM prerequisites
+        WHERE quest.id = prerequisites.quest_id
+          AND quest.previous_quest_id IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    """The chain-link data backfill intentionally remains after downgrade."""

--- a/backend/app/crud/quest.py
+++ b/backend/app/crud/quest.py
@@ -169,6 +169,8 @@ class CRUDQuest(
                     quest_category=quest.quest_category,
                     chain_id=quest.chain_id,
                     chain_order=quest.chain_order,
+                    previous_quest_id=quest.previous_quest_id,
+                    next_quest_id=quest.next_quest_id,
                     created_at=quest.created_at,
                     updated_at=quest.updated_at,
                     is_visible=link.is_visible if link else False,

--- a/backend/app/crud/quest.py
+++ b/backend/app/crud/quest.py
@@ -167,7 +167,12 @@ class CRUDQuest(
             link_result = await db_session.execute(link_stmt)
             links_by_quest = {link.quest_id: link for link in link_result.scalars().all()}
 
-        completed_quest_ids = {str(link.quest_id) for link in links_by_quest.values() if link.is_completed}
+        completed_link_stmt = select(self.link_model.quest_id).where(
+            self.link_model.vault_id == vault_id,
+            self.link_model.is_completed.is_(True),
+        )
+        completed_link_result = await db_session.execute(completed_link_stmt)
+        completed_quest_ids = {str(quest_id) for quest_id in completed_link_result.scalars().all()}
 
         result_items = []
         for quest in quests:

--- a/backend/app/crud/quest.py
+++ b/backend/app/crud/quest.py
@@ -12,7 +12,7 @@ from app.crud.mixins import CompletionMixin
 from app.crud.vault_mixin import VaultActionsMixin
 from app.models import Vault
 from app.models.quest import Quest
-from app.models.quest_requirement import QuestRequirement
+from app.models.quest_requirement import QuestRequirement, RequirementType
 from app.models.quest_reward import QuestReward
 from app.models.vault_quest import VaultQuestCompletionLink
 from app.schemas.quest import QuestCreate, QuestRead, QuestRequirementRead, QuestRewardRead, QuestUpdate
@@ -21,6 +21,22 @@ from app.services.reward_service import reward_service
 from app.utils.exceptions import ResourceNotFoundException
 
 logger = logging.getLogger(__name__)
+
+
+def _previous_quest_id(quest: Quest, requirements: list[QuestRequirement]) -> UUID4 | str | None:
+    """Return a quest's explicit or requirement-derived chain predecessor."""
+    if quest.previous_quest_id:
+        return quest.previous_quest_id
+    return next(
+        (
+            requirement.requirement_data.get("quest_id")
+            for requirement in requirements
+            if requirement.is_mandatory
+            and requirement.requirement_type == RequirementType.QUEST_COMPLETED
+            and requirement.requirement_data.get("quest_id")
+        ),
+        None,
+    )
 
 
 async def _batch_load_quest_details(
@@ -151,11 +167,15 @@ class CRUDQuest(
             link_result = await db_session.execute(link_stmt)
             links_by_quest = {link.quest_id: link for link in link_result.scalars().all()}
 
+        completed_quest_ids = {str(link.quest_id) for link in links_by_quest.values() if link.is_completed}
+
         result_items = []
         for quest in quests:
             link = links_by_quest.get(quest.id)
             reqs = reqs_by_quest.get(quest.id, [])
             rewards = rewards_by_quest.get(quest.id, [])
+            previous_quest_id = _previous_quest_id(quest, reqs)
+            is_unlocked = previous_quest_id is None or str(previous_quest_id) in completed_quest_ids
 
             result_items.append(
                 QuestRead(
@@ -169,11 +189,11 @@ class CRUDQuest(
                     quest_category=quest.quest_category,
                     chain_id=quest.chain_id,
                     chain_order=quest.chain_order,
-                    previous_quest_id=quest.previous_quest_id,
+                    previous_quest_id=previous_quest_id,
                     next_quest_id=quest.next_quest_id,
                     created_at=quest.created_at,
                     updated_at=quest.updated_at,
-                    is_visible=link.is_visible if link else False,
+                    is_visible=(link.is_visible if link else False) and is_unlocked,
                     is_completed=link.is_completed if link else False,
                     started_at=link.started_at if link else None,
                     duration_minutes=link.duration_minutes if link else quest.duration_minutes,

--- a/backend/app/schemas/quest.py
+++ b/backend/app/schemas/quest.py
@@ -29,6 +29,8 @@ class QuestRewardRead(SQLModel):
 
 class QuestRead(QuestBase):
     id: UUID4
+    previous_quest_id: UUID4 | None = None
+    next_quest_id: UUID4 | None = None
     is_visible: bool = True
     is_completed: bool = False
     started_at: datetime | None = None

--- a/backend/app/tests/test_crud/test_quest.py
+++ b/backend/app/tests/test_crud/test_quest.py
@@ -235,6 +235,15 @@ async def test_get_multi_for_vault(async_session: AsyncSession) -> None:
     assert "Quest 3" in quest_dict
     assert quest_dict["Quest 3"].is_visible is True
 
+    quest_page_indexes = {}
+    for page_index in range(3):
+        page = await crud.quest_crud.get_multi_for_vault(
+            db_session=async_session, skip=page_index, limit=1, vault_id=vault.id
+        )
+        assert len(page) == 1
+        quest_page_indexes[page[0].title] = page_index
+    assert quest_page_indexes["Quest 1"] != quest_page_indexes["Quest 2"]
+
     quest1_link = await async_session.get(crud.quest_crud.link_model, (vault.id, quest1.id))
     assert quest1_link is not None
     quest1_link.is_completed = True
@@ -244,6 +253,12 @@ async def test_get_multi_for_vault(async_session: AsyncSession) -> None:
         db_session=async_session, skip=0, limit=100, vault_id=vault.id
     )
     assert {quest.title: quest.is_visible for quest in unlocked_quests}["Quest 2"] is True
+
+    quest2_page = await crud.quest_crud.get_multi_for_vault(
+        db_session=async_session, skip=quest_page_indexes["Quest 2"], limit=1, vault_id=vault.id
+    )
+    assert quest2_page[0].title == "Quest 2"
+    assert quest2_page[0].is_visible is True
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_crud/test_quest.py
+++ b/backend/app/tests/test_crud/test_quest.py
@@ -191,6 +191,9 @@ async def test_get_multi_for_vault(async_session: AsyncSession) -> None:
         rewards="100 caps",
     )
     quest2 = await crud.quest_crud.create(async_session, obj_in=quest2_data)
+    quest2.previous_quest_id = quest1.id
+    async_session.add(quest2)
+    await async_session.commit()
 
     quest3_data = QuestCreate(
         title="Quest 3",
@@ -221,6 +224,7 @@ async def test_get_multi_for_vault(async_session: AsyncSession) -> None:
     assert quest_dict["Quest 1"].is_visible is True
     assert "Quest 2" in quest_dict
     assert quest_dict["Quest 2"].is_visible is False  # Not visible but still returned
+    assert quest_dict["Quest 2"].previous_quest_id == quest1.id
     assert "Quest 3" in quest_dict
     assert quest_dict["Quest 3"].is_visible is True
 

--- a/backend/app/tests/test_crud/test_quest.py
+++ b/backend/app/tests/test_crud/test_quest.py
@@ -163,7 +163,8 @@ async def test_assign_quest_twice_updates_visibility(async_session: AsyncSession
 
 @pytest.mark.asyncio
 async def test_get_multi_for_vault(async_session: AsyncSession) -> None:
-    """Test getting multiple quests for a vault (returns all with visibility status)."""
+    """Test vault quests reveal only chain starters until their requirement completes."""
+    from app.models.quest_requirement import QuestRequirement, RequirementType
     # Create user and vault
     user_data = create_fake_user()
     user_in = UserCreate(**user_data)
@@ -191,8 +192,13 @@ async def test_get_multi_for_vault(async_session: AsyncSession) -> None:
         rewards="100 caps",
     )
     quest2 = await crud.quest_crud.create(async_session, obj_in=quest2_data)
-    quest2.previous_quest_id = quest1.id
-    async_session.add(quest2)
+    async_session.add(
+        QuestRequirement(
+            quest_id=quest2.id,
+            requirement_type=RequirementType.QUEST_COMPLETED,
+            requirement_data={"quest_id": str(quest1.id)},
+        )
+    )
     await async_session.commit()
 
     quest3_data = QuestCreate(
@@ -204,18 +210,18 @@ async def test_get_multi_for_vault(async_session: AsyncSession) -> None:
     )
     quest3 = await crud.quest_crud.create(async_session, obj_in=quest3_data)
 
-    # Assign quests: quest1 visible, quest2 not visible, quest3 visible
+    # All links begin visible; the requirement keeps quest2 hidden until quest1 completes.
     await crud.quest_crud.assign_to_vault(
         db_session=async_session, quest_id=quest1.id, vault_id=vault.id, is_visible=True
     )
     await crud.quest_crud.assign_to_vault(
-        db_session=async_session, quest_id=quest2.id, vault_id=vault.id, is_visible=False
+        db_session=async_session, quest_id=quest2.id, vault_id=vault.id, is_visible=True
     )
     await crud.quest_crud.assign_to_vault(
         db_session=async_session, quest_id=quest3.id, vault_id=vault.id, is_visible=True
     )
 
-    # Get quests for vault (returns all assigned quests with their visibility status)
+    # Get quests for vault (returns all assigned quests with computed visibility status)
     quests = await crud.quest_crud.get_multi_for_vault(db_session=async_session, skip=0, limit=100, vault_id=vault.id)
 
     assert len(quests) == 3  # All three quests should be returned
@@ -223,10 +229,20 @@ async def test_get_multi_for_vault(async_session: AsyncSession) -> None:
     assert "Quest 1" in quest_dict
     assert quest_dict["Quest 1"].is_visible is True
     assert "Quest 2" in quest_dict
-    assert quest_dict["Quest 2"].is_visible is False  # Not visible but still returned
+    assert quest_dict["Quest 2"].is_visible is False  # Locked but still returned for Show All
     assert quest_dict["Quest 2"].previous_quest_id == quest1.id
     assert "Quest 3" in quest_dict
     assert quest_dict["Quest 3"].is_visible is True
+
+    quest1_link = await async_session.get(crud.quest_crud.link_model, (vault.id, quest1.id))
+    assert quest1_link is not None
+    quest1_link.is_completed = True
+    await async_session.commit()
+
+    unlocked_quests = await crud.quest_crud.get_multi_for_vault(
+        db_session=async_session, skip=0, limit=100, vault_id=vault.id
+    )
+    assert {quest.title: quest.is_visible for quest in unlocked_quests}["Quest 2"] is True
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_crud/test_quest.py
+++ b/backend/app/tests/test_crud/test_quest.py
@@ -165,6 +165,7 @@ async def test_assign_quest_twice_updates_visibility(async_session: AsyncSession
 async def test_get_multi_for_vault(async_session: AsyncSession) -> None:
     """Test vault quests reveal only chain starters until their requirement completes."""
     from app.models.quest_requirement import QuestRequirement, RequirementType
+
     # Create user and vault
     user_data = create_fake_user()
     user_in = UserCreate(**user_data)

--- a/backend/app/tests/test_utils/test_seed_quests.py
+++ b/backend/app/tests/test_utils/test_seed_quests.py
@@ -53,6 +53,46 @@ async def test_seed_quests_from_json_basic(async_session: AsyncSession, tmp_path
 
 
 @pytest.mark.asyncio
+async def test_seed_quests_records_completed_quest_predecessor(async_session: AsyncSession, tmp_path: Path) -> None:
+    """Seeded quest-completion requirements also populate the chain predecessor."""
+    quest_dir = tmp_path / "quests"
+    quest_dir.mkdir()
+    quest_data = {
+        "chain_name": "Test chain",
+        "quests": [
+            {
+                "quest_name": "Chain Starter",
+                "long_description": "The first quest in a test chain.",
+                "short_description": "Start the chain",
+                "requirements": "Level 1",
+                "rewards": "10 caps",
+            },
+            {
+                "quest_name": "Chain Follow-up",
+                "long_description": "The second quest in a test chain.",
+                "short_description": "Continue the chain",
+                "requirements": "Level 1",
+                "rewards": "20 caps",
+                "quest_requirements": [
+                    {
+                        "requirement_type": "QUEST_COMPLETED",
+                        "requirement_data": {"quest_name": "Chain Starter"},
+                    }
+                ],
+            },
+        ],
+    }
+    with (quest_dir / "chain.json").open("w", encoding="utf-8") as file:
+        json.dump(quest_data, file)
+
+    assert await seed_quests_from_json(async_session, quest_dir=quest_dir) == 2
+
+    quests = (await async_session.execute(select(Quest))).scalars().all()
+    quests_by_title = {quest.title: quest for quest in quests}
+    assert quests_by_title["Chain Follow-up"].previous_quest_id == quests_by_title["Chain Starter"].id
+
+
+@pytest.mark.asyncio
 async def test_seed_quests_with_list_requirements(async_session: AsyncSession, tmp_path: Path) -> None:
     """Test seeding quests with list-based requirements."""
     quest_dir = tmp_path / "quests"

--- a/backend/app/tests/test_utils/test_seed_quests.py
+++ b/backend/app/tests/test_utils/test_seed_quests.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from app.models.quest import Quest
+from app.models.quest_requirement import QuestRequirement
 from app.utils.seed_quests import seed_quests_from_json
 
 
@@ -90,6 +91,44 @@ async def test_seed_quests_records_completed_quest_predecessor(async_session: As
     quests = (await async_session.execute(select(Quest))).scalars().all()
     quests_by_title = {quest.title: quest for quest in quests}
     assert quests_by_title["Chain Follow-up"].previous_quest_id == quests_by_title["Chain Starter"].id
+
+
+@pytest.mark.asyncio
+async def test_seed_quests_skips_requirement_with_invalid_predecessor_id(
+    async_session: AsyncSession, tmp_path: Path
+) -> None:
+    """Malformed predecessor IDs do not leave pending requirements to commit."""
+    quest_dir = tmp_path / "quests"
+    quest_dir.mkdir()
+    quest_data = {
+        "quests": [
+            {
+                "quest_name": "Malformed Predecessor",
+                "long_description": "A quest with a malformed predecessor.",
+                "short_description": "Invalid predecessor",
+                "requirements": "Level 1",
+                "rewards": "10 caps",
+                "quest_requirements": [
+                    {
+                        "requirement_type": "QUEST_COMPLETED",
+                        "requirement_data": {"quest_id": "not-a-uuid"},
+                    }
+                ],
+            }
+        ]
+    }
+    with (quest_dir / "malformed.json").open("w", encoding="utf-8") as file:
+        json.dump(quest_data, file)
+
+    assert await seed_quests_from_json(async_session, quest_dir=quest_dir) == 1
+
+    quest = (await async_session.execute(select(Quest).where(Quest.title == "Malformed Predecessor"))).scalar_one()
+    requirements = (
+        (await async_session.execute(select(QuestRequirement).where(QuestRequirement.quest_id == quest.id)))
+        .scalars()
+        .all()
+    )
+    assert requirements == []
 
 
 @pytest.mark.asyncio

--- a/backend/app/utils/seed_quests.py
+++ b/backend/app/utils/seed_quests.py
@@ -173,6 +173,15 @@ async def seed_quests_from_json(db_session: AsyncSession, quest_dir: Path | None
                                     )
 
                     try:
+                        predecessor_id = None
+                        if (
+                            req_json.requirement_type.upper() == "QUEST_COMPLETED"
+                            and req_json.is_mandatory
+                            and quest.previous_quest_id is None
+                            and (previous_quest_id := requirement_data.get("quest_id"))
+                        ):
+                            predecessor_id = UUID(str(previous_quest_id))
+
                         requirement = QuestRequirement(
                             quest_id=quest.id,
                             requirement_type=RequirementType(req_json.requirement_type.lower()),
@@ -180,13 +189,8 @@ async def seed_quests_from_json(db_session: AsyncSession, quest_dir: Path | None
                             is_mandatory=req_json.is_mandatory,
                         )
                         db_session.add(requirement)
-                        if (
-                            req_json.requirement_type.upper() == "QUEST_COMPLETED"
-                            and req_json.is_mandatory
-                            and quest.previous_quest_id is None
-                            and (previous_quest_id := requirement_data.get("quest_id"))
-                        ):
-                            quest.previous_quest_id = UUID(str(previous_quest_id))
+                        if predecessor_id:
+                            quest.previous_quest_id = predecessor_id
                     except ValueError as e:
                         logger.warning(f"Failed to create requirement for quest '{quest.title}': {e}")
 

--- a/backend/app/utils/seed_quests.py
+++ b/backend/app/utils/seed_quests.py
@@ -2,6 +2,7 @@
 
 import logging
 from pathlib import Path
+from uuid import UUID
 
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -179,6 +180,13 @@ async def seed_quests_from_json(db_session: AsyncSession, quest_dir: Path | None
                             is_mandatory=req_json.is_mandatory,
                         )
                         db_session.add(requirement)
+                        if (
+                            req_json.requirement_type.upper() == "QUEST_COMPLETED"
+                            and req_json.is_mandatory
+                            and quest.previous_quest_id is None
+                            and (previous_quest_id := requirement_data.get("quest_id"))
+                        ):
+                            quest.previous_quest_id = UUID(str(previous_quest_id))
                     except ValueError as e:
                         logger.warning(f"Failed to create requirement for quest '{quest.title}': {e}")
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -75,6 +75,7 @@ app = ["py.typed"]
 line-length = 120
 target-version = "py313"
 exclude = [".git", "__pycache__", ".pytest_cache", "app/alembic", "app/cli/migrations/templates"]
+force-exclude = true
 lint.select = [
     "FAST",
     "F",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fallout-shelter-fast-api"
-version = "2.34.2"
+version = "2.34.3"
 authors = [{ name = "ElderEvil", email = "elder.evil.dev@proton.me" }, ]
 description = "Fallout Shelter FastAPI Game is a web-based simulation game where the player manages a vault full of dwellers, balancing their needs and resources to keep the vault thriving."
 requires-python = ">=3.12,<3.14"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -606,7 +606,7 @@ lua = [
 
 [[package]]
 name = "fallout-shelter-fast-api"
-version = "2.34.2"
+version = "2.34.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiosmtplib" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "2.34.2",
+  "version": "2.34.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/core/types/api.generated.ts
+++ b/frontend/src/core/types/api.generated.ts
@@ -6829,6 +6829,10 @@ export interface components {
              * Format: uuid4
              */
             id: string;
+            /** Previous Quest Id */
+            previous_quest_id?: string | null;
+            /** Next Quest Id */
+            next_quest_id?: string | null;
             /**
              * Is Visible
              * @default true

--- a/frontend/tests/unit/views/QuestsView.test.ts
+++ b/frontend/tests/unit/views/QuestsView.test.ts
@@ -243,6 +243,52 @@ describe('QuestsView', () => {
       expect(wrapper.text()).toContain('Available Quest')
     })
 
+    it('should reveal locked quests only when Show All is enabled', async () => {
+      questStore.vaultQuests = [
+        {
+          id: 'quest-1',
+          title: 'First Quest',
+          short_description: 'Start the chain',
+          long_description: 'Start the chain first',
+          requirements: 'None',
+          rewards: '50 caps',
+          created_at: '2025-01-01',
+          updated_at: '2025-01-01',
+          is_visible: true,
+          is_completed: false,
+          started_at: null,
+          duration_minutes: null,
+        },
+        {
+          id: 'quest-2',
+          title: 'Locked Quest',
+          short_description: 'Continue the chain',
+          long_description: 'Complete the first quest first',
+          requirements: 'Complete First Quest',
+          rewards: '100 caps',
+          previous_quest_id: 'quest-1',
+          created_at: '2025-01-01',
+          updated_at: '2025-01-01',
+          is_visible: true,
+          is_completed: false,
+          started_at: null,
+          duration_minutes: null,
+        },
+      ]
+
+      wrapper = mount(QuestsView, {
+        global: { stubs: { SidePanel: true, Icon: true } },
+      })
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.text()).toContain('First Quest')
+      expect(wrapper.text()).not.toContain('Locked Quest')
+
+      await wrapper.find('.toggle-input').setValue(true)
+
+      expect(wrapper.text()).toContain('Locked Quest')
+    })
+
     it('should display completed quests in completed tab', async () => {
       questStore.vaultQuests = [
         {


### PR DESCRIPTION
## Summary

- return quest chain links in vault-specific quest responses
- restore the existing Show All toggle: default view hides locked chain quests; Show All reveals them
- align backend and frontend at v2.34.3

## Validation

- `uv run ruff check app/crud/quest.py app/schemas/quest.py app/tests/test_crud/test_quest.py`
- `uv run pytest app/tests/test_crud/test_quest.py -q` (15 passed)
- `pnpm run test:run -- tests/unit/views/QuestsView.test.ts` (1,191 passed, 1 skipped)
- `pnpm run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quest chains now show prerequisite relationships and unlock follow-up quests after required quests are completed.
  * Added “Show All” behavior to reveal locked quests when enabled.
* **Bug Fixes**
  * Corrected quest visibility for locked and prerequisite-dependent quests.
  * Existing quest chains are automatically backfilled for consistent visibility.
* **Documentation**
  * Added release notes for version 2.34.3.
* **Chores**
  * Synchronized frontend and backend versions to 2.34.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->