### PR TITLE
fix: reward_service ValueError→HTTP 404/409 + EventBus cross-loop loc…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Fixed
 
+- **Quest completion 500 on full storage** — `reward_service.grant_item` now raises `ResourceNotFoundException`
+  (404, no storage row) and `ResourceConflictException` (409, storage full) instead of bare `ValueError`, so the
+  quest completion endpoint returns the correct HTTP status code
+- **Cross-thread EventBus / asyncpg InterfaceError race** — `EventBus.emit` locks are now keyed by
+  `(event_type, vault_id, event_loop)` so each Dramatiq worker thread gets its own lock; objective evaluators
+  use a loop-local session maker (via `set_current_session_maker`) so concurrent ticks never share a single
+  asyncpg connection, eliminating the `InterfaceError: another operation is in progress` (324×/24h on Hetzner)
 - **Exploration SSE channel** — the exploration coordinator published completion events to the vault owner id while
   the frontend subscribes to the vault id, so rewards never reached the client; the publish now targets the vault
   channel

--- a/backend/app/api/tasks.py
+++ b/backend/app/api/tasks.py
@@ -12,6 +12,7 @@ from pydantic import UUID4
 import app.core.dramatiq  # ruff: ignore[unused-import] — ensures broker is configured when dramatiq CLI imports this module
 from app.services.cleanup_service import cleanup_service
 from app.services.death_service import death_service
+from app.services.event_bus import event_bus
 from app.services.game_loop import game_loop_service
 
 logger = logging.getLogger(__name__)
@@ -76,6 +77,8 @@ def game_tick():
     else:
         logger.info(f"Game tick completed: {stats}")
         return stats
+    finally:
+        event_bus.clear_locks()
 
 
 @dramatiq.actor(actor_name="process_vault_tick", max_retries=3, min_backoff=30000)
@@ -123,6 +126,8 @@ def process_vault_tick(vault_id: str):
     else:
         logger.info(f"Vault {vault_id} tick completed")
         return result
+    finally:
+        event_bus.clear_locks()
 
 
 @dramatiq.actor(actor_name="check_permanent_deaths", max_retries=3, min_backoff=3600000)

--- a/backend/app/api/tasks.py
+++ b/backend/app/api/tasks.py
@@ -48,7 +48,7 @@ def game_tick():
             from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
             from app.core.config import settings
-            from app.services.objective_evaluators import evaluator_manager
+            from app.services.objective_evaluators import evaluator_manager, set_current_session_maker
             from app.services.objective_notifications import register_objective_event_handlers
 
             evaluator_manager.initialize()
@@ -61,6 +61,7 @@ def game_tick():
                 pool_pre_ping=True,
             )
             session_maker = async_sessionmaker(engine, expire_on_commit=False)
+            set_current_session_maker(session_maker)
 
             try:
                 async with session_maker() as session:
@@ -94,7 +95,7 @@ def process_vault_tick(vault_id: str):
             from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
             from app.core.config import settings
-            from app.services.objective_evaluators import evaluator_manager
+            from app.services.objective_evaluators import evaluator_manager, set_current_session_maker
             from app.services.objective_notifications import register_objective_event_handlers
 
             evaluator_manager.initialize()
@@ -107,6 +108,7 @@ def process_vault_tick(vault_id: str):
                 pool_pre_ping=True,
             )
             session_maker = async_sessionmaker(engine, expire_on_commit=False)
+            set_current_session_maker(session_maker)
 
             try:
                 async with session_maker() as session:

--- a/backend/app/services/event_bus.py
+++ b/backend/app/services/event_bus.py
@@ -89,6 +89,10 @@ class EventBus:
         self._emit_locks.clear()
         logger.debug("All event handlers cleared")
 
+    def clear_locks(self) -> None:
+        """Remove all emit locks while preserving subscriptions and handlers."""
+        self._emit_locks.clear()
+
     @staticmethod
     async def _safe_call(handler: EventHandler, event_type: GameEvent, vault_id: UUID4, data: dict[str, Any]) -> None:
         await handler(event_type, vault_id, data)

--- a/backend/app/services/event_bus.py
+++ b/backend/app/services/event_bus.py
@@ -45,7 +45,7 @@ class EventBus:
 
     def __init__(self) -> None:
         self._handlers: dict[GameEvent, list[EventHandler]] = defaultdict(list)
