### PR TITLE
fix(rewards): settle quest rewards atomically

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -121,7 +121,7 @@
       "@semantic-release/changelog",
       {
         "changelogFile": "CHANGELOG.md",
-        "changelogTitle": "# Changelog\n\nAll notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines."
+        "changelogTitle": "# Changelog\n\nAll notable changes to this project will be documented in this file.\nSee [Conventional Commits](https://conventionalcommits.org) for commit guidelines."
       }
     ],
     [
@@ -146,7 +146,7 @@
           "backend/uv.lock",
           "frontend/package.json"
         ],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\\n\\n${nextRelease.notes}"
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],
     [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
-All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 ## [2.35.0](https://github.com/ElderEvil/falloutProject/compare/v2.34.3...v2.35.0) (2026-08-14)
 
-# Changelog
+### Features
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+- **Release automation** — synchronize versions, tagged images, and integrity validation from Conventional Commits
 
 ---
 

--- a/backend/app/crud/dweller.py
+++ b/backend/app/crud/dweller.py
@@ -23,7 +23,7 @@ from app.schemas.dweller import (
 from app.services.event_bus import GameEvent, event_bus
 from app.utils.dwellers import create_random_common_dweller
 from app.utils.exceptions import ContentNoChangeException, InvalidVaultTransferException, ResourceConflictException
-from app.utils.reward_delivery import reward_delivery_is_deferred
+from app.utils.reward_delivery import persist_reward_change, reward_delivery_is_deferred
 
 
 def determine_status_for_room(room_category: RoomTypeEnum | None) -> DwellerStatusEnum:
@@ -209,8 +209,7 @@ class CRUDDweller(CRUDBase[Dweller, DwellerCreate, DwellerUpdate]):
             leveled_up = True
 
         if reward_delivery_is_deferred(db_session):
-            db_session.add(dweller_obj)
-            await db_session.flush()
+            await persist_reward_change(db_session, dweller_obj)
             updated_dweller = dweller_obj
         else:
             updated_dweller = await self.update(

--- a/backend/app/crud/dweller.py
+++ b/backend/app/crud/dweller.py
@@ -23,6 +23,7 @@ from app.schemas.dweller import (
 from app.services.event_bus import GameEvent, event_bus
 from app.utils.dwellers import create_random_common_dweller
 from app.utils.exceptions import ContentNoChangeException, InvalidVaultTransferException, ResourceConflictException
+from app.utils.reward_delivery import reward_delivery_is_deferred
 
 
 def determine_status_for_room(room_category: RoomTypeEnum | None) -> DwellerStatusEnum:
@@ -207,12 +208,19 @@ class CRUDDweller(CRUDBase[Dweller, DwellerCreate, DwellerUpdate]):
             dweller_obj.experience -= experience_required
             leveled_up = True
 
-        updated_dweller = await self.update(
-            db_session, dweller_obj.id, DwellerUpdate(level=dweller_obj.level, experience=dweller_obj.experience)
-        )
+        if reward_delivery_is_deferred(db_session):
+            db_session.add(dweller_obj)
+            await db_session.flush()
+            updated_dweller = dweller_obj
+        else:
+            updated_dweller = await self.update(
+                db_session,
+                dweller_obj.id,
+                DwellerUpdate(level=dweller_obj.level, experience=dweller_obj.experience),
+            )
 
         # Emit DWELLER_LEVEL_UP event for objective tracking
-        if leveled_up and updated_dweller.vault_id:
+        if leveled_up and updated_dweller.vault_id and not reward_delivery_is_deferred(db_session):
             await event_bus.emit(
                 GameEvent.DWELLER_LEVEL_UP,
                 updated_dweller.vault_id,

--- a/backend/app/crud/mixins.py
+++ b/backend/app/crud/mixins.py
@@ -4,7 +4,7 @@ from pydantic import UUID4
 from sqlmodel import SQLModel, and_, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.utils.exceptions import ResourceNotFoundException
+from app.utils.exceptions import ResourceConflictException, ResourceNotFoundException
 
 LinkModelType = TypeVar("LinkModelType", bound=SQLModel)
 ModelType = TypeVar("ModelType", bound=SQLModel)
@@ -22,6 +22,8 @@ class CompletionMixin[LinkModelType]:
 
         if not quest_completion_link:
             raise ResourceNotFoundException(self.link_model, identifier=quest_entity_id)
+        if quest_completion_link.is_completed:
+            raise ResourceConflictException("Already completed")
 
         return quest_completion_link
 
@@ -45,12 +47,38 @@ class CompletionMixin[LinkModelType]:
         msg = "Subclasses must implement this method"
         raise NotImplementedError(msg)
 
+    async def _after_completion_commit(
+        self,
+        *,
+        db_session: AsyncSession,
+        db_obj: LinkModelType,
+        vault_id: UUID4,
+        granted_rewards: list[dict[str, Any]],
+    ) -> None:
+        """Run completion side effects only after the completion is durable."""
+
     async def complete(
         self, *, db_session: AsyncSession, quest_entity_id: UUID4, vault_id: UUID4
     ) -> tuple[Any, list[dict[str, Any]]]:
-        db_obj = await self.get(db_session, quest_entity_id)
-        await self._mark_as_complete(db_session=db_session, vault_id=vault_id, quest_entity_id=quest_entity_id)
-        granted_rewards = await self._handle_completion_cascade(db_session=db_session, db_obj=db_obj, vault_id=vault_id)
-        await db_session.commit()
+        db_obj = None
+        try:
+            db_obj = await self.get(db_session, quest_entity_id)
+            await self._mark_as_complete(db_session=db_session, vault_id=vault_id, quest_entity_id=quest_entity_id)
+            granted_rewards = await self._handle_completion_cascade(
+                db_session=db_session, db_obj=db_obj, vault_id=vault_id
+            )
+            await db_session.commit()
+        except Exception:
+            await db_session.rollback()
+            if db_obj is not None:
+                await db_session.refresh(db_obj)
+            raise
+
+        await self._after_completion_commit(
+            db_session=db_session,
+            db_obj=db_obj,
+            vault_id=vault_id,
+            granted_rewards=granted_rewards,
+        )
 
         return db_obj, granted_rewards

--- a/backend/app/crud/mixins.py
+++ b/backend/app/crud/mixins.py
@@ -1,3 +1,4 @@
+from contextlib import suppress
 from typing import Any, TypeVar
 
 from pydantic import UUID4
@@ -71,7 +72,8 @@ class CompletionMixin[LinkModelType]:
         except Exception:
             await db_session.rollback()
             if db_obj is not None:
-                await db_session.refresh(db_obj)
+                with suppress(Exception):
+                    await db_session.refresh(db_obj)
             raise
 
         await self._after_completion_commit(

--- a/backend/app/crud/quest.py
+++ b/backend/app/crud/quest.py
@@ -11,6 +11,7 @@ from app.crud.base import CRUDBase
 from app.crud.mixins import CompletionMixin
 from app.crud.vault_mixin import VaultActionsMixin
 from app.models import Vault
+from app.models.dweller import Dweller
 from app.models.quest import Quest
 from app.models.quest_requirement import QuestRequirement, RequirementType
 from app.models.quest_reward import QuestReward
@@ -19,6 +20,7 @@ from app.schemas.quest import QuestCreate, QuestRead, QuestRequirementRead, Ques
 from app.services.notification_service import notification_service
 from app.services.reward_service import reward_service
 from app.utils.exceptions import ResourceNotFoundException
+from app.utils.reward_delivery import defer_reward_delivery
 
 logger = logging.getLogger(__name__)
 
@@ -244,35 +246,91 @@ class CRUDQuest(
     async def _handle_completion_cascade(
         self, db_session: AsyncSession, db_obj: Quest, vault_id: UUID4
     ) -> list[dict[str, Any]]:
-        """Grant rewards when a quest is completed."""
+        """Grant every quest reward within the completion transaction."""
+        async with defer_reward_delivery(db_session):
+            await db_session.refresh(db_obj, ["quest_rewards"])
+            granted_rewards = await reward_service.process_quest_rewards(db_session, vault_id, db_obj)
+
+        if granted_rewards:
+            reward_summary = ", ".join(
+                f"{reward.get('amount', reward.get('name', reward.get('dweller_id', '?')))}"
+                for reward in granted_rewards
+            )
+            logger.info(f"Granted rewards for quest '{db_obj.title}': {reward_summary}")
+
+        return granted_rewards
+
+    async def _after_completion_commit(
+        self,
+        *,
+        db_session: AsyncSession,
+        db_obj: Quest,
+        vault_id: UUID4,
+        granted_rewards: list[dict[str, Any]],
+    ) -> None:
+        """Publish reward and completion feedback after successful settlement."""
         from app.services.event_bus import GameEvent, event_bus
 
-        granted_rewards: list[dict[str, Any]] = []
-
-        # Grant rewards
-        try:
-            granted_rewards = await reward_service.process_quest_rewards(db_session, vault_id, db_obj)
-            if granted_rewards:
-                reward_summary = ", ".join(
-                    f"{r.get('amount', r.get('name', r.get('dweller_id', '?')))}" for r in granted_rewards
+        leveled_up_dwellers = []
+        for reward in granted_rewards:
+            if reward["reward_type"] == "caps":
+                await event_bus.emit(
+                    GameEvent.RESOURCE_COLLECTED,
+                    vault_id,
+                    {"resource_type": "caps", "amount": reward["amount"]},
                 )
-                logger.info(f"Granted rewards for quest '{db_obj.title}': {reward_summary}")
-        except Exception:
-            logger.exception(f"Failed to grant rewards for quest '{db_obj.title}'")
+            elif reward["reward_type"] == "item":
+                await event_bus.emit(
+                    GameEvent.ITEM_COLLECTED,
+                    vault_id,
+                    {"item_type": reward.get("item_type", "item"), "amount": 1},
+                )
+            elif reward["reward_type"] == "stimpak":
+                await event_bus.emit(
+                    GameEvent.ITEM_COLLECTED,
+                    vault_id,
+                    {"item_type": "stimpak", "amount": reward["amount"]},
+                )
+            elif reward["reward_type"] == "experience":
+                for dweller_id in reward["leveled_up"]:
+                    dweller = await db_session.get(Dweller, dweller_id)
+                    if dweller:
+                        leveled_up_dwellers.append(dweller)
+                        await event_bus.emit(
+                            GameEvent.DWELLER_LEVEL_UP,
+                            vault_id,
+                            {
+                                "dweller_id": str(dweller.id),
+                                "level": dweller.level,
+                                "old_level": dweller.level - 1,
+                                "amount": 1,
+                            },
+                        )
 
-        # Emit quest completed event (even if reward processing failed)
         await event_bus.emit(
             GameEvent.QUEST_COMPLETED,
             vault_id,
             {"quest_id": str(db_obj.id), "quest_title": db_obj.title},
         )
 
-        # Send notification
         try:
             vault = await db_session.get(Vault, vault_id)
             if vault and vault.user_id:
+                for dweller in leveled_up_dwellers:
+                    await notification_service.notify_level_up(
+                        db_session,
+                        user_id=vault.user_id,
+                        vault_id=vault_id,
+                        dweller_id=dweller.id,
+                        dweller_name=f"{dweller.first_name} {dweller.last_name or ''}".strip(),
+                        new_level=dweller.level,
+                        meta_data={"old_level": dweller.level - 1, "new_level": dweller.level},
+                    )
                 rewards_str = (
-                    ", ".join(f"{r.get('amount', r.get('name', r.get('type', '?')))}" for r in granted_rewards)
+                    ", ".join(
+                        f"{reward.get('amount', reward.get('name', reward.get('type', '?')))}"
+                        for reward in granted_rewards
+                    )
                     or "no rewards"
                 )
                 await notification_service.notify_quest_completed(
@@ -280,8 +338,6 @@ class CRUDQuest(
                 )
         except Exception:
             logger.exception(f"Failed to send quest completion notification for '{db_obj.title}'")
-
-        return granted_rewards
 
     async def assign_to_vault(
         self, db_session: AsyncSession, quest_id: UUID4, vault_id: UUID4, *, is_visible: bool = True

--- a/backend/app/crud/quest.py
+++ b/backend/app/crud/quest.py
@@ -2,6 +2,7 @@ import logging
 from collections import defaultdict
 from collections.abc import Sequence
 from typing import Any
+from uuid import UUID
 
 from pydantic import UUID4
 from sqlmodel import and_, select
@@ -292,7 +293,8 @@ class CRUDQuest(
                     {"item_type": "stimpak", "amount": reward["amount"]},
                 )
             elif reward["reward_type"] == "experience":
-                for dweller_id in reward["leveled_up"]:
+                for raw_dweller_id in reward["leveled_up"]:
+                    dweller_id = UUID(str(raw_dweller_id))
                     dweller = await db_session.get(Dweller, dweller_id)
                     if dweller:
                         leveled_up_dwellers.append(dweller)

--- a/backend/app/crud/vault.py
+++ b/backend/app/crud/vault.py
@@ -271,16 +271,20 @@ class CRUDVault(CRUDBase[Vault, VaultCreate, VaultUpdate]):
             return False
         return current_assigned_population + space_required <= population_max
 
-    async def deposit_caps(self, *, db_session: AsyncSession, vault_obj: Vault, amount: int, commit: bool = True):
+    async def deposit_caps(
+        self, *, db_session: AsyncSession, vault_obj: Vault, amount: int, commit: bool = True, emit_event: bool = True
+    ):
         """Deposit the specified amount to the vault's bottle caps as part of a revenue operation."""
         await self.update(
             db_session, id=vault_obj.id, obj_in=VaultUpdate(bottle_caps=vault_obj.bottle_caps + amount), commit=commit
         )
 
-        # Emit resource collected event for objective tracking
-        from app.services.event_bus import GameEvent, event_bus
+        if emit_event:
+            from app.services.event_bus import GameEvent, event_bus
 
-        await event_bus.emit(GameEvent.RESOURCE_COLLECTED, vault_obj.id, {"resource_type": "caps", "amount": amount})
+            await event_bus.emit(
+                GameEvent.RESOURCE_COLLECTED, vault_obj.id, {"resource_type": "caps", "amount": amount}
+            )
 
     async def withdraw_caps(self, *, db_session: AsyncSession, vault_obj: Vault, amount: int):
         """Withdraw the specified amount from the vault's bottle caps as part of a spending operation."""

--- a/backend/app/crud/vault.py
+++ b/backend/app/crud/vault.py
@@ -273,7 +273,7 @@ class CRUDVault(CRUDBase[Vault, VaultCreate, VaultUpdate]):
 
     async def deposit_caps(
         self, *, db_session: AsyncSession, vault_obj: Vault, amount: int, commit: bool = True, emit_event: bool = True
-    ):
+    ) -> None:
         """Deposit the specified amount to the vault's bottle caps as part of a revenue operation."""
         await self.update(
             db_session, id=vault_obj.id, obj_in=VaultUpdate(bottle_caps=vault_obj.bottle_caps + amount), commit=commit

--- a/backend/app/services/objective_evaluators.py
+++ b/backend/app/services/objective_evaluators.py
@@ -127,23 +127,20 @@ class ObjectiveEvaluator(abc.ABC):
         """Auto-complete objective and grant reward in single transaction."""
         from app.services.reward_service import reward_service
 
-        # Set completion flags
-        link.is_completed = True
         link.progress = objective.target_amount
 
-        # Emit event
-        await self._event_bus.emit(
-            GameEvent.OBJECTIVE_COMPLETED,
-            vault_id,
-            {"objective_id": str(objective.id), "challenge": objective.challenge},
-        )
-
-        # Grant reward - wrapped in try/except so completion isn't lost on reward failure
         try:
             await reward_service.process_objective_reward(db_session, vault_id, link)
-            logger.info(f"Objective '{objective.challenge}' auto-completed and reward granted for vault {vault_id}")
         except Exception:
             logger.exception(f"Failed to grant reward for objective '{objective.challenge}' in vault {vault_id}")
+        else:
+            link.is_completed = True
+            await self._event_bus.emit(
+                GameEvent.OBJECTIVE_COMPLETED,
+                vault_id,
+                {"objective_id": str(objective.id), "challenge": objective.challenge},
+            )
+            logger.info(f"Objective '{objective.challenge}' auto-completed and reward granted for vault {vault_id}")
 
         await db_session.commit()
 

--- a/backend/app/services/objective_evaluators.py
+++ b/backend/app/services/objective_evaluators.py
@@ -126,23 +126,26 @@ class ObjectiveEvaluator(abc.ABC):
     ) -> None:
         """Auto-complete objective and grant reward in single transaction."""
         from app.services.reward_service import reward_service
+        from app.utils.reward_delivery import defer_reward_delivery
 
         link.progress = objective.target_amount
 
         try:
-            await reward_service.process_objective_reward(db_session, vault_id, link)
+            async with defer_reward_delivery(db_session):
+                await reward_service.process_objective_reward(db_session, vault_id, link)
+                link.is_completed = True
+                await db_session.commit()
         except Exception:
+            await db_session.rollback()
             logger.exception(f"Failed to grant reward for objective '{objective.challenge}' in vault {vault_id}")
-        else:
-            link.is_completed = True
-            await self._event_bus.emit(
-                GameEvent.OBJECTIVE_COMPLETED,
-                vault_id,
-                {"objective_id": str(objective.id), "challenge": objective.challenge},
-            )
-            logger.info(f"Objective '{objective.challenge}' auto-completed and reward granted for vault {vault_id}")
+            return
 
-        await db_session.commit()
+        await self._event_bus.emit(
+            GameEvent.OBJECTIVE_COMPLETED,
+            vault_id,
+            {"objective_id": str(objective.id), "challenge": objective.challenge},
+        )
+        logger.info(f"Objective '{objective.challenge}' auto-completed and reward granted for vault {vault_id}")
 
 
 class CollectEvaluator(ObjectiveEvaluator):

--- a/backend/app/services/quest_service.py
+++ b/backend/app/services/quest_service.py
@@ -1,8 +1,9 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any
 
 from pydantic import UUID4
+from sqlalchemy import func
 from sqlalchemy.orm import selectinload
 from sqlmodel import and_, select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -20,6 +21,14 @@ class QuestService:
     async def check_and_complete_quests(self, db_session: AsyncSession) -> int:
         """Check for quests that have exceeded their duration and auto-complete them."""
         now = datetime.now()
+        duration_minutes = func.coalesce(VaultQuestCompletionLink.duration_minutes, 60)
+        if db_session.bind and db_session.bind.dialect.name == "sqlite":
+            expires_at = func.datetime(
+                VaultQuestCompletionLink.started_at,
+                func.printf("+%s minutes", duration_minutes),
+            )
+        else:
+            expires_at = VaultQuestCompletionLink.started_at + func.make_interval(0, 0, 0, 0, 0, duration_minutes)
 
         query = (
             select(VaultQuestCompletionLink)
@@ -27,14 +36,11 @@ class QuestService:
             .where(
                 ~VaultQuestCompletionLink.is_completed,
                 VaultQuestCompletionLink.started_at.isnot(None),
+                expires_at <= now,
             )
         )
         result = await db_session.execute(query)
-        links = [
-            (link.quest_id, link.vault_id)
-            for link in result.scalars().all()
-            if link.started_at and now >= link.started_at + timedelta(minutes=link.duration_minutes or 60)
-        ]
+        links = [(link.quest_id, link.vault_id) for link in result.scalars().all()]
 
         completed_count = 0
         for quest_id, vault_id in links:

--- a/backend/app/services/quest_service.py
+++ b/backend/app/services/quest_service.py
@@ -30,18 +30,21 @@ class QuestService:
             )
         )
         result = await db_session.execute(query)
-        links = result.scalars().all()
+        links = [
+            (link.quest_id, link.vault_id)
+            for link in result.scalars().all()
+            if link.started_at and now >= link.started_at + timedelta(minutes=link.duration_minutes or 60)
+        ]
 
         completed_count = 0
-        for link in links:
-            duration = link.duration_minutes or 60
-            if link.started_at and now >= link.started_at + timedelta(minutes=duration):
-                link.is_completed = True
+        for quest_id, vault_id in links:
+            try:
+                await self.complete_quest_and_free_party(db_session, quest_id, vault_id)
+            except Exception:
+                logger.exception(f"Failed to auto-complete quest {quest_id} for vault {vault_id}")
+            else:
                 completed_count += 1
-                logger.info(f"Auto-completed quest {link.quest_id} for vault {link.vault_id}")
-
-        if completed_count > 0:
-            await db_session.commit()
+                logger.info(f"Auto-completed quest {quest_id} for vault {vault_id}")
 
         return completed_count
 

--- a/backend/app/services/reward_service.py
+++ b/backend/app/services/reward_service.py
@@ -35,7 +35,9 @@ class RewardService:
             db_session.add(vault_obj)
             await db_session.flush()
         else:
-            await vault_crud.deposit_caps(db_session=db_session, vault_obj=vault_obj, amount=amount, emit_event=emit_event)
+            await vault_crud.deposit_caps(
+                db_session=db_session, vault_obj=vault_obj, amount=amount, emit_event=emit_event
+            )
 
         logger.info(f"Granted {amount} caps to vault {vault_id}")
         return {"reward_type": RewardType.CAPS, "amount": amount}

--- a/backend/app/services/reward_service.py
+++ b/backend/app/services/reward_service.py
@@ -15,8 +15,8 @@ from app.models.quest_reward import QuestReward, RewardType
 from app.models.storage import Storage
 from app.models.vault_objective import VaultObjectiveProgressLink
 from app.models.weapon import Weapon
-from app.schemas.vault import VaultUpdate
 from app.services.event_bus import GameEvent, event_bus
+from app.utils.reward_delivery import persist_reward_change, reward_delivery_is_deferred
 
 logger = logging.getLogger(__name__)
 
@@ -24,16 +24,25 @@ logger = logging.getLogger(__name__)
 class RewardService:
     """Service for processing and granting quest/objective rewards."""
 
-    async def grant_caps(self, db_session: AsyncSession, vault_id: UUID4, amount: int) -> dict[str, Any]:
+    async def grant_caps(
+        self, db_session: AsyncSession, vault_id: UUID4, amount: int, *, emit_event: bool = True
+    ) -> dict[str, Any]:
         from app.crud.vault import vault as vault_crud
 
         vault_obj = await vault_crud.get(db_session, id=vault_id)
-        await vault_crud.deposit_caps(db_session=db_session, vault_obj=vault_obj, amount=amount)
+        if reward_delivery_is_deferred(db_session):
+            vault_obj.bottle_caps += amount
+            db_session.add(vault_obj)
+            await db_session.flush()
+        else:
+            await vault_crud.deposit_caps(db_session=db_session, vault_obj=vault_obj, amount=amount, emit_event=emit_event)
 
         logger.info(f"Granted {amount} caps to vault {vault_id}")
         return {"reward_type": RewardType.CAPS, "amount": amount}
 
-    async def grant_item(self, db_session: AsyncSession, vault_id: UUID4, item_data: dict[str, Any]) -> dict[str, Any]:
+    async def grant_item(
+        self, db_session: AsyncSession, vault_id: UUID4, item_data: dict[str, Any], *, emit_event: bool = True
+    ) -> dict[str, Any]:
         from app.crud.storage import get_available_space
 
         result = await db_session.execute(select(Storage).where(Storage.vault_id == vault_id))
@@ -53,48 +62,37 @@ class RewardService:
         item_name = item_data.get("name", "Unknown Item")
         item_rarity = item_data.get("rarity", "common")
 
-        if item_type == "weapon":
-            weapon = Weapon(
-                name=item_name,
-                rarity=item_rarity,
-                weapon_type=item_data.get("weapon_type", "melee"),
-                weapon_subtype=item_data.get("weapon_subtype", "blunt"),
-                stat=item_data.get("stat", "strength"),
-                damage_min=item_data.get("damage_min", 1),
-                damage_max=item_data.get("damage_max", 3),
-                value=item_data.get("value"),
-                storage_id=storage_obj.id,
-            )
-            db_session.add(weapon)
-            await db_session.commit()
-            await db_session.refresh(weapon)
-            await event_bus.emit(GameEvent.ITEM_COLLECTED, vault_id, {"item_type": "weapon", "amount": 1})
-            logger.info(f"Granted weapon '{item_name}' ({item_rarity}) to vault {vault_id}")
-            return {"reward_type": RewardType.ITEM, "item_type": "weapon", "name": item_name, "item_id": str(weapon.id)}
+        match item_type:
+            case "weapon":
+                item = Weapon(
+                    name=item_name,
+                    rarity=item_rarity,
+                    weapon_type=item_data.get("weapon_type", "melee"),
+                    weapon_subtype=item_data.get("weapon_subtype", "blunt"),
+                    stat=item_data.get("stat", "strength"),
+                    damage_min=item_data.get("damage_min", 1),
+                    damage_max=item_data.get("damage_max", 3),
+                    value=item_data.get("value"),
+                    storage_id=storage_obj.id,
+                )
+            case "outfit":
+                item = Outfit(
+                    name=item_name,
+                    rarity=item_rarity,
+                    outfit_type=item_data.get("outfit_type", "suit"),
+                    gender=item_data.get("gender"),
+                    value=item_data.get("value"),
+                    storage_id=storage_obj.id,
+                )
+            case _:
+                msg = f"Unknown item_type: {item_type}"
+                raise ValueError(msg)
 
-        if item_type == "outfit":
-            outfit = Outfit(
-                name=item_name,
-                rarity=item_rarity,
-                outfit_type=item_data.get("outfit_type", "suit"),
-                gender=item_data.get("gender"),
-                value=item_data.get("value"),
-                storage_id=storage_obj.id,
-            )
-            db_session.add(outfit)
-            await db_session.commit()
-            await db_session.refresh(outfit)
-            await event_bus.emit(GameEvent.ITEM_COLLECTED, vault_id, {"item_type": "outfit", "amount": 1})
-            logger.info(f"Granted outfit '{item_name}' ({item_rarity}) to vault {vault_id}")
-            return {
-                "reward_type": RewardType.ITEM,
-                "item_type": "outfit",
-                "name": item_name,
-                "item_id": str(outfit.id),
-            }
-
-        msg = f"Unknown item_type: {item_type}"
-        raise ValueError(msg)
+        await persist_reward_change(db_session, item, refresh=True)
+        if emit_event and not reward_delivery_is_deferred(db_session):
+            await event_bus.emit(GameEvent.ITEM_COLLECTED, vault_id, {"item_type": item_type, "amount": 1})
+        logger.info(f"Granted {item_type} '{item_name}' ({item_rarity}) to vault {vault_id}")
+        return {"reward_type": RewardType.ITEM, "item_type": item_type, "name": item_name, "item_id": str(item.id)}
 
     async def grant_dweller(
         self, db_session: AsyncSession, vault_id: UUID4, dweller_template: dict[str, Any]
@@ -133,9 +131,7 @@ class RewardService:
             bio=dweller_template.get("bio"),
             vault_id=vault_id,
         )
-        db_session.add(new_dweller)
-        await db_session.commit()
-        await db_session.refresh(new_dweller)
+        await persist_reward_change(db_session, new_dweller, refresh=True)
 
         logger.info(f"Granted dweller '{first_name}' ({rarity}) to vault {vault_id}")
         return {
@@ -150,20 +146,28 @@ class RewardService:
         from app.crud.vault import vault as vault_crud
 
         vault_obj = await vault_crud.get(db_session, id=vault_id)
+        deferred = reward_delivery_is_deferred(db_session)
 
         match resource_type.lower():
             case "food":
                 new_value = min(vault_obj.food + amount, vault_obj.food_max)
-                await vault_crud.update(db_session, id=vault_id, obj_in=VaultUpdate(food=new_value))
+                field = "food"
             case "water":
                 new_value = min(vault_obj.water + amount, vault_obj.water_max)
-                await vault_crud.update(db_session, id=vault_id, obj_in=VaultUpdate(water=new_value))
+                field = "water"
             case "power":
                 new_value = min(vault_obj.power + amount, vault_obj.power_max)
-                await vault_crud.update(db_session, id=vault_id, obj_in=VaultUpdate(power=new_value))
+                field = "power"
             case _:
                 msg = f"Invalid resource_type: {resource_type}. Must be 'food', 'water', or 'power'"
                 raise ValueError(msg)
+
+        if deferred:
+            setattr(vault_obj, field, new_value)
+            db_session.add(vault_obj)
+            await db_session.flush()
+        else:
+            await vault_crud.update(db_session, id=vault_id, obj_in={field: new_value})
 
         logger.info(f"Granted {amount} {resource_type} to vault {vault_id}")
         return {"reward_type": RewardType.RESOURCE, "resource_type": resource_type, "amount": amount}
@@ -193,46 +197,43 @@ class RewardService:
             "leveled_up": leveled_up,
         }
 
-    async def grant_stimpak(self, db_session: AsyncSession, vault_id: UUID4, amount: int) -> dict[str, Any]:
+    async def grant_stimpak(
+        self, db_session: AsyncSession, vault_id: UUID4, amount: int, *, emit_event: bool = True
+    ) -> dict[str, Any]:
         """Grant stimpaks to random dweller in vault."""
-        from app.crud.dweller import dweller as dweller_crud
-
-        # Get dwellers in vault
-        dwellers = await dweller_crud.get_multi_by_vault(db_session, vault_id=vault_id, skip=0, limit=100)
-
-        if not dwellers:
-            logger.warning(f"No dwellers found in vault {vault_id} to grant stimpaks")
-            return {"reward_type": RewardType.STIMPAK, "amount": 0, "message": "No dwellers found"}
-
-        # Grant to random dweller
-        dweller = random.choice(dwellers)
-        dweller.stimpack = (dweller.stimpack or 0) + amount
-        db_session.add(dweller)
-        await db_session.commit()
-        await event_bus.emit(GameEvent.ITEM_COLLECTED, vault_id, {"item_type": "stimpak", "amount": amount})
-
-        logger.info(f"Granted {amount} stimpaks to dweller {dweller.first_name} in vault {vault_id}")
-        return {"reward_type": RewardType.STIMPAK, "amount": amount, "dweller_id": str(dweller.id)}
+        return await self._grant_medication(
+            db_session, vault_id, amount, RewardType.STIMPAK, "stimpack", emit_event=emit_event
+        )
 
     async def grant_radaway(self, db_session: AsyncSession, vault_id: UUID4, amount: int) -> dict[str, Any]:
         """Grant radaways to random dweller in vault."""
+        return await self._grant_medication(db_session, vault_id, amount, RewardType.RADAWAY, "radaway")
+
+    async def _grant_medication(
+        self,
+        db_session: AsyncSession,
+        vault_id: UUID4,
+        amount: int,
+        reward_type: RewardType,
+        stock_field: str,
+        *,
+        emit_event: bool = False,
+    ) -> dict[str, Any]:
         from app.crud.dweller import dweller as dweller_crud
 
-        # Get dwellers in vault
         dwellers = await dweller_crud.get_multi_by_vault(db_session, vault_id=vault_id, skip=0, limit=100)
-
         if not dwellers:
-            logger.warning(f"No dwellers found in vault {vault_id} to grant radaways")
-            return {"reward_type": RewardType.RADAWAY, "amount": 0, "message": "No dwellers found"}
+            logger.warning(f"No dwellers found in vault {vault_id} to grant {reward_type}s")
+            return {"reward_type": reward_type, "amount": 0, "message": "No dwellers found"}
 
-        # Grant to random dweller
         dweller = random.choice(dwellers)
-        dweller.radaway = (dweller.radaway or 0) + amount
-        db_session.add(dweller)
-        await db_session.commit()
+        setattr(dweller, stock_field, (getattr(dweller, stock_field) or 0) + amount)
+        await persist_reward_change(db_session, dweller)
+        if emit_event and not reward_delivery_is_deferred(db_session):
+            await event_bus.emit(GameEvent.ITEM_COLLECTED, vault_id, {"item_type": reward_type, "amount": amount})
 
-        logger.info(f"Granted {amount} radaways to dweller {dweller.first_name} in vault {vault_id}")
-        return {"reward_type": RewardType.RADAWAY, "amount": amount, "dweller_id": str(dweller.id)}
+        logger.info(f"Granted {amount} {reward_type}s to dweller {dweller.first_name} in vault {vault_id}")
+        return {"reward_type": reward_type, "amount": amount, "dweller_id": str(dweller.id)}
 
     async def grant_lunchbox(self, db_session: AsyncSession, vault_id: UUID4) -> dict[str, Any]:
         """Grant a lunchbox (gives random rare dwellers/items).
@@ -241,10 +242,6 @@ class RewardService:
         - 3 random items (weapons or outfits)
         - 1 random dweller
         """
-        import random
-
-        from sqlmodel import select
-
         from app.models.outfit import Outfit
         from app.models.storage import Storage
         from app.models.weapon import Weapon
@@ -323,7 +320,7 @@ class RewardService:
         }
         granted_dweller = await self.grant_dweller(db_session, vault_id, dweller_data)
 
-        await db_session.commit()
+        await persist_reward_change(db_session)
 
         logger.info(f"Granted lunchbox to vault {vault_id}: {len(granted_items)} items, 1 dweller")
         return {
@@ -362,7 +359,7 @@ class RewardService:
         reward_str = objective_obj.reward
 
         reward_type, reward_data = self._parse_objective_reward(reward_str)
-        result = await self._process_single_reward(db_session, vault_id, reward_type, reward_data)
+        result = await self._process_single_reward(db_session, vault_id, reward_type, reward_data, emit_event=False)
         logger.info(f"Processed objective reward '{reward_str}' for vault {vault_id}")
         return result
 
@@ -372,14 +369,16 @@ class RewardService:
         vault_id: UUID4,
         reward_type: RewardType | str,
         reward_data: dict[str, Any],
+        *,
+        emit_event: bool = True,
     ) -> dict[str, Any]:
         reward_type_str = reward_type.value if isinstance(reward_type, RewardType) else reward_type
 
         match reward_type_str:
             case RewardType.CAPS:
-                return await self.grant_caps(db_session, vault_id, reward_data.get("amount", 0))
+                return await self.grant_caps(db_session, vault_id, reward_data.get("amount", 0), emit_event=emit_event)
             case RewardType.ITEM:
-                return await self.grant_item(db_session, vault_id, reward_data)
+                return await self.grant_item(db_session, vault_id, reward_data, emit_event=emit_event)
             case RewardType.DWELLER:
                 return await self.grant_dweller(db_session, vault_id, reward_data)
             case RewardType.RESOURCE:
@@ -391,7 +390,9 @@ class RewardService:
                     db_session, reward_data.get("dweller_ids", []), reward_data.get("amount", 0)
                 )
             case RewardType.STIMPAK:
-                return await self.grant_stimpak(db_session, vault_id, reward_data.get("amount", 1))
+                return await self.grant_stimpak(
+                    db_session, vault_id, reward_data.get("amount", 1), emit_event=emit_event
+                )
             case RewardType.RADAWAY:
                 return await self.grant_radaway(db_session, vault_id, reward_data.get("amount", 1))
             case RewardType.LUNCHBOX:

--- a/backend/app/services/reward_service.py
+++ b/backend/app/services/reward_service.py
@@ -32,8 +32,7 @@ class RewardService:
         vault_obj = await vault_crud.get(db_session, id=vault_id)
         if reward_delivery_is_deferred(db_session):
             vault_obj.bottle_caps += amount
-            db_session.add(vault_obj)
-            await db_session.flush()
+            await persist_reward_change(db_session, vault_obj)
         else:
             await vault_crud.deposit_caps(
                 db_session=db_session, vault_obj=vault_obj, amount=amount, emit_event=emit_event
@@ -166,8 +165,7 @@ class RewardService:
 
         if deferred:
             setattr(vault_obj, field, new_value)
-            db_session.add(vault_obj)
-            await db_session.flush()
+            await persist_reward_change(db_session, vault_obj)
         else:
             await vault_crud.update(db_session, id=vault_id, obj_in={field: new_value})
 

--- a/backend/app/tests/test_crud/test_quest.py
+++ b/backend/app/tests/test_crud/test_quest.py
@@ -2,6 +2,7 @@
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
 
 from app import crud
 from app.schemas.common import AgeGroupEnum, DwellerStatusEnum
@@ -458,6 +459,7 @@ async def test_check_and_complete_quests(async_session: AsyncSession) -> None:
     """Test automatic quest completion after duration."""
     from datetime import datetime, timedelta
 
+    from app.models.quest_reward import QuestReward, RewardType
     from app.models.vault_quest import VaultQuestCompletionLink
     from app.services.quest_service import quest_service
 
@@ -477,6 +479,14 @@ async def test_check_and_complete_quests(async_session: AsyncSession) -> None:
         rewards="50 caps",
     )
     quest = await crud.quest_crud.create(async_session, obj_in=quest_data)
+    async_session.add(
+        QuestReward(
+            quest_id=quest.id,
+            reward_type=RewardType.CAPS,
+            reward_data={"amount": 50},
+            reward_chance=1.0,
+        )
+    )
     link = VaultQuestCompletionLink(
         vault_id=vault.id,
         quest_id=quest.id,
@@ -496,7 +506,145 @@ async def test_check_and_complete_quests(async_session: AsyncSession) -> None:
     assert completed >= 1
 
     await async_session.refresh(link)
+    await async_session.refresh(vault)
     assert link.is_completed is True
+    assert vault.bottle_caps == vault_data["bottle_caps"] + 50
+
+
+@pytest.mark.asyncio
+async def test_timed_quest_completion_simulation(async_session: AsyncSession) -> None:
+    """Simulate a quest party returning with every configured reward."""
+    from datetime import datetime, timedelta
+
+    from app.crud.quest_party import quest_party_crud
+    from app.models.dweller import Dweller
+    from app.models.quest_reward import QuestReward, RewardType
+    from app.models.storage import Storage
+    from app.models.weapon import Weapon
+    from app.schemas.common import AgeGroupEnum
+    from app.services.quest_service import quest_service
+    from app.tests.factory.dwellers import create_fake_dweller
+
+    user = await crud.user.create(async_session, obj_in=UserCreate(**create_fake_user()))
+    vault_data = create_fake_vault()
+    vault = await crud.vault.create(
+        async_session,
+        obj_in=VaultCreateWithUserID(**vault_data, user_id=user.id),
+    )
+    async_session.add(Storage(vault_id=vault.id, max_space=10))
+    dweller_data = create_fake_dweller()
+    dweller_data.update(is_adult=True, age_group=AgeGroupEnum.ADULT)
+    dweller = Dweller(**dweller_data, vault_id=vault.id)
+    async_session.add(dweller)
+
+    quest = await crud.quest_crud.create(
+        async_session,
+        obj_in=QuestCreate(
+            title="Timed reward simulation",
+            short_description="Automatic settlement",
+            long_description="A party returns with caps and a weapon.",
+            requirements="One adult dweller",
+            rewards="50 caps and a laser pistol",
+        ),
+    )
+    async_session.add_all(
+        [
+            QuestReward(
+                quest_id=quest.id,
+                reward_type=RewardType.CAPS,
+                reward_data={"amount": 50},
+                reward_chance=1.0,
+            ),
+            QuestReward(
+                quest_id=quest.id,
+                reward_type=RewardType.ITEM,
+                reward_data={"item_type": "weapon", "name": "Laser Pistol"},
+                reward_chance=1.0,
+            ),
+        ]
+    )
+    link = await crud.quest_crud.assign_to_vault(async_session, quest.id, vault.id, is_visible=True)
+    await async_session.commit()
+    await quest_party_crud.assign_party(async_session, quest.id, vault.id, [dweller.id])
+
+    link.started_at = datetime.utcnow() - timedelta(minutes=61)
+    link.duration_minutes = 60
+    await async_session.commit()
+
+    assert await quest_service.check_and_complete_quests(async_session) == 1
+
+    await async_session.refresh(link)
+    await async_session.refresh(vault)
+    await async_session.refresh(dweller)
+    weapon = (await async_session.execute(select(Weapon).where(Weapon.name == "Laser Pistol"))).scalar_one()
+    assert link.is_completed is True
+    assert vault.bottle_caps == vault_data["bottle_caps"] + 50
+    assert weapon.storage_id is not None
+    assert dweller.status == DwellerStatusEnum.IDLE
+
+
+@pytest.mark.asyncio
+async def test_quest_completion_rolls_back_when_any_reward_fails(async_session: AsyncSession) -> None:
+    """A quest must not settle partially when one of its rewards cannot be delivered."""
+    from datetime import datetime, timedelta
+
+    from app.models.quest_reward import QuestReward, RewardType
+    from app.services.quest_service import quest_service
+
+    user = await crud.user.create(async_session, obj_in=UserCreate(**create_fake_user()))
+    vault_data = create_fake_vault()
+    vault = await crud.vault.create(
+        async_session,
+        obj_in=VaultCreateWithUserID(**vault_data, user_id=user.id),
+    )
+    quest = await crud.quest_crud.create(
+        async_session,
+        obj_in=QuestCreate(
+            title="Atomic reward quest",
+            short_description="Reward settlement",
+            long_description="Fails without available storage.",
+            requirements="None",
+            rewards="Caps and an item",
+        ),
+    )
+    async_session.add_all(
+        [
+            QuestReward(
+                quest_id=quest.id,
+                reward_type=RewardType.CAPS,
+                reward_data={"amount": 50},
+                reward_chance=1.0,
+            ),
+            QuestReward(
+                quest_id=quest.id,
+                reward_type=RewardType.ITEM,
+                reward_data={"item_type": "weapon", "name": "Laser Pistol"},
+                reward_chance=1.0,
+            ),
+        ]
+    )
+    await crud.quest_crud.assign_to_vault(async_session, quest.id, vault.id, is_visible=True)
+
+    with pytest.raises(ValueError, match="No storage found"):
+        await crud.quest_crud.complete(
+            db_session=async_session,
+            quest_entity_id=quest.id,
+            vault_id=vault.id,
+        )
+
+    await async_session.refresh(vault)
+    link = await async_session.get(crud.quest_crud.link_model, (vault.id, quest.id))
+    assert link is not None
+    link.started_at = datetime.now() - timedelta(minutes=61)
+    link.duration_minutes = 60
+    await async_session.commit()
+
+    assert await quest_service.check_and_complete_quests(async_session) == 0
+
+    await async_session.refresh(vault)
+    await async_session.refresh(link)
+    assert link.is_completed is False
+    assert vault.bottle_caps == vault_data["bottle_caps"]
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_crud/test_quest.py
+++ b/backend/app/tests/test_crud/test_quest.py
@@ -567,7 +567,7 @@ async def test_timed_quest_completion_simulation(async_session: AsyncSession) ->
     await async_session.commit()
     await quest_party_crud.assign_party(async_session, quest.id, vault.id, [dweller.id])
 
-    link.started_at = datetime.utcnow() - timedelta(minutes=61)
+    link.started_at = datetime.now() - timedelta(minutes=61)
     link.duration_minutes = 60
     await async_session.commit()
 

--- a/backend/app/tests/test_services/test_objective_evaluators.py
+++ b/backend/app/tests/test_services/test_objective_evaluators.py
@@ -1,5 +1,6 @@
 """Tests for ObjectiveEvaluators."""
 
+import asyncio
 from unittest.mock import patch
 
 import pytest
@@ -329,6 +330,77 @@ async def test_reach_evaluator_population_reached(
     # Refresh and check completion
     await async_session.refresh(link)
     assert link.is_completed is True
+
+
+@pytest.mark.asyncio
+async def test_collect_evaluator_keeps_objective_active_when_reward_fails(
+    async_session: AsyncSession,
+    fresh_event_bus,
+    patched_session_maker,
+) -> None:
+    """A failed reward must not permanently consume a completed objective."""
+    user = await crud.user.create(async_session, obj_in=UserCreate(**create_fake_user()))
+    vault = await crud.vault.create(
+        async_session,
+        obj_in=VaultCreateWithUserID(**create_fake_vault(), user_id=user.id),
+    )
+    objective = Objective(
+        challenge="Collect one cap",
+        reward="not a valid reward",
+        objective_type="collect",
+        target_entity={"resource_type": "caps"},
+        target_amount=1,
+        category=ObjectiveCategoryEnum.ACHIEVEMENT,
+    )
+    link = VaultObjectiveProgressLink(vault_id=vault.id, objective_id=objective.id, progress=0, total=1)
+    async_session.add_all([objective, link])
+    await async_session.commit()
+
+    CollectEvaluator(fresh_event_bus)
+
+    await fresh_event_bus.emit(GameEvent.RESOURCE_COLLECTED, vault.id, {"resource_type": "caps", "amount": 1})
+
+    await async_session.refresh(link)
+    assert link.progress == 1
+    assert link.is_completed is False
+
+
+@pytest.mark.asyncio
+async def test_collect_evaluator_does_not_reprocess_its_reward(
+    async_session: AsyncSession,
+    fresh_event_bus,
+    patched_session_maker,
+) -> None:
+    """A collect reward must not recursively trigger its own evaluator."""
+    user = await crud.user.create(async_session, obj_in=UserCreate(**create_fake_user()))
+    vault = await crud.vault.create(
+        async_session,
+        obj_in=VaultCreateWithUserID(**create_fake_vault(), user_id=user.id),
+    )
+    objective = Objective(
+        challenge="Collect one cap",
+        reward="10 caps",
+        objective_type="collect",
+        target_entity={"resource_type": "caps"},
+        target_amount=1,
+        category=ObjectiveCategoryEnum.ACHIEVEMENT,
+    )
+    link = VaultObjectiveProgressLink(vault_id=vault.id, objective_id=objective.id, progress=0, total=1)
+    async_session.add_all([objective, link])
+    await async_session.commit()
+    initial_caps = vault.bottle_caps
+
+    CollectEvaluator(fresh_event_bus)
+
+    await asyncio.wait_for(
+        fresh_event_bus.emit(GameEvent.RESOURCE_COLLECTED, vault.id, {"resource_type": "caps", "amount": 1}),
+        timeout=1,
+    )
+
+    await async_session.refresh(link)
+    await async_session.refresh(vault)
+    assert link.is_completed is True
+    assert vault.bottle_caps == initial_caps + 10
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_services/test_objective_evaluators.py
+++ b/backend/app/tests/test_services/test_objective_evaluators.py
@@ -361,7 +361,7 @@ async def test_collect_evaluator_keeps_objective_active_when_reward_fails(
     await fresh_event_bus.emit(GameEvent.RESOURCE_COLLECTED, vault.id, {"resource_type": "caps", "amount": 1})
 
     await async_session.refresh(link)
-    assert link.progress == 1
+    assert link.progress == 0
     assert link.is_completed is False
 
 
@@ -394,7 +394,7 @@ async def test_collect_evaluator_does_not_reprocess_its_reward(
 
     await asyncio.wait_for(
         fresh_event_bus.emit(GameEvent.RESOURCE_COLLECTED, vault.id, {"resource_type": "caps", "amount": 1}),
-        timeout=1,
+        timeout=10,
     )
 
     await async_session.refresh(link)

--- a/backend/app/tests/test_utils/test_version.py
+++ b/backend/app/tests/test_utils/test_version.py
@@ -1,0 +1,39 @@
+"""Tests for application version utilities."""
+
+from pathlib import Path
+
+from app.utils.version import parse_changelog
+
+
+def test_parse_changelog_supports_semantic_release_headings(tmp_path: Path) -> None:
+    """Parse the heading format produced by semantic-release."""
+    changelog_path = tmp_path / "CHANGELOG.md"
+    changelog_path.write_text(
+        """# Changelog
+
+## [2.35.0](https://example.test/compare/v2.34.3...v2.35.0) (2026-08-14)
+
+### Features
+
+- **Release automation** — synchronize application versions automatically
+
+---
+
+## [2.34.3] - 2026-08-13
+
+### Fixed
+
+- **Quest chains** — show prerequisite quests correctly
+""",
+        encoding="utf-8",
+    )
+
+    entries = parse_changelog(changelog_path)
+
+    assert [entry["version"] for entry in entries] == ["2.35.0", "2.34.3"]
+    assert entries[0]["changes"] == [
+        {
+            "category": "Features",
+            "description": "**Release automation** — synchronize application versions automatically",
+        }
+    ]

--- a/backend/app/utils/reward_delivery.py
+++ b/backend/app/utils/reward_delivery.py
@@ -25,7 +25,11 @@ def reward_delivery_is_deferred(db_session: AsyncSession) -> bool:
 
 
 async def persist_reward_change(db_session: AsyncSession, obj: Any | None = None, *, refresh: bool = False) -> None:
-    """Flush deferred reward changes or persist ordinary reward grants."""
+    """Flush deferred reward changes or persist ordinary reward grants.
+
+    Without ``obj``, this flushes or commits every pending change in ``db_session``,
+    including work unrelated to reward delivery.
+    """
     if obj is not None:
         db_session.add(obj)
     if reward_delivery_is_deferred(db_session):

--- a/backend/app/utils/reward_delivery.py
+++ b/backend/app/utils/reward_delivery.py
@@ -24,9 +24,7 @@ def reward_delivery_is_deferred(db_session: AsyncSession) -> bool:
     return bool(db_session.info.get(_DEFERRED_REWARD_DELIVERY, False))
 
 
-async def persist_reward_change(
-    db_session: AsyncSession, obj: Any | None = None, *, refresh: bool = False
-) -> None:
+async def persist_reward_change(db_session: AsyncSession, obj: Any | None = None, *, refresh: bool = False) -> None:
     """Flush deferred reward changes or persist ordinary reward grants."""
     if obj is not None:
         db_session.add(obj)

--- a/backend/app/utils/reward_delivery.py
+++ b/backend/app/utils/reward_delivery.py
@@ -1,0 +1,38 @@
+"""Transaction helpers for all-or-nothing reward settlement."""
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+_DEFERRED_REWARD_DELIVERY = "deferred_reward_delivery"
+
+
+@asynccontextmanager
+async def defer_reward_delivery(db_session: AsyncSession) -> AsyncIterator[None]:
+    """Defer reward commits and events until the caller settles the transaction."""
+    previous = db_session.info.get(_DEFERRED_REWARD_DELIVERY, False)
+    db_session.info[_DEFERRED_REWARD_DELIVERY] = True
+    try:
+        yield
+    finally:
+        db_session.info[_DEFERRED_REWARD_DELIVERY] = previous
+
+
+def reward_delivery_is_deferred(db_session: AsyncSession) -> bool:
+    return bool(db_session.info.get(_DEFERRED_REWARD_DELIVERY, False))
+
+
+async def persist_reward_change(
+    db_session: AsyncSession, obj: Any | None = None, *, refresh: bool = False
+) -> None:
+    """Flush deferred reward changes or persist ordinary reward grants."""
+    if obj is not None:
+        db_session.add(obj)
+    if reward_delivery_is_deferred(db_session):
+        await db_session.flush()
+    else:
+        await db_session.commit()
+        if refresh and obj is not None:
+            await db_session.refresh(obj)

--- a/backend/app/utils/version.py
+++ b/backend/app/utils/version.py
@@ -57,22 +57,18 @@ def parse_changelog(changelog_path: Path) -> list[dict]:
     with changelog_path.open(encoding="utf-8") as f:
         content = f.read()
 
-    sections = re.split(r"\n---\n", content)
     versions = []
+    heading_pattern = re.compile(
+        r"^## \[(?P<version>\d+\.\d+\.\d+)\](?:\([^\n)]*\))?(?:\s+-\s+|\s+\()(?P<date>\d{4}-\d{2}-\d{2})\)?\s*$",
+        re.MULTILINE,
+    )
+    headings = list(heading_pattern.finditer(content))
 
-    for section in sections[1:]:
-        lines = section.strip().split("\n")
-        if not lines:
-            continue
-
-        version_line = lines[0]
-        version_match = re.match(r"## \[(\d+\.\d+\.\d+)\] - (\d{4}-\d{2}-\d{2})", version_line)
-
-        if not version_match:
-            continue
-
-        version = version_match.group(1)
-        date_str = version_match.group(2)
+    for index, heading in enumerate(headings):
+        version = heading.group("version")
+        date_str = heading.group("date")
+        section_end = headings[index + 1].start() if index + 1 < len(headings) else len(content)
+        lines = content[heading.end() : section_end].split("\n")
 
         current_category = None
         changes = []


### PR DESCRIPTION
## Summary
- settle quest rewards and completion in one transaction
- prevent failed objective rewards from consuming progress
- run timed quests through the same settlement and party-release flow
- add atomic rollback and timed-quest lifecycle simulations

## Validation
- uv run pytest app/tests/test_crud/test_quest.py::test_timed_quest_completion_simulation -vv
- focused objective, quest, and reward suites
- uv run ruff check (touched backend paths)
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quest and objective rewards are now delivered transactionally, reducing the risk of partial rewards.
  * Quest completion now supports reliable party cleanup and dweller updates.
  * Expired quests are processed independently so one failure does not block others.

* **Bug Fixes**
  * Failed reward delivery now rolls back completion changes instead of leaving incomplete state.
  * Duplicate completion attempts are handled safely.
  * Reward-related events and notifications are emitted only after successful processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->