### PR TITLE
feat(incidents): add responder rounds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,3 +335,6 @@ Or call the script from a task:
 ```
 task(category="quick", load_skills=[], prompt="Run ./scripts/dev-up.sh from the repo root")
 ```
+
+Use `./scripts/dev-up.sh --reload` when editing backend code; it starts Uvicorn with hot reload. The launcher
+always replaces the `fallout-be` and `fallout-fe` tmux sessions, so running it again is already a fresh restart.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## Unreleased
+
+### Features
+
+- **Incident response** — dispatch healthy adult dwellers to an active incident room; combat now resolves in bounded,
+  online vault rounds instead of allowing a manual instant-win action
+
+### Changed
+
+- **Incident balance** — use configured threat weights and difficulty ranges; unsupported client-only incident types
+  are removed from the interface
+- **Development server** — `./scripts/dev-up.sh --reload` enables backend hot reload; every launcher run already
+  replaces the managed frontend and backend sessions
+
 ## [2.36.0](https://github.com/ElderEvil/falloutProject/compare/v2.35.1...v2.36.0) (2026-08-14)
 
 ### Features

--- a/backend/app/api/v1/endpoints/game_control.py
+++ b/backend/app/api/v1/endpoints/game_control.py
@@ -17,6 +17,8 @@ from app.schemas.incident import (
     IncidentListItem,
     IncidentListResponse,
     IncidentRead,
+    IncidentRespondersRequest,
+    IncidentRespondersResponse,
     IncidentSpawnResponse,
     PauseResumeResponse,
 )
@@ -225,32 +227,24 @@ async def manual_tick(
     }
 
 
-@router.post("/vaults/{vault_id}/incidents/{incident_id}/resolve", status_code=200)
-async def resolve_incident(
+@router.post("/vaults/{vault_id}/incidents/{incident_id}/responders", response_model=IncidentRespondersResponse)
+async def assign_incident_responders(
     *,
     vault: Annotated[Vault, Depends(get_user_vault_or_403)],
     incident_id: UUID4,
+    responders: IncidentRespondersRequest,
     db_session: Annotated[AsyncSession, Depends(get_async_session)],
-    success: bool = True,
-) -> dict[str, Any]:
-    """Manually resolve an active incident.
-
-    This endpoint allows players to mark an incident as resolved,
-    triggering loot generation and cleanup.
-
-    Returns:
-        dict[str, Any]: Resolution result with loot details.
-
-    Raises:
-        HTTPException: 404 if incident not found. 400 if resolution fails.
-    """
-    # Verify incident belongs to vault
+) -> IncidentRespondersResponse:
+    """Assign healthy adult dwellers to defend an active incident room."""
     incident = await crud.incident_crud.get(db_session, incident_id)
     if not incident or incident.vault_id != vault.id:
         raise HTTPException(status_code=404, detail="Incident not found")
 
     try:
-        return await incident_service.resolve_incident_manually(db_session, incident_id, success)
+        assigned = await incident_service.assign_responders(db_session, incident, responders.dweller_ids)
+        return IncidentRespondersResponse(
+            incident_id=incident.id, room_id=incident.room_id, assigned_dweller_ids=assigned
+        )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 