-        self._emit_locks: dict[tuple[GameEvent, UUID4], asyncio.Lock] = {}
+        self._emit_locks: dict[tuple[GameEvent, UUID4, int], asyncio.Lock] = {}
 
     def subscribe(self, event_type: GameEvent, handler: EventHandler) -> None:
         if handler not in self._handlers[event_type]:
@@ -60,7 +60,7 @@ class EventBus:
         shared database connection, while preserving independent delivery for
         other vaults and event types.
         """
-        lock = self._emit_locks.setdefault((event_type, vault_id), asyncio.Lock())
+        lock = self._emit_locks.setdefault((event_type, vault_id, id(asyncio.get_running_loop())), asyncio.Lock())
         async with lock:
             handlers = self._handlers.get(event_type, [])
             if not handlers:

--- a/backend/app/services/objective_evaluators.py
+++ b/backend/app/services/objective_evaluators.py
@@ -13,6 +13,7 @@ Example flow:
 """
 
 import abc
+import contextvars
 import logging
 from typing import Any
 
@@ -31,6 +32,17 @@ from app.utils.objective_constants import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Loop-local session maker: dramatiq worker threads each run ``asyncio.run(run_tick())``
+# with their own event loop, so handlers must open sessions from the maker bound to
+# the loop that emitted the event (not the module-global one, which would share a
+# single asyncpg connection across loops and trigger InterfaceError collisions).
+current_session_maker: contextvars.ContextVar[Any] = contextvars.ContextVar("current_session_maker", default=None)
+
+
+def set_current_session_maker(maker: Any) -> None:
+    """Set the session maker for the current event loop's context."""
+    current_session_maker.set(maker)
 
 
 class ObjectiveEvaluator(abc.ABC):
@@ -55,7 +67,8 @@ class ObjectiveEvaluator(abc.ABC):
 
     async def _handle_event(self, event_type: str, vault_id: UUID4, data: dict[str, Any]) -> None:
         logger.debug(f"[DEBUG] {self.__class__.__name__} received {event_type} for vault {vault_id} with data: {data}")
-        async with async_session_maker() as db_session:
+        maker = current_session_maker.get() or async_session_maker
+        async with maker() as db_session:
             objectives = await self._get_active_objectives(db_session, vault_id)
             for objective, link in objectives:
                 try:

--- a/backend/app/services/reward_service.py
+++ b/backend/app/services/reward_service.py
@@ -16,6 +16,7 @@ from app.models.storage import Storage
 from app.models.vault_objective import VaultObjectiveProgressLink
 from app.models.weapon import Weapon
 from app.services.event_bus import GameEvent, event_bus
+from app.utils.exceptions import ResourceConflictException, ResourceNotFoundException
 from app.utils.outfit_assets import get_outfit_image_url
 from app.utils.reward_delivery import persist_reward_change, reward_delivery_is_deferred
 from app.utils.weapon_assets import get_weapon_image_url
@@ -53,13 +54,13 @@ class RewardService:
         if not storage_obj:
             msg = f"No storage found for vault {vault_id}"
             logger.warning(msg)
-            raise ValueError(msg)
+            raise ResourceNotFoundException(Storage, vault_id, identifier_type="vault_id")
 
         available = await get_available_space(db_session, storage_obj.id)
         if available <= 0:
             msg = f"Storage full for vault {vault_id}"
             logger.warning(msg)
-            raise ValueError(msg)
+            raise ResourceConflictException(msg)
 
         item_type = item_data.get("item_type", "weapon")
         item_name = item_data.get("name", "Unknown Item")

--- a/backend/app/tests/test_api/test_quest.py
+++ b/backend/app/tests/test_api/test_quest.py
@@ -1,0 +1,64 @@
+"""Quest endpoint tests — error mapping for complete_quest."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.utils.exceptions import ResourceConflictException, ResourceNotFoundException
+
+
+@pytest.mark.asyncio
+async def test_complete_quest_storage_full_returns_409(
+    async_client,
+    superuser_token_headers: dict[str, str],
+) -> None:
+    """POST /quests/{vault_id}/{quest_id}/complete returns 409, not 500, when storage is full."""
+    vault_id = uuid4()
+    quest_id = uuid4()
+
+    with (
+        patch(
+            "app.api.v1.endpoints.quest.get_user_vault_or_403",
+            AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.api.v1.endpoints.quest.quest_service.complete_quest_and_free_party",
+            AsyncMock(side_effect=ResourceConflictException("Storage full for vault")),
+        ),
+    ):
+        response = await async_client.post(
+            f"/quests/{vault_id}/{quest_id}/complete",
+            headers=superuser_token_headers,
+        )
+    assert response.status_code == 409
+    assert "Storage full" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_complete_quest_no_storage_returns_404(
+    async_client,
+    superuser_token_headers: dict[str, str],
+) -> None:
+    """POST /quests/{vault_id}/{quest_id}/complete returns 404 when no storage exists."""
+    vault_id = uuid4()
+    quest_id = uuid4()
+    storage_model = MagicMock()
+    storage_model.__name__ = "Storage"
+
+    with (
+        patch(
+            "app.api.v1.endpoints.quest.get_user_vault_or_403",
+            AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.api.v1.endpoints.quest.quest_service.complete_quest_and_free_party",
+            AsyncMock(side_effect=ResourceNotFoundException(storage_model, vault_id)),
+        ),
+    ):
+        response = await async_client.post(
+            f"/quests/{vault_id}/{quest_id}/complete",
+            headers=superuser_token_headers,
+        )
+    assert response.status_code == 404
+    assert "Storage" in response.json()["detail"]

--- a/backend/app/tests/test_crud/test_quest.py
+++ b/backend/app/tests/test_crud/test_quest.py
@@ -11,6 +11,7 @@ from app.schemas.user import UserCreate
 from app.schemas.vault import VaultCreateWithUserID
 from app.tests.factory.users import create_fake_user
 from app.tests.factory.vaults import create_fake_vault
+from app.utils.exceptions import ResourceNotFoundException
 
 
 @pytest.mark.asyncio
@@ -625,7 +626,7 @@ async def test_quest_completion_rolls_back_when_any_reward_fails(async_session: 
     )
     await crud.quest_crud.assign_to_vault(async_session, quest.id, vault.id, is_visible=True)
 
-    with pytest.raises(ValueError, match="No storage found"):
+    with pytest.raises(ResourceNotFoundException, match="Storage"):
         await crud.quest_crud.complete(
             db_session=async_session,
             quest_entity_id=quest.id,

--- a/backend/app/tests/test_services/test_game_tick_concurrency.py
+++ b/backend/app/tests/test_services/test_game_tick_concurrency.py
@@ -13,8 +13,9 @@ trips the same single-operation invariant enforced by asyncpg.
 
 import asyncio
 import logging
+import threading
 from collections.abc import AsyncGenerator
-from typing import Any
+from typing import Any, ClassVar
 
 import asyncpg
 import pytest
@@ -27,6 +28,7 @@ from sqlalchemy.pool import StaticPool
 from sqlmodel import SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.services import objective_evaluators
 from app.services.event_bus import EventBus, GameEvent
 from app.services.objective_evaluators import ObjectiveEvaluator
 
@@ -54,6 +56,46 @@ class _ConcurrencyGuardedSession(AsyncSession):
             return await super().execute(*args, **kwargs)
         finally:
             _ConcurrencyGuardedSession._in_flight -= 1
+
+
+class _ThreadSafeGuardedSession(AsyncSession):
+    """AsyncSession enforcing one in-flight operation per connection, thread-safe.
+
+    State is keyed by the bound connection so that sessions from different
+    threads (each with their own connection post-fix) never collide, while
+    sessions sharing one connection (pre-fix) deterministically do.
+    """
+
+    _state_lock = threading.Lock()
+    _in_flight: ClassVar[dict[int, int]] = {}
+    collisions: ClassVar[int] = 0
+    executions: ClassVar[int] = 0
+
+    @classmethod
+    def reset(cls) -> None:
+        with cls._state_lock:
+            cls._in_flight.clear()
+            cls.collisions = 0
+            cls.executions = 0
+
+    async def execute(self, *args: Any, **kwargs: Any) -> Any:
+        conn_key = id(self.bind)
+        with _ThreadSafeGuardedSession._state_lock:
+            if _ThreadSafeGuardedSession._in_flight.get(conn_key, 0) > 0:
+                _ThreadSafeGuardedSession.collisions += 1
+                raise asyncpg.InterfaceError("another operation is in progress")
+            _ThreadSafeGuardedSession._in_flight[conn_key] = _ThreadSafeGuardedSession._in_flight.get(conn_key, 0) + 1
+            _ThreadSafeGuardedSession.executions += 1
+        try:
+            # Hold the simulated connection busy so a concurrent operation from
+            # the other worker thread deterministically trips the guard.
+            await asyncio.sleep(0.1)
+            return await super().execute(*args, **kwargs)
+        finally:
+            with _ThreadSafeGuardedSession._state_lock:
+                _ThreadSafeGuardedSession._in_flight[conn_key] = (
+                    _ThreadSafeGuardedSession._in_flight.get(conn_key, 0) - 1
+                )
 
 
 @pytest_asyncio.fixture
@@ -98,6 +140,19 @@ def _make_shared_session_maker(shared_conn: AsyncConnection) -> Any:
 
     def _maker() -> _ConcurrencyGuardedSession:
         return _ConcurrencyGuardedSession(
+            bind=shared_conn,
+            expire_on_commit=False,
+            autoflush=False,
+        )
+
+    return _maker
+
+
+def _make_thread_safe_session_maker(shared_conn: AsyncConnection) -> Any:
+    """Return a callable mimicking ``async_session_maker`` bound to shared_conn."""
+
+    def _maker() -> _ThreadSafeGuardedSession:
+        return _ThreadSafeGuardedSession(
             bind=shared_conn,
             expire_on_commit=False,
             autoflush=False,
@@ -173,3 +228,134 @@ async def test_overlapping_resource_collected_emits_do_not_collide_on_objective_
         _ConcurrencyGuardedSession.collisions = 0
         _ConcurrencyGuardedSession.executions = 0
         await shared_conn.close()
+
+
+def _seeded_engine() -> tuple[Any, Any, Any]:
+    """Create a fresh in-memory engine (SQLite, StaticPool) with schema.
+
+    Returns ``(engine, create_all, dispose)`` so callers control lifecycle
+    from their own event loop (``await create_all()`` / ``await dispose()``).
+    """
+
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        echo=False,
+        future=True,
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+
+    @event.listens_for(SQLModel.metadata, "before_create")
+    def _replace_jsonb_with_json(target, connection, **kw):
+        for table in target.tables.values():
+            for column in table.columns:
+                if isinstance(column.type, JSONB):
+                    column.type = JSON()
+
+    async def _create_all() -> None:
+        async with engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+
+    async def _dispose() -> None:
+        await engine.dispose()
+        event.remove(SQLModel.metadata, "before_create", _replace_jsonb_with_json)
+
+    return engine, _create_all, _dispose
+
+
+def test_cross_thread_ticks_do_not_collide_on_shared_objective_connection(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Dramatiq worker threads (each with its own event loop) must not share one DB connection.
+
+    Production: ``asyncio.run(run_tick())`` runs per worker thread with a fresh
+    loop, while objective evaluators open sessions from the module-global
+    ``async_session_maker``. Two ticks then issue queries through one pooled
+    asyncpg connection -> ``InterfaceError: another operation is in progress``.
+
+    Pre-fix the fix API ``set_current_session_maker`` does not exist, so both
+    threads fall back to the patched module-global maker sharing one connection
+    and deterministically collide. Post-fix each thread sets its own
+    loop-local session maker, so no connection is shared.
+    """
+    import threading
+    from unittest.mock import patch
+
+    _ThreadSafeGuardedSession.reset()
+
+    shared_engine, create_shared, dispose_shared = _seeded_engine()
+
+    async def _connect_shared() -> Any:
+        await create_shared()
+        return await shared_engine.connect()
+
+    shared_conn = asyncio.run(_connect_shared())
+    shared_maker = _make_thread_safe_session_maker(shared_conn)
+
+    bus = EventBus()
+    vaults = [
+        UUID4("00000000-0000-0000-0000-000000000002"),
+        UUID4("00000000-0000-0000-0000-000000000003"),
+    ]
+    barrier = threading.Barrier(2)
+    errors: list[BaseException] = []
+
+    def _worker_thread(vault_id: UUID4) -> threading.Thread:
+        def _run() -> None:
+            async def _main() -> None:
+                setter = getattr(objective_evaluators, "set_current_session_maker", None)
+                own_conn = None
+                own_dispose = None
+                if setter is not None:
+                    engine, create_all, dispose = _seeded_engine()
+                    await create_all()
+                    own_conn = await engine.connect()
+                    own_dispose = dispose
+                    setter(_make_thread_safe_session_maker(own_conn))
+                try:
+                    barrier.wait(timeout=30)
+                    for _ in range(3):
+                        await bus.emit(
+                            GameEvent.RESOURCE_COLLECTED,
+                            vault_id,
+                            {"resource_type": "caps", "amount": 10},
+                        )
+                finally:
+                    if own_conn is not None:
+                        await own_conn.close()
+                        await own_dispose()
+
+            try:
+                asyncio.run(_main())
+            except BaseException as exc:
+                errors.append(exc)
+
+        thread = threading.Thread(target=_run, name=f"worker-{vault_id}")
+        thread.start()
+        return thread
+
+    try:
+        _CollectLikeEvaluator(bus)
+
+        with (
+            patch("app.services.objective_evaluators.async_session_maker", shared_maker),
+            caplog.at_level(logging.ERROR, logger="app.services.event_bus"),
+        ):
+            threads = [_worker_thread(vault_id) for vault_id in vaults]
+            for thread in threads:
+                thread.join(timeout=60)
+
+        interface_errors = [
+            record
+            for record in caplog.records
+            if record.exc_info and isinstance(record.exc_info[1], asyncpg.InterfaceError)
+        ]
+        assert not errors, f"worker threads raised: {errors}"
+        assert _ThreadSafeGuardedSession.collisions == 0
+        assert _ThreadSafeGuardedSession.executions == 6
+        assert not interface_errors
+    finally:
+        bus.clear()
+        _ThreadSafeGuardedSession.reset()
+        asyncio.run(shared_conn.close())
+        asyncio.run(dispose_shared())