--- a/backend/app/api/v1/endpoints/game_control.py
+++ b/backend/app/api/v1/endpoints/game_control.py
@@ -25,6 +25,7 @@ from app.schemas.incident import (
 from app.schemas.system import GameBalanceResponse
 from app.services.game_loop import game_loop_service
 from app.services.incident_service import incident_service
+from app.utils.exceptions import AccessDeniedException, ResourceNotFoundException, ValidationException
 
 router = APIRouter(prefix="/game", tags=["Game"])
 
@@ -236,17 +237,14 @@ async def assign_incident_responders(
     db_session: Annotated[AsyncSession, Depends(get_async_session)],
 ) -> IncidentRespondersResponse:
     """Assign healthy adult dwellers to defend an active incident room."""
-    incident = await crud.incident_crud.get(db_session, incident_id)
-    if not incident or incident.vault_id != vault.id:
-        raise HTTPException(status_code=404, detail="Incident not found")
-
     try:
+        incident = await incident_service.get_incident_for_vault(db_session, incident_id, vault.id)
         assigned = await incident_service.assign_responders(db_session, incident, responders.dweller_ids)
         return IncidentRespondersResponse(
             incident_id=incident.id, room_id=incident.room_id, assigned_dweller_ids=assigned
         )
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
+    except (ResourceNotFoundException, AccessDeniedException, ValidationException) as error:
+        raise HTTPException(status_code=error.status_code, detail=error.detail) from error
 
 
 @router.post("/vaults/{vault_id}/incidents/spawn", response_model=IncidentSpawnResponse, status_code=201)

--- a/backend/app/schemas/incident.py
+++ b/backend/app/schemas/incident.py
@@ -1,6 +1,6 @@
 """Incident schemas for API responses."""
 
-from pydantic import UUID4, BaseModel
+from pydantic import UUID4, BaseModel, Field
 
 from app.models.incident import IncidentStatus, IncidentType
 
@@ -87,11 +87,28 @@ class ManualTickResponse(BaseModel):
     breeding_processed: int = 0
 
 
-class IncidentResolveResponse(BaseModel):
-    """Response after resolving an incident."""
+class IncidentRespondersRequest(BaseModel):
+    """Dwellers ordered to defend an active incident."""
 
-    message: str
-    incident_id: str
-    loot: dict | None
-    caps_earned: int
-    items_earned: list[dict]
+    dweller_ids: list[UUID4] = Field(min_length=1, max_length=6)
+
+
+class IncidentRespondersResponse(BaseModel):
+    """Response after assigning defenders to an incident room."""
+
+    incident_id: UUID4
+    room_id: UUID4
+    assigned_dweller_ids: list[UUID4]
+
+
+class IncidentRoundResult(BaseModel):
+    """Validated outcome of one incident game-loop round."""
+
+    skipped: bool = False
+    no_defenders: bool = False
+    damage_to_dwellers: float = 0
+    damage_to_raiders: float = 0
+    dwellers_damaged: int = 0
+    dwellers_killed: int = 0
+    enemies_defeated: int = 0
+    caps_earned: int = 0

--- a/backend/app/services/game_loop.py
+++ b/backend/app/services/game_loop.py
@@ -535,7 +535,9 @@ class GameLoopService:
                 return stats
 
             # Check if new incident should spawn
-            should_spawn = await incident_service.should_spawn_incident(db_session, vault_id, seconds_passed, game_state)
+            should_spawn = await incident_service.should_spawn_incident(
+                db_session, vault_id, seconds_passed, game_state
+            )
             if should_spawn:
                 new_incident = await incident_service.spawn_incident(db_session, vault_id)
                 if new_incident:

--- a/backend/app/services/game_loop.py
+++ b/backend/app/services/game_loop.py
@@ -135,7 +135,7 @@ class GameLoopService:
             results["updates"]["resources"] = {"error": str(e)}
 
         # === PHASE 2: Incident Management ===
-        incident_update = await self._process_incidents(db_session, vault_id, seconds_passed)
+        incident_update = await self._process_incidents(db_session, vault_id, seconds_passed, game_state)
         results["updates"]["incidents"] = incident_update
 
         # === PHASE 3: Wasteland Exploration ===
@@ -208,6 +208,9 @@ class GameLoopService:
     async def get_vault_status(self, db_session: AsyncSession, vault_id: UUID4) -> dict:
         """Get current game loop status for a vault."""
         game_state = await self._get_or_create_game_state(db_session, vault_id)
+        game_state.update_activity()
+        db_session.add(game_state)
+        await db_session.commit()
 
         return {
             "vault_id": str(vault_id),
@@ -500,7 +503,9 @@ class GameLoopService:
         # Happiness service handles its own errors internally, no wrapper needed
         return await happiness_service.update_vault_happiness(db_session, vault_id, seconds_passed)
 
-    async def _process_incidents(self, db_session: AsyncSession, vault_id: UUID4, seconds_passed: int) -> dict:
+    async def _process_incidents(
+        self, db_session: AsyncSession, vault_id: UUID4, seconds_passed: int, game_state: GameState | None = None
+    ) -> dict:
         """Process all active incidents for a vault.
 
         - Check if new incident should spawn
@@ -522,17 +527,20 @@ class GameLoopService:
         }
 
         try:
+            active_incidents = await incident_crud.get_active_by_vault(db_session, vault_id)
+            stats["active_count"] = len(active_incidents)
+
+            # Incidents do not punish players for time away from the vault.
+            if game_state and not game_state.is_user_online():
+                return stats
+
             # Check if new incident should spawn
-            should_spawn = await incident_service.should_spawn_incident(db_session, vault_id, seconds_passed)
+            should_spawn = await incident_service.should_spawn_incident(db_session, vault_id, seconds_passed, game_state)
             if should_spawn:
                 new_incident = await incident_service.spawn_incident(db_session, vault_id)
                 if new_incident:
                     stats["spawned"] = 1
                     self.logger.info(f"Spawned new incident {new_incident.type} in vault {vault_id}")
-
-            # Get all active incidents
-            active_incidents = await incident_crud.get_active_by_vault(db_session, vault_id)
-            stats["active_count"] = len(active_incidents)
 
             # Track total caps earned from all incidents
             total_caps_earned = 0
@@ -540,15 +548,17 @@ class GameLoopService:
             # Process each active incident
             for incident in active_incidents:
                 try:
-                    result = await incident_service.process_incident(db_session, incident, seconds_passed)
+                    result = await incident_service.process_incident(
+                        db_session, incident, min(seconds_passed, game_config.game_loop.tick_interval)
+                    )
 
-                    if result.get("skipped"):
+                    if result.skipped:
                         continue
 
                     stats["processed"] += 1
 
                     # Accumulate caps earned
-                    caps_earned = result.get("caps_earned", 0)
+                    caps_earned = result.caps_earned
                     if caps_earned > 0:
                         total_caps_earned += caps_earned
 

--- a/backend/app/services/incident_service.py
+++ b/backend/app/services/incident_service.py
@@ -14,7 +14,8 @@ from app.models.dweller import Dweller
 from app.models.game_state import GameState
 from app.models.incident import Incident, IncidentStatus, IncidentType
 from app.models.room import Room
-from app.schemas.common import AgeGroupEnum
+from app.schemas.common import AgeGroupEnum, DwellerStatusEnum
+from app.schemas.incident import IncidentRoundResult
 from app.schemas.incident_sse import IncidentSseEvent
 from app.services.notification_service import notification_service
 from app.services.stream_manager import sse_manager
@@ -109,10 +110,8 @@ class IncidentService:
                 # If vault already has incidents, use the same type
                 incident_type = next(iter(active_types))
             else:
-                # No active incidents, pick random
-                incident_type = random.choice(
-                    [IncidentType.RAIDER_ATTACK, IncidentType.RADROACH_INFESTATION, IncidentType.FIRE]
-                )
+                incident_types, weights = zip(*game_config.incident.get_spawn_weights().items(), strict=True)
+                incident_type = random.choices(incident_types, weights=weights, k=1)[0]
         # If type specified but vault has different type, don't spawn
         elif active_types and incident_type not in active_types:
             self.logger.info(f"Cannot spawn {incident_type} in vault {vault_id} - vault already has {active_types}")
@@ -166,12 +165,7 @@ class IncidentService:
             # Pick random room
             target_room = random.choice(available_rooms)
 
-        # Determine difficulty (1-10, weighted toward medium)
-        difficulty = random.choices(
-            range(1, 11),
-            weights=[5, 10, 15, 20, 20, 15, 10, 3, 1, 1],
-            k=1,  # Weighted toward 4-5
-        )[0]
+        difficulty = random.randint(*game_config.incident.get_difficulty_range(incident_type))
 
         # Create incident
         incident = await incident_crud.create(
@@ -257,7 +251,7 @@ class IncidentService:
 
     async def process_incident(
         self, db_session: AsyncSession, incident: Incident, seconds_passed: int
-    ) -> dict[str, int | float]:
+    ) -> IncidentRoundResult:
         """Process an active incident (apply damage, check victory conditions).
 
         Args:
@@ -269,7 +263,7 @@ class IncidentService:
             dict with combat results
         """
         if incident.status not in [IncidentStatus.ACTIVE, IncidentStatus.SPREADING]:
-            return {"skipped": True}
+            return IncidentRoundResult(skipped=True)
 
         transitioned = False
 
@@ -323,7 +317,11 @@ class IncidentService:
                         incident.id,
                         incident.vault_id,
                     )
-            return {"no_defenders": True, "damage": 0}
+            if incident.spread_count >= game_config.incident.max_spread_count:
+                incident.resolve(success=False)
+                db_session.add(incident)
+                await db_session.commit()
+            return IncidentRoundResult(no_defenders=True)
 
         # Calculate combat power
         dweller_power = self._calculate_dweller_combat_power(dwellers)
@@ -408,102 +406,49 @@ class IncidentService:
                     incident.vault_id,
                 )
 
-        return {
-            "damage_to_dwellers": damage_to_dwellers,
-            "damage_to_raiders": damage_to_raiders,
-            "dwellers_damaged": damaged_count,
-            "dwellers_killed": deaths_count,
-            "enemies_defeated": enemies_this_tick,
-            "caps_earned": caps_earned,  # Return for batch update
-        }
-
-    async def resolve_incident_manually(
-        self,
-        db_session: AsyncSession,
-        incident_id: UUID4,
-        success: bool = True,
-    ) -> dict:
-        """Manually resolve an incident (player intervention).
-
-        Args:
-            db_session: Database session
-            incident_id: ID of incident to resolve
-            success: Whether resolution was successful
-
-        Returns:
-            dict with loot and resolution info
-        """
-        incident = await incident_crud.get(db_session, incident_id)
-        if not incident:
-            raise ValueError(f"Incident {incident_id} not found")
-
-        if incident.status not in [IncidentStatus.ACTIVE, IncidentStatus.SPREADING]:
-            raise ValueError(f"Incident {incident_id} is not active")
-
-        # Generate loot if successful
-        loot = {}
-        caps_earned = 0
-        if success:
-            loot = self._generate_loot(incident.difficulty, incident.type)
-            caps_earned = loot.get("caps", 0)
-
-            # Award caps to vault using deposit_caps (emits RESOURCE_COLLECTED event for objectives)
-            vault = await vault_crud.get(db_session, incident.vault_id)
-            if vault and caps_earned > 0:
-                await vault_crud.deposit_caps(db_session=db_session, vault_obj=vault, amount=caps_earned)
-
-            # Award XP only to the adult dwellers who could have fought.
-            if incident.room_id:
-                query = select(Dweller).where(
-                    Dweller.room_id == incident.room_id,
-                    Dweller.health > 0,
-                    Dweller.is_adult,
-                    Dweller.age_group == AgeGroupEnum.ADULT,
-                )
-                result = await db_session.execute(query)
-                dwellers = list(result.scalars().all())
-                await self._award_combat_xp(db_session, incident, dwellers)
-
-        incident.loot = loot
-        incident.resolve(success=success)
-        db_session.add(incident)
-        await db_session.commit()
-
-        try:
-            await sse_manager.publish(
-                incident.vault_id,
-                "incidents",
-                IncidentSseEvent(
-                    event_id=str(incident.id),
-                    type="incident_resolved",
-                    incident_id=str(incident.id),
-                    vault_id=str(incident.vault_id),
-                    incident_type=incident.type,
-                    status=incident.status,
-                    room_id=str(incident.room_id) if incident.room_id else None,
-                    room_name=None,
-                    difficulty=incident.difficulty,
-                    success=success,
-                ).model_dump(),
-            )
-        except Exception:
-            self.logger.exception(
-                "Failed to publish SSE incident_resolved: incident_id=%s, vault_id=%s",
-                incident.id,
-                incident.vault_id,
-            )
-
-        self.logger.info(
-            f"Incident {incident_id} manually resolved ({'success' if success else 'failure'}). Loot: {loot}"
+        return IncidentRoundResult(
+            damage_to_dwellers=damage_to_dwellers,
+            damage_to_raiders=damage_to_raiders,
+            dwellers_damaged=damaged_count,
+            dwellers_killed=deaths_count,
+            enemies_defeated=enemies_this_tick,
+            caps_earned=caps_earned,
         )
 
-        return {
-            "message": "Incident resolved successfully" if success else "Incident failed",
-            "incident_id": str(incident_id),
-            "loot": loot,
-            "caps_earned": caps_earned,
-            "items_earned": loot.get("items", []),
-        }
+    async def assign_responders(
+        self, db_session: AsyncSession, incident: Incident, dweller_ids: list[UUID4]
+    ) -> list[UUID4]:
+        """Move eligible dwellers into an active incident room before its next round."""
+        if incident.status not in [IncidentStatus.ACTIVE, IncidentStatus.SPREADING]:
+            raise ValueError("Incident is no longer active")
+
+        unique_ids = list(dict.fromkeys(dweller_ids))
+        if len(unique_ids) != len(dweller_ids):
+            raise ValueError("Choose each responder only once")
+
+        query = select(Dweller).where(Dweller.id.in_(unique_ids), Dweller.vault_id == incident.vault_id)
+        result = await db_session.execute(query)
+        dwellers = list(result.scalars().all())
+        if len(dwellers) != len(unique_ids):
+            raise ValueError("One or more responders do not belong to this vault")
+
+        unavailable = [
+            dweller
+            for dweller in dwellers
+            if not dweller.is_adult
+            or dweller.age_group != AgeGroupEnum.ADULT
+            or dweller.health <= 0
+            or dweller.is_dead
+            or dweller.status in {DwellerStatusEnum.EXPLORING, DwellerStatusEnum.QUESTING, DwellerStatusEnum.DEAD}
+        ]
+        if unavailable:
+            raise ValueError("Only healthy adult dwellers in the vault can respond")
+
+        from app.services.dweller_service import dweller_service
+
+        for dweller in dwellers:
+            await dweller_service.update_dweller(db_session, dweller.id, {"room_id": incident.room_id})
+        return unique_ids
 
     async def _spread_incident(self, db_session: AsyncSession, incident: Incident) -> None:
         """Spread incident to an adjacent room with the same incident type."""

--- a/backend/app/services/incident_service.py
+++ b/backend/app/services/incident_service.py
@@ -297,7 +297,10 @@ class IncidentService:
                 await self._publish_event(incident, "incident_spreading")
                 return IncidentRoundResult(no_defenders=True)
 
-            if incident.spread_count >= game_config.incident.max_spread_count or incident.elapsed_time() >= incident.duration:
+            if (
+                incident.spread_count >= game_config.incident.max_spread_count
+                or incident.elapsed_time() >= incident.duration
+            ):
                 incident.resolve(success=False)
                 db_session.add(incident)
                 await db_session.commit()

--- a/backend/app/services/incident_service.py
+++ b/backend/app/services/incident_service.py
@@ -19,6 +19,7 @@ from app.schemas.incident import IncidentRoundResult
 from app.schemas.incident_sse import IncidentSseEvent
 from app.services.notification_service import notification_service
 from app.services.stream_manager import sse_manager
+from app.utils.exceptions import AccessDeniedException, ResourceNotFoundException, ValidationException
 
 logger = logging.getLogger(__name__)
 
@@ -287,40 +288,20 @@ class IncidentService:
         dwellers = list(dwellers_result.scalars().all())
 
         if not dwellers:
-            # No dwellers to fight - incident spreads
             if (
                 incident.elapsed_time() >= incident.duration
                 and incident.spread_count < game_config.incident.max_spread_count
+                and await self._spread_incident(db_session, incident)
             ):
-                transitioned = True
-                await self._spread_incident(db_session, incident)
                 await db_session.commit()
-                try:
-                    await sse_manager.publish(
-                        incident.vault_id,
-                        "incidents",
-                        IncidentSseEvent(
-                            event_id=str(incident.id),
-                            type="incident_spreading",
-                            incident_id=str(incident.id),
-                            vault_id=str(incident.vault_id),
-                            incident_type=incident.type,
-                            status=incident.status,
-                            room_id=str(incident.room_id) if incident.room_id else None,
-                            room_name=None,
-                            difficulty=incident.difficulty,
-                        ).model_dump(),
-                    )
-                except Exception:
-                    self.logger.exception(
-                        "Failed to publish SSE incident_spreading: incident_id=%s, vault_id=%s",
-                        incident.id,
-                        incident.vault_id,
-                    )
-            if incident.spread_count >= game_config.incident.max_spread_count:
+                await self._publish_event(incident, "incident_spreading")
+                return IncidentRoundResult(no_defenders=True)
+
+            if incident.spread_count >= game_config.incident.max_spread_count or incident.elapsed_time() >= incident.duration:
                 incident.resolve(success=False)
                 db_session.add(incident)
                 await db_session.commit()
+                await self._publish_event(incident, "incident_resolved", success=False)
             return IncidentRoundResult(no_defenders=True)
 
         # Calculate combat power
@@ -382,29 +363,7 @@ class IncidentService:
         await db_session.commit()
 
         if transitioned:
-            try:
-                await sse_manager.publish(
-                    incident.vault_id,
-                    "incidents",
-                    IncidentSseEvent(
-                        event_id=str(incident.id),
-                        type="incident_resolved",
-                        incident_id=str(incident.id),
-                        vault_id=str(incident.vault_id),
-                        incident_type=incident.type,
-                        status=incident.status,
-                        room_id=str(incident.room_id) if incident.room_id else None,
-                        room_name=None,
-                        difficulty=incident.difficulty,
-                        success=True,
-                    ).model_dump(),
-                )
-            except Exception:
-                self.logger.exception(
-                    "Failed to publish SSE incident_resolved: incident_id=%s, vault_id=%s",
-                    incident.id,
-                    incident.vault_id,
-                )
+            await self._publish_event(incident, "incident_resolved", success=True)
 
         return IncidentRoundResult(
             damage_to_dwellers=damage_to_dwellers,
@@ -415,22 +374,30 @@ class IncidentService:
             caps_earned=caps_earned,
         )
 
+    async def get_incident_for_vault(self, db_session: AsyncSession, incident_id: UUID4, vault_id: UUID4) -> Incident:
+        incident = await incident_crud.get(db_session, incident_id)
+        if not incident:
+            raise ResourceNotFoundException(Incident, incident_id)
+        if incident.vault_id != vault_id:
+            raise AccessDeniedException("Incident does not belong to this vault")
+        return incident
+
     async def assign_responders(
         self, db_session: AsyncSession, incident: Incident, dweller_ids: list[UUID4]
     ) -> list[UUID4]:
         """Move eligible dwellers into an active incident room before its next round."""
         if incident.status not in [IncidentStatus.ACTIVE, IncidentStatus.SPREADING]:
-            raise ValueError("Incident is no longer active")
+            raise ValidationException("Incident is no longer active")
 
         unique_ids = list(dict.fromkeys(dweller_ids))
         if len(unique_ids) != len(dweller_ids):
-            raise ValueError("Choose each responder only once")
+            raise ValidationException("Choose each responder only once")
 
         query = select(Dweller).where(Dweller.id.in_(unique_ids), Dweller.vault_id == incident.vault_id)
         result = await db_session.execute(query)
         dwellers = list(result.scalars().all())
         if len(dwellers) != len(unique_ids):
-            raise ValueError("One or more responders do not belong to this vault")
+            raise ValidationException("One or more responders do not belong to this vault")
 
         unavailable = [
             dweller
@@ -442,7 +409,7 @@ class IncidentService:
             or dweller.status in {DwellerStatusEnum.EXPLORING, DwellerStatusEnum.QUESTING, DwellerStatusEnum.DEAD}
         ]
         if unavailable:
-            raise ValueError("Only healthy adult dwellers in the vault can respond")
+            raise ValidationException("Only healthy adult dwellers in the vault can respond")
 
         from app.services.dweller_service import dweller_service
 
@@ -450,15 +417,15 @@ class IncidentService:
             await dweller_service.update_dweller(db_session, dweller.id, {"room_id": incident.room_id})
         return unique_ids
 
-    async def _spread_incident(self, db_session: AsyncSession, incident: Incident) -> None:
-        """Spread incident to an adjacent room with the same incident type."""
+    async def _spread_incident(self, db_session: AsyncSession, incident: Incident) -> bool:
+        """Spread an incident to an adjacent room and report whether it succeeded."""
         # Get the current room to find its coordinates
         current_room_query = select(Room).where(Room.id == incident.room_id)
         current_room_result = await db_session.execute(current_room_query)
         current_room = current_room_result.scalar_one_or_none()
 
         if not current_room or current_room.coordinate_x is None or current_room.coordinate_y is None:
-            return
+            return False
 
         # Get rooms that already have active incidents
         rooms_with_incidents = await incident_crud.get_rooms_with_active_incidents(db_session, incident.vault_id)
@@ -511,6 +478,36 @@ class IncidentService:
             self.logger.warning(
                 f"Incident {incident.type} spread from {current_room.name} to {new_room.name} "
                 f"(difficulty {new_incident.difficulty})"
+            )
+            return True
+
+        return False
+
+    async def _publish_event(self, incident: Incident, event_type: str, success: bool | None = None) -> None:
+        """Publish a non-critical incident event."""
+        try:
+            await sse_manager.publish(
+                incident.vault_id,
+                "incidents",
+                IncidentSseEvent(
+                    event_id=str(incident.id),
+                    type=event_type,
+                    incident_id=str(incident.id),
+                    vault_id=str(incident.vault_id),
+                    incident_type=incident.type,
+                    status=incident.status,
+                    room_id=str(incident.room_id) if incident.room_id else None,
+                    room_name=None,
+                    difficulty=incident.difficulty,
+                    success=success,
+                ).model_dump(),
+            )
+        except Exception:
+            self.logger.exception(
+                "Failed to publish SSE %s: incident_id=%s, vault_id=%s",
+                event_type,
+                incident.id,
+                incident.vault_id,
             )
 
     def _calculate_dweller_combat_power(self, dwellers: list[Dweller]) -> float:

--- a/backend/app/tests/test_api/test_game_control.py
+++ b/backend/app/tests/test_api/test_game_control.py
@@ -393,12 +393,12 @@ async def test_get_incident_details(
 
 
 @pytest.mark.asyncio
-async def test_resolve_incident_success(
+async def test_assign_incident_responders(
     async_client: AsyncClient,
     async_session: AsyncSession,
     normal_user_token_headers: dict[str, str],
 ):
-    """Test resolving an incident successfully."""
+    """Test assigning an eligible dweller to defend an incident."""
     from app.models.incident import IncidentType
 
     # Create a vault with incident
@@ -408,7 +408,6 @@ async def test_resolve_incident_success(
         obj_in=VaultNumber(number=990),
         user_id=user.id,
     )
-    initial_caps = vault.bottle_caps
 
     # Create room with dweller
     from app.schemas.dweller import DwellerCreate
@@ -448,30 +447,25 @@ async def test_resolve_incident_success(
     )
     await async_session.commit()
 
-    # Resolve incident
+    # Assign defender
     response = await async_client.post(
-        f"/game/vaults/{vault.id}/incidents/{incident.id}/resolve",
+        f"/game/vaults/{vault.id}/incidents/{incident.id}/responders",
         headers=normal_user_token_headers,
-        params={"success": True},
+        json={"dweller_ids": [str(dweller.id)]},
     )
     assert response.status_code == 200
     data = response.json()
-    assert "caps_earned" in data
-    assert data["caps_earned"] > 0
-    assert "items_earned" in data
-
-    # Verify vault caps increased
-    await async_session.refresh(vault)
-    assert vault.bottle_caps > initial_caps
+    assert data["incident_id"] == str(incident.id)
+    assert data["assigned_dweller_ids"] == [str(dweller.id)]
 
 
 @pytest.mark.asyncio
-async def test_resolve_incident_failure(
+async def test_assign_incident_responders_requires_a_dweller(
     async_client: AsyncClient,
     async_session: AsyncSession,
     normal_user_token_headers: dict[str, str],
 ):
-    """Test abandoning an incident."""
+    """Reject an empty responder order before changing the incident room."""
     from app.models.incident import IncidentType
 
     # Create a vault with incident
@@ -520,13 +514,10 @@ async def test_resolve_incident_failure(
     )
     await async_session.commit()
 
-    # Abandon incident
+    # An empty command is invalid.
     response = await async_client.post(
-        f"/game/vaults/{vault.id}/incidents/{incident.id}/resolve",
+        f"/game/vaults/{vault.id}/incidents/{incident.id}/responders",
         headers=normal_user_token_headers,
-        params={"success": False},
+        json={"dweller_ids": []},
     )
-    assert response.status_code == 200
-    data = response.json()
-    assert data["caps_earned"] == 0
-    assert data["message"] == "Incident failed"
+    assert response.status_code == 422

--- a/backend/app/tests/test_api/test_game_control.py
+++ b/backend/app/tests/test_api/test_game_control.py
@@ -409,13 +409,15 @@ async def test_assign_incident_responders(
         user_id=user.id,
     )
 
-    # Create room with dweller
+    # Create the incident room and a separate room containing the responder.
     from app.schemas.dweller import DwellerCreate
     from app.schemas.room import RoomCreate
 
     room_data = create_fake_room()
     room_in = RoomCreate(**room_data, vault_id=vault.id)
     room = await crud.room.create(db_session=async_session, obj_in=room_in)
+    responder_room_in = RoomCreate(**create_fake_room(), vault_id=vault.id)
+    responder_room = await crud.room.create(db_session=async_session, obj_in=responder_room_in)
 
     dweller_in = DwellerCreate(
         first_name="Hero",
@@ -423,7 +425,7 @@ async def test_assign_incident_responders(
         gender="female",
         rarity="legendary",
         vault_id=vault.id,
-        room_id=room.id,
+        room_id=responder_room.id,
         strength=10,
         perception=10,
         endurance=10,
@@ -433,8 +435,6 @@ async def test_assign_incident_responders(
         luck=10,
     )
     dweller = await crud.dweller.create(db_session=async_session, obj_in=dweller_in)
-    dweller.room_id = room.id
-    async_session.add(dweller)
     await async_session.commit()
 
     # Create incident
@@ -456,7 +456,10 @@ async def test_assign_incident_responders(
     assert response.status_code == 200
     data = response.json()
     assert data["incident_id"] == str(incident.id)
+    assert data["room_id"] == str(room.id)
     assert data["assigned_dweller_ids"] == [str(dweller.id)]
+    await async_session.refresh(dweller)
+    assert dweller.room_id == room.id
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_incident_sse.py
+++ b/backend/app/tests/test_incident_sse.py
@@ -108,7 +108,7 @@ async def test_process_incident_publishes_only_on_transition(async_session: Asyn
 
     with patch("app.services.incident_service.sse_manager.publish", new_callable=AsyncMock) as mock_publish:
         result = await incident_service.process_incident(async_session, incident_no_transition, 1)
-        assert result.get("skipped") is not True
+        assert result.skipped is False
         mock_publish.assert_not_awaited()
 
     # --- Part B: Transition via auto-resolve (high enemies_defeated) ---
@@ -126,7 +126,7 @@ async def test_process_incident_publishes_only_on_transition(async_session: Asyn
 
     with patch("app.services.incident_service.sse_manager.publish", new_callable=AsyncMock) as mock_publish:
         result = await incident_service.process_incident(async_session, incident_resolve, 60)
-        assert result.get("skipped") is not True
+        assert result.skipped is False
         mock_publish.assert_awaited_once()
         call_args = mock_publish.call_args
         assert call_args[0][1] == "incidents"
@@ -156,47 +156,10 @@ async def test_process_incident_publishes_only_on_transition(async_session: Asyn
 
     with patch("app.services.incident_service.sse_manager.publish", new_callable=AsyncMock) as mock_publish:
         result = await incident_service.process_incident(async_session, incident_spread, 60)
-        assert result.get("no_defenders") is True
+        assert result.no_defenders is True
         mock_publish.assert_awaited_once()
         call_args = mock_publish.call_args
         assert call_args[0][1] == "incidents"
         payload = call_args[0][2]
         assert payload["type"] == "incident_spreading"
         assert payload["incident_id"] == str(incident_spread.id)
-
-
-@pytest.mark.asyncio
-async def test_resolve_incident_manually_publishes_sse(async_session: AsyncSession, room_with_dwellers: dict):
-    """Verify resolve_incident_manually publishes SSE with correct success field."""
-    room = room_with_dwellers["room"]
-    incident = await incident_service.spawn_incident(async_session, room.vault_id, IncidentType.FIRE)
-    await async_session.commit()
-    await async_session.refresh(incident)
-
-    # Success case
-    with patch("app.services.incident_service.sse_manager.publish", new_callable=AsyncMock) as mock_publish:
-        result = await incident_service.resolve_incident_manually(async_session, incident.id, success=True)
-        assert result["message"] == "Incident resolved successfully"
-        mock_publish.assert_awaited_once()
-        call_args = mock_publish.call_args
-        assert call_args[0][1] == "incidents"
-        payload = call_args[0][2]
-        assert payload["type"] == "incident_resolved"
-        assert payload["success"] is True
-        assert payload["incident_id"] == str(incident.id)
-
-    # Failure case - need a new incident
-    incident2 = await incident_service.spawn_incident(async_session, room.vault_id, IncidentType.FIRE)
-    await async_session.commit()
-    await async_session.refresh(incident2)
-
-    with patch("app.services.incident_service.sse_manager.publish", new_callable=AsyncMock) as mock_publish:
-        result = await incident_service.resolve_incident_manually(async_session, incident2.id, success=False)
-        assert result["message"] == "Incident failed"
-        mock_publish.assert_awaited_once()
-        call_args = mock_publish.call_args
-        assert call_args[0][1] == "incidents"
-        payload = call_args[0][2]
-        assert payload["type"] == "incident_resolved"
-        assert payload["success"] is False
-        assert payload["incident_id"] == str(incident2.id)

--- a/backend/app/tests/test_incident_sse.py
+++ b/backend/app/tests/test_incident_sse.py
@@ -7,6 +7,7 @@ import pytest
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app import crud
+from app.core.game_config import game_config
 from app.models.incident import IncidentStatus, IncidentType
 from app.schemas.incident_sse import IncidentSseEvent
 from app.services.incident_service import incident_service
@@ -54,6 +55,8 @@ async def test_process_incident_publishes_only_on_transition(async_session: Asyn
         t3_upgrade_cost=1500,
         size_min=1,
         size_max=3,
+        coordinate_x=1,
+        coordinate_y=1,
         vault_id=vault.id,
     )
     room1 = await crud.room.create(db_session=async_session, obj_in=room1_in)
@@ -163,3 +166,47 @@ async def test_process_incident_publishes_only_on_transition(async_session: Asyn
         payload = call_args[0][2]
         assert payload["type"] == "incident_spreading"
         assert payload["incident_id"] == str(incident_spread.id)
+
+
+@pytest.mark.asyncio
+async def test_undefended_max_spread_publishes_failed_resolution(async_session: AsyncSession, vault: "Vault"):
+    """An incident that exhausts its spread limit broadcasts its failed resolution."""
+    from app.schemas.room import RoomCreate
+
+    room = await crud.room.create(
+        async_session,
+        obj_in=RoomCreate(
+            name="Power Generator",
+            category="Production",
+            ability=None,
+            base_cost=100,
+            t2_upgrade_cost=500,
+            t3_upgrade_cost=1500,
+            size_min=1,
+            size_max=3,
+            coordinate_x=1,
+            coordinate_y=1,
+            vault_id=vault.id,
+        ),
+    )
+    incident = await crud.incident_crud.create(
+        async_session,
+        vault_id=vault.id,
+        room_id=room.id,
+        incident_type=IncidentType.FIRE,
+        difficulty=1,
+    )
+    incident.spread_count = game_config.incident.max_spread_count
+    async_session.add(incident)
+    await async_session.commit()
+
+    with patch("app.services.incident_service.sse_manager.publish", new_callable=AsyncMock) as mock_publish:
+        result = await incident_service.process_incident(async_session, incident, 60)
+
+    await async_session.refresh(incident)
+    assert result.no_defenders is True
+    assert incident.status == IncidentStatus.FAILED
+    mock_publish.assert_awaited_once()
+    payload = mock_publish.call_args.args[2]
+    assert payload["type"] == "incident_resolved"
+    assert payload["success"] is False

--- a/backend/app/tests/test_services/test_game_loop.py
+++ b/backend/app/tests/test_services/test_game_loop.py
@@ -19,7 +19,9 @@ import pytest
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.dweller import Dweller
+from app.models.game_state import GameState
 from app.models.vault import Vault
+from app.schemas.incident import IncidentRoundResult
 from app.schemas.vault import ResourceTickEvents
 from app.services.game_loop import game_loop_service
 
@@ -266,11 +268,26 @@ class TestProcessIncidents:
         with patch("app.services.incident_service.incident_service") as mock_is:
             mock_is.should_spawn_incident = AsyncMock(return_value=True)
             mock_is.spawn_incident = AsyncMock(return_value=mock_incident)
+            mock_is.process_incident = AsyncMock()
             with patch("app.services.game_loop.incident_crud") as mock_crud:
                 mock_crud.get_active_by_vault = AsyncMock(return_value=[])
                 result = await game_loop_service._process_incidents(async_session, vault.id, 60)
         assert result["spawned"] == 1
         assert result["active_count"] == 0
+        mock_is.process_incident.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_offline_vault_does_not_process_existing_incidents(self, async_session: AsyncSession, vault: Vault):
+        game_state = GameState(vault_id=vault.id, last_activity_time=datetime.utcnow() - timedelta(minutes=11))
+        with patch("app.services.incident_service.incident_service") as mock_is:
+            mock_is.process_incident = AsyncMock()
+            with patch("app.services.game_loop.incident_crud") as mock_crud:
+                mock_crud.get_active_by_vault = AsyncMock(return_value=[MagicMock()])
+                result = await game_loop_service._process_incidents(async_session, vault.id, 60, game_state)
+
+        assert result["active_count"] == 1
+        mock_is.should_spawn_incident.assert_not_called()
+        mock_is.process_incident.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_spawn_returns_none(self, async_session: AsyncSession, vault: Vault):
@@ -300,7 +317,7 @@ class TestProcessIncidents:
             gl_mod.vault_crud.deposit_caps = AsyncMock()
             with patch("app.services.incident_service.incident_service") as mock_is:
                 mock_is.should_spawn_incident = AsyncMock(return_value=False)
-                mock_is.process_incident = AsyncMock(return_value={"caps_earned": 50, "skipped": False})
+                mock_is.process_incident = AsyncMock(return_value=IncidentRoundResult(caps_earned=50))
                 # _process_incidents calls db_session.refresh(incident) — mock it
                 with patch.object(async_session, "refresh", new_callable=AsyncMock):
                     result = await game_loop_service._process_incidents(async_session, vault.id, 60)
@@ -324,7 +341,7 @@ class TestProcessIncidents:
             gl_mod.incident_crud.get_active_by_vault = AsyncMock(return_value=[mock_incident])
             with patch("app.services.incident_service.incident_service") as mock_is:
                 mock_is.should_spawn_incident = AsyncMock(return_value=False)
-                mock_is.process_incident = AsyncMock(return_value={"skipped": True})
+                mock_is.process_incident = AsyncMock(return_value=IncidentRoundResult(skipped=True))
                 result = await game_loop_service._process_incidents(async_session, vault.id, 60)
         finally:
             gl_mod.incident_crud = saved_crud
@@ -346,7 +363,7 @@ class TestProcessIncidents:
             call_count[0] += 1
             if call_count[0] == 1:
                 raise RuntimeError("Simulated error")
-            return {"caps_earned": 0, "skipped": False}
+            return IncidentRoundResult()
 
         import app.services.game_loop as gl_mod
 

--- a/backend/app/tests/test_services/test_incident_service.py
+++ b/backend/app/tests/test_services/test_incident_service.py
@@ -143,6 +143,30 @@ async def test_process_incident_auto_resolve(async_session: AsyncSession, room_w
 
 
 @pytest.mark.asyncio
+async def test_undefended_incident_without_spread_target_fails(async_session: AsyncSession, room: Room):
+    """An elapsed incident fails when there is no adjacent room left to spread into."""
+    room.coordinate_x = 1
+    room.coordinate_y = 1
+    async_session.add(room)
+    await async_session.commit()
+    incident = await crud.incident_crud.create(
+        async_session,
+        vault_id=room.vault_id,
+        room_id=room.id,
+        incident_type=IncidentType.FIRE,
+        difficulty=1,
+    )
+    incident.start_time = datetime.utcnow() - timedelta(seconds=incident.duration)
+    async_session.add(incident)
+    await async_session.commit()
+
+    await incident_service.process_incident(async_session, incident, 60)
+
+    await async_session.refresh(incident)
+    assert incident.status == IncidentStatus.FAILED
+
+
+@pytest.mark.asyncio
 async def test_calculate_dweller_combat_power(
     async_session: AsyncSession,
     room_with_dwellers: dict,

--- a/backend/app/tests/test_services/test_incident_service.py
+++ b/backend/app/tests/test_services/test_incident_service.py
@@ -78,12 +78,10 @@ async def test_process_incident_combat(async_session: AsyncSession, room_with_dw
     # Process combat for 60 seconds
     result = await incident_service.process_incident(async_session, incident, 60)
 
-    # Check result keys (format may vary based on incident type)
-    assert "damage_to_dwellers" in result
-    assert "damage_to_raiders" in result
-    assert "dwellers_damaged" in result
-    assert result["damage_to_dwellers"] >= 0
-    assert result["damage_to_raiders"] >= 0
+    # Check validated round outcome.
+    assert result.dwellers_damaged >= 0
+    assert result.damage_to_dwellers >= 0
+    assert result.damage_to_raiders >= 0
 
     # Verify incident was updated
     await async_session.refresh(incident)
@@ -141,7 +139,7 @@ async def test_process_incident_auto_resolve(async_session: AsyncSession, room_w
 
     # Should auto-resolve
     await async_session.refresh(incident)
-    assert incident.status == IncidentStatus.RESOLVED or result["enemies_defeated"] >= 2
+    assert incident.status == IncidentStatus.RESOLVED or result.enemies_defeated >= 2
 
 
 @pytest.mark.asyncio
@@ -178,68 +176,22 @@ async def test_generate_loot(async_session: AsyncSession, vault: Vault):
 
 
 @pytest.mark.asyncio
-async def test_resolve_incident_manually_success(async_session: AsyncSession, room_with_dwellers: dict):
-    """Test manual incident resolution with success."""
-    room = room_with_dwellers["room"]
-    dwellers = room_with_dwellers["dwellers"]
-    incident = await incident_service.spawn_incident(async_session, room.vault_id, IncidentType.FIRE)
-    await async_session.refresh(dwellers[0].vault)
-    initial_caps = dwellers[0].vault.bottle_caps
-
-    result = await incident_service.resolve_incident_manually(async_session, incident.id, success=True)
-
-    assert result["message"] == "Incident resolved successfully"
-    assert result["caps_earned"] > 0
-    assert "items_earned" in result
-
-    # Verify incident status
-    await async_session.refresh(incident)
-    assert incident.status == IncidentStatus.RESOLVED
-
-    # Verify vault caps increased
-    await async_session.refresh(dwellers[0].vault)
-    assert dwellers[0].vault.bottle_caps > initial_caps
-
-
-@pytest.mark.asyncio
-async def test_resolve_incident_manually_does_not_award_child_combat_xp(
-    async_session: AsyncSession, room_with_dwellers: dict
+async def test_assign_responders_moves_healthy_adult(
+    async_session: AsyncSession, room_with_dwellers: dict, dweller_data: dict
 ):
-    """Children present in the incident room do not receive manual-resolution combat XP."""
-    from app.tests.factory.dwellers import create_random_common_dweller
-
+    """A healthy adult can join an active incident room before the next round."""
     room = room_with_dwellers["room"]
-    child_data = create_random_common_dweller()
-    child_data.update(is_adult=False, age_group=AgeGroupEnum.CHILD, experience=0)
-    child = await crud.dweller.create(
+    responder = await crud.dweller.create(
         async_session,
-        obj_in=DwellerCreate(**child_data, vault_id=room.vault_id),
+        obj_in=DwellerCreate(**dweller_data, vault_id=room.vault_id),
     )
-    await crud.dweller.move_to_room(async_session, child.id, room.id)
-    await async_session.commit()
-
     incident = await incident_service.spawn_incident(async_session, room.vault_id, IncidentType.FIRE)
     assert incident is not None
-    await incident_service.resolve_incident_manually(async_session, incident.id, success=True)
+    assigned = await incident_service.assign_responders(async_session, incident, [responder.id])
 
-    await async_session.refresh(child)
-    assert child.experience == 0
-
-
-@pytest.mark.asyncio
-async def test_resolve_incident_manually_failure(async_session: AsyncSession, room_with_dwellers: dict):
-    """Test manual incident resolution with failure."""
-    room = room_with_dwellers["room"]
-    incident = await incident_service.spawn_incident(async_session, room.vault_id, IncidentType.FIRE)
-
-    result = await incident_service.resolve_incident_manually(async_session, incident.id, success=False)
-
-    assert result["message"] == "Incident failed"
-    assert result["caps_earned"] == 0
-
-    # Verify incident status
-    await async_session.refresh(incident)
-    assert incident.status == IncidentStatus.FAILED
+    await async_session.refresh(responder)
+    assert assigned == [responder.id]
+    assert responder.room_id == room.id
 
 
 @pytest.mark.asyncio

--- a/frontend/src/core/types/api.generated.ts
+++ b/frontend/src/core/types/api.generated.ts
@@ -1610,7 +1610,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/game/vaults/{vault_id}/incidents/{incident_id}/resolve": {
+    "/api/v1/game/vaults/{vault_id}/incidents/{incident_id}/responders": {
         parameters: {
             query?: never;
             header?: never;
@@ -1620,19 +1620,10 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Resolve Incident
-         * @description Manually resolve an active incident.
-         *
-         *     This endpoint allows players to mark an incident as resolved,
-         *     triggering loot generation and cleanup.
-         *
-         *     Returns:
-         *         dict[str, Any]: Resolution result with loot details.
-         *
-         *     Raises:
-         *         HTTPException: 404 if incident not found. 400 if resolution fails.
+         * Assign Incident Responders
+         * @description Assign healthy adult dwellers to defend an active incident room.
          */
-        post: operations["resolve_incident_api_v1_game_vaults__vault_id__incidents__incident_id__resolve_post"];
+        post: operations["assign_incident_responders_api_v1_game_vaults__vault_id__incidents__incident_id__responders_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -6016,6 +6007,32 @@ export interface components {
             loot: {
                 [key: string]: unknown;
             } | null;
+        };
+        /**
+         * IncidentRespondersRequest
+         * @description Dwellers ordered to defend an active incident.
+         */
+        IncidentRespondersRequest: {
+            /** Dweller Ids */
+            dweller_ids: string[];
+        };
+        /**
+         * IncidentRespondersResponse
+         * @description Response after assigning defenders to an incident room.
+         */
+        IncidentRespondersResponse: {
+            /**
+             * Incident Id
+             * Format: uuid4
+             */
+            incident_id: string;
+            /**
+             * Room Id
+             * Format: uuid4
+             */
+            room_id: string;
+            /** Assigned Dweller Ids */
+            assigned_dweller_ids: string[];
         };
         /**
          * IncidentSpawnResponse
@@ -10564,11 +10581,9 @@ export interface operations {
             };
         };
     };
-    resolve_incident_api_v1_game_vaults__vault_id__incidents__incident_id__resolve_post: {
+    assign_incident_responders_api_v1_game_vaults__vault_id__incidents__incident_id__responders_post: {
         parameters: {
-            query?: {
-                success?: boolean;
-            };
+            query?: never;
             header?: never;
             path: {
                 incident_id: string;
@@ -10576,7 +10591,11 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["IncidentRespondersRequest"];
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {
@@ -10584,9 +10603,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["IncidentRespondersResponse"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/src/modules/combat/api/incident.ts
+++ b/frontend/src/modules/combat/api/incident.ts
@@ -1,5 +1,5 @@
 import axios from '@/core/plugins/axios'
-import type { Incident, IncidentListResponse, IncidentResolveResponse } from '../models/incident'
+import type { Incident, IncidentListResponse } from '../models/incident'
 
 export const incidentApi = {
   /**
@@ -26,28 +26,12 @@ export const incidentApi = {
     return response.data
   },
 
-  /**
-   * Manually resolve an incident
-   */
-  async resolveIncident(
-    vaultId: string,
-    incidentId: string,
-    token: string,
-    success: boolean = true
-  ): Promise<IncidentResolveResponse> {
-    const response = await axios.post(
-      `/api/v1/game/vaults/${vaultId}/incidents/${incidentId}/resolve`,
-      null,
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-        params: {
-          success,
-        },
-      }
+  async assignResponders(vaultId: string, incidentId: string, dwellerIds: string[], token: string): Promise<void> {
+    await axios.post(
+      `/api/v1/game/vaults/${vaultId}/incidents/${incidentId}/responders`,
+      { dweller_ids: dwellerIds },
+      { headers: { Authorization: `Bearer ${token}` } }
     )
-    return response.data
   },
 
   /**

--- a/frontend/src/modules/combat/components/incidents/CombatModal.vue
+++ b/frontend/src/modules/combat/components/incidents/CombatModal.vue
@@ -104,16 +104,33 @@
           </div>
         </div>
       </div>
+
+      <div class="section">
+        <h3 class="section-title">&gt;&gt; RESPONSE TEAM</h3>
+        <div class="section-content">
+          <p class="expected-loot">Responders join this room before the next vault round.</p>
+          <div v-if="availableResponders.length" class="responder-list">
+            <UButton
+              v-for="dweller in availableResponders"
+              :key="dweller.id"
+              variant="secondary"
+              size="sm"
+              :disabled="assigningDwellerId === dweller.id"
+              @click="assignResponder(dweller.id)"
+            >
+              {{ assigningDwellerId === dweller.id ? 'ASSIGNING...' : `SEND ${dweller.first_name}` }}
+              — Lv. {{ dweller.level }} · {{ dweller.health }}/{{ dweller.max_health }} HP
+            </UButton>
+          </div>
+          <p v-else class="expected-loot">All available adults are already defending or away.</p>
+        </div>
+      </div>
     </div>
 
     <template #footer>
       <div class="modal-footer">
-        <UButton @click="handleResolve(true)" variant="primary" :disabled="isResolving">
-          {{ isResolving ? 'RESOLVING...' : 'RESOLVE INCIDENT' }}
-        </UButton>
-        <UButton @click="handleResolve(false)" variant="danger" :disabled="isResolving">
-          ABANDON ROOM
-        </UButton>
+        <span class="footer-note">Combat resolves automatically on the next vault round.</span>
+        <UButton @click="$emit('close')" variant="secondary">CLOSE</UButton>
       </div>
     </template>
 
@@ -130,6 +147,7 @@ import UModal from '@/core/components/ui/UModal.vue'
 import UButton from '@/core/components/ui/UButton.vue'
 import { usePolling } from '@/core/composables/usePolling'
 import { useToast } from '@/core/composables/useToast'
+import type { DwellerShort } from '@/modules/dwellers/models/dweller'
 import { useIncidentStore } from '../../stores/incident'
 import type { Incident } from '../../models/incident'
 import { IncidentType } from '../../models/incident'
@@ -137,13 +155,14 @@ import { IncidentType } from '../../models/incident'
 interface Props {
   incidentId: string
   vaultId: string
+  dwellers: DwellerShort[]
 }
 
 const props = defineProps<Props>()
 
 const emit = defineEmits<{
   close: []
-  resolved: []
+  responded: []
 }>()
 
 const authStore = useAuthStore()
@@ -152,7 +171,7 @@ const toast = useToast()
 
 const incident = ref<Incident | null>(null)
 const isLoading = ref(true)
-const isResolving = ref(false)
+const assigningDwellerId = ref<string | null>(null)
 // Lifecycle
 onMounted(async () => {
   await loadIncident()
@@ -163,7 +182,7 @@ async function loadIncident() {
   if (!authStore.token) return
 
   try {
-    const data = await incidentStore.fetchIncidents(props.vaultId, authStore.token)
+    await incidentStore.fetchIncidents(props.vaultId, authStore.token)
     incident.value = incidentStore.getIncidentById(props.incidentId) || null
     isLoading.value = false
   } catch {
@@ -174,19 +193,16 @@ async function loadIncident() {
 // Auto-refresh every 5 seconds while the modal is mounted.
 usePolling(loadIncident, { interval: 5_000, immediate: false })
 
-async function handleResolve(success: boolean) {
-  if (!authStore.token || isResolving.value) return
-
-  isResolving.value = true
-
+async function assignResponder(dwellerId: string) {
+  if (!authStore.token || assigningDwellerId.value) return
+  assigningDwellerId.value = dwellerId
   try {
-    await incidentStore.resolveIncident(props.vaultId, props.incidentId, authStore.token, success)
-    emit('resolved')
-    emit('close')
+    await incidentStore.assignResponders(props.vaultId, props.incidentId, [dwellerId], authStore.token)
+    emit('responded')
   } catch {
-    toast.error('Failed to resolve incident')
+    toast.error('Failed to assign responder')
   } finally {
-    isResolving.value = false
+    assigningDwellerId.value = null
   }
 }
 
@@ -224,12 +240,8 @@ const incidentIcon = computed(() => {
       return 'mdi:paw'
     case IncidentType.DEATHCLAW_ATTACK:
       return 'mdi:claw-mark'
-    case IncidentType.RADIATION_LEAK:
-      return 'mdi:radioactive'
-    case IncidentType.ELECTRICAL_FAILURE:
-      return 'mdi:lightning-bolt'
-    case IncidentType.WATER_CONTAMINATION:
-      return 'mdi:water-alert'
+    case IncidentType.FERAL_GHOUL_ATTACK:
+      return 'mdi:ghost'
     default:
       return 'mdi:alert-octagon'
   }
@@ -257,6 +269,16 @@ const estimatedCaps = computed(() => {
   const max = 50 + incident.value.difficulty * 100
   return `${min}-${max}`
 })
+
+const availableResponders = computed(() =>
+  props.dwellers.filter(
+    (dweller) =>
+      dweller.is_adult &&
+      dweller.health > 0 &&
+      dweller.room_id !== incident.value?.room_id &&
+      !['exploring', 'questing', 'dead'].includes(dweller.status)
+  )
+)
 </script>
 
 <style scoped>

--- a/frontend/src/modules/combat/components/incidents/IncidentAlert.vue
+++ b/frontend/src/modules/combat/components/incidents/IncidentAlert.vue
@@ -83,12 +83,8 @@ const incidentIcon = computed(() => {
       return 'mdi:paw'
     case IncidentType.DEATHCLAW_ATTACK:
       return 'mdi:claw-mark'
-    case IncidentType.RADIATION_LEAK:
-      return 'mdi:radioactive'
-    case IncidentType.ELECTRICAL_FAILURE:
-      return 'mdi:lightning-bolt'
-    case IncidentType.WATER_CONTAMINATION:
-      return 'mdi:water-alert'
+    case IncidentType.FERAL_GHOUL_ATTACK:
+      return 'mdi:ghost'
     default:
       return 'mdi:alert-octagon'
   }

--- a/frontend/src/modules/combat/models/incident.ts
+++ b/frontend/src/modules/combat/models/incident.ts
@@ -5,9 +5,6 @@ export enum IncidentType {
   DEATHCLAW_ATTACK = 'deathclaw_attack',
   FERAL_GHOUL_ATTACK = 'feral_ghoul_attack',
   FIRE = 'fire',
-  RADIATION_LEAK = 'radiation_leak',
-  ELECTRICAL_FAILURE = 'electrical_failure',
-  WATER_CONTAMINATION = 'water_contamination',
 }
 
 export enum IncidentStatus {
@@ -61,36 +58,12 @@ export interface IncidentListResponse {
   }>
 }
 
-export interface IncidentResolveResponse {
-  message: string
-  incident_id: string
-  loot: {
-    caps?: number
-    items?: Array<{
-      type: string
-      rarity?: string
-      name: string
-      quantity?: number
-    }>
-  } | null
-  caps_earned: number
-  items_earned: Array<{
-    type: string
-    rarity?: string
-    name: string
-    quantity?: number
-  }>
-}
-
 export const INCIDENT_ICON_MAP: Record<IncidentType, string> = {
   [IncidentType.RAIDER_ATTACK]: 'mdi:skull',
   [IncidentType.RADROACH_INFESTATION]: 'mdi:bug',
   [IncidentType.FIRE]: 'mdi:fire',
   [IncidentType.MOLE_RAT_ATTACK]: 'mdi:paw',
   [IncidentType.DEATHCLAW_ATTACK]: 'mdi:claw-mark',
-  [IncidentType.RADIATION_LEAK]: 'mdi:radioactive',
-  [IncidentType.ELECTRICAL_FAILURE]: 'mdi:lightning-bolt',
-  [IncidentType.WATER_CONTAMINATION]: 'mdi:water-alert',
   [IncidentType.FERAL_GHOUL_ATTACK]: 'mdi:ghost',
 }
 

--- a/frontend/src/modules/combat/models/index.ts
+++ b/frontend/src/modules/combat/models/index.ts
@@ -3,7 +3,6 @@ export {
   IncidentStatus,
   type Incident,
   type IncidentListResponse,
-  type IncidentResolveResponse,
 } from './incident'
 
 export {

--- a/frontend/src/modules/combat/stores/incident.ts
+++ b/frontend/src/modules/combat/stores/incident.ts
@@ -78,28 +78,19 @@ export const useIncidentStore = defineStore('incident', () => {
     }
   }
 
-  async function resolveIncident(
+  async function assignResponders(
     vaultId: string,
     incidentId: string,
-    token: string,
-    success: boolean = true
+    dwellerIds: string[],
+    token: string
   ): Promise<void> {
     try {
-      const response = await incidentApi.resolveIncident(vaultId, incidentId, token, success)
-
-      // Remove from active incidents
-      activeIncidentIds.value = activeIncidentIds.value.filter((id) => id !== incidentId)
-      incidents.value.delete(incidentId)
-
-      // Show loot notification
-      if (success && response.caps_earned > 0) {
-        showSuccess(`Incident Resolved! Earned ${response.caps_earned} caps`)
-      }
-
-      return Promise.resolve()
+      await incidentApi.assignResponders(vaultId, incidentId, dwellerIds, token)
+      await fetchIncidents(vaultId, token)
+      showSuccess('Responders assigned. They will fight on the next vault round.')
     } catch (err) {
-      handleStoreError(err, 'Failed to resolve incident')
-      showError('Resolution Failed: Failed to resolve incident')
+      handleStoreError(err, 'Failed to assign incident responders')
+      showError('Responder assignment failed')
       throw err
     }
   }
@@ -271,7 +262,7 @@ export const useIncidentStore = defineStore('incident', () => {
 
     // Actions
     fetchIncidents,
-    resolveIncident,
+    assignResponders,
     startPolling,
     stopPolling,
     clearIncidents,

--- a/frontend/src/modules/vault/views/VaultView.vue
+++ b/frontend/src/modules/vault/views/VaultView.vue
@@ -20,6 +20,7 @@ import UTooltip from '@/core/components/ui/UTooltip.vue'
 import SidePanel from '@/core/components/common/SidePanel.vue'
 import { useSidePanel } from '@/core/composables/useSidePanel'
 import { useToast } from '@/core/composables/useToast'
+import { usePolling } from '@/core/composables/usePolling'
 import type { RoomTemplate } from '@/modules/rooms/models/room'
 import { Icon } from '@iconify/vue'
 
@@ -111,6 +112,11 @@ const resourceRates = computed(() =>
 )
 
 const activeIncidents = computed(() => incidentStore.activeIncidents)
+
+usePolling(
+  () => (vaultId.value && authStore.token ? vaultStore.fetchGameState(vaultId.value, authStore.token) : undefined),
+  { interval: 60_000, immediate: false }
+)
 
 const loadVaultData = async (id: string) => {
   if (!id) {
@@ -276,7 +282,7 @@ const handleCombatModalClose = () => {
   selectedIncidentId.value = null
 }
 
-const handleIncidentResolved = async () => {
+const handleIncidentResponded = async () => {
   // Refresh vault data to update resources/stats
   if (vaultId.value && authStore.token) {
     await vaultStore.refreshVault(vaultId.value, authStore.token)
@@ -446,8 +452,9 @@ const handleIncidentResolved = async () => {
       v-if="showCombatModal && selectedIncidentId && vaultId"
       :incidentId="selectedIncidentId"
       :vaultId="vaultId"
+      :dwellers="dwellerStore.dwellers"
       @close="handleCombatModalClose"
-      @resolved="handleIncidentResolved"
+      @responded="handleIncidentResponded"
     />
   </div>
 </template>

--- a/frontend/src/modules/vault/views/VaultView.vue
+++ b/frontend/src/modules/vault/views/VaultView.vue
@@ -283,9 +283,9 @@ const handleCombatModalClose = () => {
 }
 
 const handleIncidentResponded = async () => {
-  // Refresh vault data to update resources/stats
   if (vaultId.value && authStore.token) {
     await vaultStore.refreshVault(vaultId.value, authStore.token)
+    await dwellerStore.fetchDwellersByVault(vaultId.value, authStore.token)
   }
 }
 </script>

--- a/frontend/tests/unit/components/incidents/IncidentAlert.test.ts
+++ b/frontend/tests/unit/components/incidents/IncidentAlert.test.ts
@@ -243,9 +243,7 @@ describe('IncidentAlert', () => {
       { type: IncidentType.RADROACH_INFESTATION, icon: 'mdi:bug' },
       { type: IncidentType.MOLE_RAT_ATTACK, icon: 'mdi:paw' },
       { type: IncidentType.DEATHCLAW_ATTACK, icon: 'mdi:claw-mark' },
-      { type: IncidentType.RADIATION_LEAK, icon: 'mdi:radioactive' },
-      { type: IncidentType.ELECTRICAL_FAILURE, icon: 'mdi:lightning-bolt' },
-      { type: IncidentType.WATER_CONTAMINATION, icon: 'mdi:water-alert' },
+      { type: IncidentType.FERAL_GHOUL_ATTACK, icon: 'mdi:ghost' },
     ]
 
     incidentTypes.forEach(({ type, icon }) => {

--- a/frontend/tests/unit/stores/incident.test.ts
+++ b/frontend/tests/unit/stores/incident.test.ts
@@ -175,38 +175,21 @@ describe('Incident Store', () => {
     })
   })
 
-  describe('resolveIncident', () => {
-    it('should resolve incident successfully', async () => {
+  describe('assignResponders', () => {
+    it('should refresh the incident after assigning a responder', async () => {
       const store = useIncidentStore()
+      vi.mocked(incidentApi.assignResponders).mockResolvedValueOnce()
+      vi.mocked(incidentApi.getActiveIncidents).mockResolvedValueOnce(mockIncidentList)
+      vi.mocked(incidentApi.getIncident).mockResolvedValueOnce(mockIncident)
 
-      store.incidents.set('incident-1', mockIncident)
-      store.activeIncidentIds = ['incident-1']
+      await store.assignResponders('vault-1', 'incident-1', ['dweller-1'], 'token')
 
-      vi.mocked(incidentApi.resolveIncident).mockResolvedValueOnce({
-        message: 'Incident resolved',
-        incident_id: 'incident-1',
-        caps_earned: 150,
-        items_earned: [],
-      })
-
-      await store.resolveIncident('vault-1', 'incident-1', 'token', true)
-
-      expect(store.activeIncidentIds).not.toContain('incident-1')
-      expect(store.incidents.has('incident-1')).toBe(false)
-      // Toast notification is shown (tested by integration, not mocked here)
-    })
-
-    it('should handle resolve failure', async () => {
-      const store = useIncidentStore()
-
-      store.incidents.set('incident-1', mockIncident)
-      store.activeIncidentIds = ['incident-1']
-
-      vi.mocked(incidentApi.resolveIncident).mockRejectedValueOnce(new Error('Resolve failed'))
-
-      await expect(store.resolveIncident('vault-1', 'incident-1', 'token')).rejects.toThrow()
-
-      // Toast error notification is shown (tested by integration, not mocked here)
+      expect(incidentApi.assignResponders).toHaveBeenCalledWith(
+        'vault-1',
+        'incident-1',
+        ['dweller-1'],
+        'token'
+      )
     })
   })
 

--- a/frontend/tests/unit/stores/incident.test.ts
+++ b/frontend/tests/unit/stores/incident.test.ts
@@ -190,6 +190,20 @@ describe('Incident Store', () => {
         ['dweller-1'],
         'token'
       )
+      expect(incidentApi.getActiveIncidents).toHaveBeenCalledWith('vault-1', 'token')
+      expect(incidentApi.getIncident).toHaveBeenCalledWith('vault-1', 'incident-1', 'token')
+    })
+
+    it('should rethrow assignment failures without refreshing the incident', async () => {
+      const store = useIncidentStore()
+      vi.mocked(incidentApi.assignResponders).mockRejectedValueOnce(new Error('Assignment failed'))
+
+      await expect(store.assignResponders('vault-1', 'incident-1', ['dweller-1'], 'token')).rejects.toThrow(
+        'Assignment failed'
+      )
+
+      expect(incidentApi.getActiveIncidents).not.toHaveBeenCalled()
+      expect(incidentApi.getIncident).not.toHaveBeenCalled()
     })
   })
 

--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -2,7 +2,17 @@
 set -euo pipefail
 
 # dev-up.sh — Start full Fallout Shelter dev environment (infra + BE + FE)
-# Usage: ./scripts/dev-up.sh
+# Usage: ./scripts/dev-up.sh [--reload]
+
+RELOAD_ARGS=()
+case "${1:-}" in
+  '') ;;
+  --reload) RELOAD_ARGS=(--reload) ;;
+  *)
+    echo "Usage: $0 [--reload]"
+    exit 64
+    ;;
+esac
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
@@ -61,10 +71,10 @@ echo ""
 # ── Step 4: Backend (tmux) ──────────────────────────────────────────────
 echo ""
 echo "═══════════════════════════════════════════════════════════════"
-echo "  3/4  Starting Backend (uvicorn) on :8000 (tmux: fallout-be)"
+echo "  3/4  Starting Backend (uvicorn) on :8000 (tmux: fallout-be)${RELOAD_ARGS:+ with reload}"
 echo "═══════════════════════════════════════════════════════════════"
 tmux new-session -d -s fallout-be -c "$ROOT/backend" \
-  'uv run uvicorn main:app --host 0.0.0.0 --port 8000'
+  "uv run uvicorn main:app --host 0.0.0.0 --port 8000 ${RELOAD_ARGS[*]}"
 echo ""
 
 # ── Step 5: Dramatiq workers (if not already running) ───────────────────

--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 # Usage: ./scripts/dev-up.sh [--reload]
 
 RELOAD_ARGS=()
+(( $# <= 1 )) || { echo "Usage: $0 [--reload]"; exit 64; }
+
 case "${1:-}" in
   '') ;;
   --reload) RELOAD_ARGS=(--reload) ;;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assign eligible dwellers to respond to active incidents.
  * Incident combat now resolves automatically during vault rounds.
  * Added feral ghoul attack incident support and iconography.
  * Active vault state refreshes periodically while open.

* **Bug Fixes**
  * Offline vaults no longer process or spawn incidents.
  * Improved validation and error handling for responder assignments.

* **Chores**
  * Added a development-server reload option and clarified session replacement behavior.
  * Updated the changelog and development guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->