--- a/backend/app/tests/test_services/test_reward_service_extended.py
+++ b/backend/app/tests/test_services/test_reward_service_extended.py
@@ -15,6 +15,7 @@ from app.schemas.vault import VaultCreateWithUserID
 from app.services.reward_service import reward_service
 from app.tests.factory.users import create_fake_user
 from app.tests.factory.vaults import create_fake_vault
+from app.utils.exceptions import ResourceConflictException, ResourceNotFoundException
 
 
 @pytest.mark.asyncio
@@ -106,7 +107,7 @@ async def test_grant_item_no_storage_raises(async_session: AsyncSession) -> None
     vault_data = create_fake_vault()
     vault = await crud.vault.create(async_session, obj_in=VaultCreateWithUserID(**vault_data, user_id=user.id))
 
-    with pytest.raises(ValueError, match="No storage found"):
+    with pytest.raises(ResourceNotFoundException, match="Storage"):
         await reward_service.grant_item(
             async_session,
             vault.id,
@@ -144,7 +145,7 @@ async def test_grant_item_storage_full_raises(async_session: AsyncSession) -> No
     async_session.add(weapon)
     await async_session.commit()
 
-    with pytest.raises(ValueError, match="Storage full"):
+    with pytest.raises(ResourceConflictException, match="Storage full"):
         await reward_service.grant_item(
             async_session,
             vault.id,


### PR DESCRIPTION
…ks + loop-local session maker

Two production bugs fixed:

1. Quest completion 500 on full storage — grant_item now raises ResourceNotFoundException (404) and ResourceConflictException (409) instead of bare ValueError, so the endpoint returns the correct status.

2. Cross-thread EventBus / asyncpg InterfaceError race (324×/24h on Hetzner) — EventBus.emit locks now keyed by (event_type, vault_id, event_loop) so each Dramatiq worker thread gets its own lock; objective evaluators use a loop-local session maker via set_current_session_maker() so concurrent ticks never share a single asyncpg connection.

Tests: 4 new/updated failing tests (RED) → all GREEN post-fix.
Full suite: 1581 passed, 3 skipped. Ruff check + format clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Quest completion now returns clearer 404 errors when storage is unavailable and 409 errors when storage is full.
  - Improved concurrent event processing to prevent database operation conflicts across worker event loops.

- **Tests**
  - Added coverage for quest completion error responses and concurrent game-tick processing.
  - Updated reward and quest tests for the more specific error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->