### PR TITLE
fix: postpartum breeding cooldown and father's last-name inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## Unreleased
+
+### Fixed
+
+- **Postpartum breeding cooldown** — mothers who delivered within `birth_cooldown_hours` (default 6h) are excluded
+  from conception checks, so a high-affinity couple can no longer conceive again on the next game tick and produce
+  a baby every pregnancy cycle (3h) indefinitely
+- **Baby last-name inheritance** — newborns now take the father's last name by default, with a 20% chance of the
+  mother's last name (`maternal_last_name_chance`), so a baby no longer routinely shares the mother's exact full
+  name ("April Hernandez gave birth to April Hernandez!")
+
 ## [2.41.2](https://github.com/ElderEvil/falloutProject/compare/v2.41.1...v2.41.2) (2026-08-19)
 
 ### Fixed
@@ -60,17 +71,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 - **Objectives debug overlay** — the floating debug button and its `console.log` patching are removed from the
   player UI
-
-## Unreleased
-
-### Fixed
-
-- **Postpartum breeding cooldown** — mothers who delivered within `birth_cooldown_hours` (default 6h) are excluded
-  from conception checks, so a high-affinity couple can no longer conceive again on the next game tick and produce
-  a baby every pregnancy cycle (3h) indefinitely
-- **Baby last-name inheritance** — newborns now take the father's last name by default, with a 20% chance of the
-  mother's last name (`maternal_last_name_chance`), so a baby no longer routinely shares the mother's exact full
-  name ("April Hernandez gave birth to April Hernandez!")
 
 ## [2.40.0](https://github.com/ElderEvil/falloutProject/compare/v2.39.4...v2.40.0) (2026-08-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,26 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [2.41.2](https://github.com/ElderEvil/falloutProject/compare/v2.41.1...v2.41.2) (2026-08-19)
 
+### Fixed
+
+- **Quest completion 500 on full storage** — `reward_service.grant_item` now raises `ResourceNotFoundException`
+  (404, no storage row) and `ResourceConflictException` (409, storage full) instead of bare `ValueError`, so the
+  quest completion endpoint returns the correct HTTP status code
+- **Cross-thread EventBus / asyncpg InterfaceError race** — `EventBus.emit` locks are now keyed by
+  `(event_type, vault_id, event_loop)` so each Dramatiq worker thread gets its own lock; objective evaluators
+  use a loop-local session maker (via `set_current_session_maker`) so concurrent ticks never share a single
+  asyncpg connection, eliminating the `InterfaceError: another operation is in progress` (324×/24h on Hetzner)
+
 ## [2.41.1](https://github.com/ElderEvil/falloutProject/compare/v2.41.0...v2.41.1) (2026-08-18)
 
-## [2.41.0](https://github.com/ElderEvil/falloutProject/compare/v2.40.0...v2.41.0) (2026-08-17)
+### Fixed
 
-## Unreleased
+- **Frontend audit CRITICAL/MAJOR fixes** — dead camelCase token utilities replaced with kebab-case equivalents
+  across 20+ components (Tailwind v4 generates no utilities for camelCase tokens); broken `--color-terminal-green-*`
+  theme vars removed and remapped to the surviving semantic tokens; hardcoded hex colors migrated to design tokens
+  (happiness bands, quest palette, rarity, vault shell); router monkey-patch properly typed instead of implicit `any`
+
+## [2.41.0](https://github.com/ElderEvil/falloutProject/compare/v2.40.0...v2.41.0) (2026-08-17)
 
 ### Features
 
@@ -33,13 +48,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Fixed
 
-- **Quest completion 500 on full storage** — `reward_service.grant_item` now raises `ResourceNotFoundException`
-  (404, no storage row) and `ResourceConflictException` (409, storage full) instead of bare `ValueError`, so the
-  quest completion endpoint returns the correct HTTP status code
-- **Cross-thread EventBus / asyncpg InterfaceError race** — `EventBus.emit` locks are now keyed by
-  `(event_type, vault_id, event_loop)` so each Dramatiq worker thread gets its own lock; objective evaluators
-  use a loop-local session maker (via `set_current_session_maker`) so concurrent ticks never share a single
-  asyncpg connection, eliminating the `InterfaceError: another operation is in progress` (324×/24h on Hetzner)
 - **Exploration SSE channel** — the exploration coordinator published completion events to the vault owner id while
   the frontend subscribes to the vault id, so rewards never reached the client; the publish now targets the vault
   channel
@@ -53,9 +61,18 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **Objectives debug overlay** — the floating debug button and its `console.log` patching are removed from the
   player UI
 
-## [2.40.0](https://github.com/ElderEvil/falloutProject/compare/v2.39.4...v2.40.0) (2026-08-15)
-
 ## Unreleased
+
+### Fixed
+
+- **Postpartum breeding cooldown** — mothers who delivered within `birth_cooldown_hours` (default 6h) are excluded
+  from conception checks, so a high-affinity couple can no longer conceive again on the next game tick and produce
+  a baby every pregnancy cycle (3h) indefinitely
+- **Baby last-name inheritance** — newborns now take the father's last name by default, with a 20% chance of the
+  mother's last name (`maternal_last_name_chance`), so a baby no longer routinely shares the mother's exact full
+  name ("April Hernandez gave birth to April Hernandez!")
+
+## [2.40.0](https://github.com/ElderEvil/falloutProject/compare/v2.39.4...v2.40.0) (2026-08-15)
 
 ### Features
 

--- a/backend/app/core/game_config.py
+++ b/backend/app/core/game_config.py
@@ -406,6 +406,17 @@ class BreedingConfig(BaseSettings):
         le=1.0,
     )
     pregnancy_duration_hours: int = Field(default=3, description="Real-time hours", ge=1)
+    birth_cooldown_hours: int = Field(
+        default=6,
+        description="Hours after delivery before the mother can conceive again",
+        ge=0,
+    )
+    maternal_last_name_chance: float = Field(
+        default=0.2,
+        description="20% chance baby takes mother's last name instead of father's",
+        ge=0.0,
+        le=1.0,
+    )
     trait_inheritance_variance: int = Field(default=2, description="± SPECIAL variance from parents", ge=0)
     rarity_upgrade_chance: float = Field(
         default=0.15,

--- a/backend/app/services/breeding_service.py
+++ b/backend/app/services/breeding_service.py
@@ -132,7 +132,10 @@ class BreedingService:
         return set((await db_session.execute(query)).scalars().all())
 
     @staticmethod
-    async def _get_postpartum_mother_ids(db_session: AsyncSession) -> set[UUID4]:
+    async def _get_postpartum_mother_ids(
+        db_session: AsyncSession,
+        vault_id: UUID4,
+    ) -> set[UUID4]:
         """Get set of mother IDs still within the post-birth cooldown window.
 
         Mothers who delivered within ``birth_cooldown_hours`` are excluded from
@@ -141,14 +144,20 @@ class BreedingService:
 
         :param db_session: Database session
         :type db_session: AsyncSession
+        :param vault_id: Vault ID to scope the query
+        :type vault_id: UUID4
         :returns: Set of mother IDs in the postpartum cooldown window
         :rtype: set[UUID4]
         """
+        from app.models.dweller import Dweller
+
         cooldown_start = datetime.now(UTC).replace(tzinfo=None) - timedelta(
             hours=game_config.breeding.birth_cooldown_hours
         )
         query = (
             select(Pregnancy.mother_id)
+            .join(Dweller, Pregnancy.mother_id == Dweller.id)
+            .where(Dweller.vault_id == vault_id)
             .where(Pregnancy.status == PregnancyStatusEnum.DELIVERED)
             .where(Pregnancy.updated_at.is_not(None))
             .where(Pregnancy.updated_at >= cooldown_start)
@@ -270,7 +279,7 @@ class BreedingService:
         living_quarters_ids = [room.id for room in living_quarters]
         dwellers = await BreedingService._get_eligible_dwellers(db_session, vault_id, living_quarters_ids)
         pregnant_mother_ids = await BreedingService._get_pregnant_mother_ids(db_session)
-        postpartum_mother_ids = await BreedingService._get_postpartum_mother_ids(db_session)
+        postpartum_mother_ids = await BreedingService._get_postpartum_mother_ids(db_session, vault_id)
         unavailable_mother_ids = pregnant_mother_ids | postpartum_mother_ids
 
         new_pregnancies: list[Pregnancy] = []

--- a/backend/app/services/breeding_service.py
+++ b/backend/app/services/breeding_service.py
@@ -132,6 +132,30 @@ class BreedingService:
         return set((await db_session.execute(query)).scalars().all())
 
     @staticmethod
+    async def _get_postpartum_mother_ids(db_session: AsyncSession) -> set[UUID4]:
+        """Get set of mother IDs still within the post-birth cooldown window.
+
+        Mothers who delivered within ``birth_cooldown_hours`` are excluded from
+        conceiving again, preventing a high-affinity couple from producing a baby
+        every pregnancy cycle back-to-back.
+
+        :param db_session: Database session
+        :type db_session: AsyncSession
+        :returns: Set of mother IDs in the postpartum cooldown window
+        :rtype: set[UUID4]
+        """
+        cooldown_start = datetime.now(UTC).replace(tzinfo=None) - timedelta(
+            hours=game_config.breeding.birth_cooldown_hours
+        )
+        query = (
+            select(Pregnancy.mother_id)
+            .where(Pregnancy.status == PregnancyStatusEnum.DELIVERED)
+            .where(Pregnancy.updated_at.is_not(None))
+            .where(Pregnancy.updated_at >= cooldown_start)
+        )
+        return set((await db_session.execute(query)).scalars().all())
+
+    @staticmethod
     def _is_pair_eligible(
         dweller: Dweller,
         pregnant_mother_ids: set[UUID4],
@@ -246,12 +270,14 @@ class BreedingService:
         living_quarters_ids = [room.id for room in living_quarters]
         dwellers = await BreedingService._get_eligible_dwellers(db_session, vault_id, living_quarters_ids)
         pregnant_mother_ids = await BreedingService._get_pregnant_mother_ids(db_session)
+        postpartum_mother_ids = await BreedingService._get_postpartum_mother_ids(db_session)
+        unavailable_mother_ids = pregnant_mother_ids | postpartum_mother_ids
 
         new_pregnancies: list[Pregnancy] = []
         checked_pairs: set[tuple[str, str]] = set()
 
         for dweller in dwellers:
-            if not BreedingService._is_pair_eligible(dweller, pregnant_mother_ids, checked_pairs):
+            if not BreedingService._is_pair_eligible(dweller, unavailable_mother_ids, checked_pairs):
                 continue
 
             pair_key = tuple(sorted([str(dweller.id), str(dweller.partner_id)]))
@@ -439,7 +465,11 @@ class BreedingService:
 
         # Generate name (simplified - take from mother or father)
         first_name = random.choice([mother.first_name, father.first_name])
-        last_name = mother.last_name  # Use mother's last name by default
+        # Father's last name by default; occasionally inherit the mother's instead
+        if random.random() < game_config.breeding.maternal_last_name_chance:
+            last_name = mother.last_name
+        else:
+            last_name = father.last_name
 
         # Create a child dweller
         from app import crud

--- a/backend/app/tests/test_services/test_breeding_service.py
+++ b/backend/app/tests/test_services/test_breeding_service.py
@@ -317,6 +317,81 @@ async def test_check_for_conception_already_pregnant(
 
 
 @pytest.mark.asyncio
+async def test_check_for_conception_postpartum_cooldown(
+    async_session: AsyncSession,
+    vault: Vault,
+    living_quarters: Room,
+    male_dweller: Dweller,
+    female_dweller: Dweller,
+):
+    """Test that mothers who recently delivered can't conceive again within cooldown."""
+    # Make them partners in living quarters
+    male_dweller.partner_id = female_dweller.id
+    female_dweller.partner_id = male_dweller.id
+    male_dweller.room_id = living_quarters.id
+    female_dweller.room_id = living_quarters.id
+    await async_session.commit()
+
+    # Deliver a pregnancy now (within cooldown window)
+    pregnancy = await BreedingService.create_pregnancy(
+        async_session,
+        female_dweller.id,
+        male_dweller.id,
+    )
+    pregnancy.due_at = datetime.utcnow() - timedelta(hours=1)
+    await async_session.commit()
+    await BreedingService.deliver_baby(async_session, pregnancy.id)
+
+    # Try to conceive again while still in the postpartum cooldown
+    with patch("random.random", return_value=0.0):
+        pregnancies = await BreedingService.check_for_conception(
+            async_session,
+            vault.id,
+        )
+
+    assert pregnancies == []
+
+
+@pytest.mark.asyncio
+async def test_check_for_conception_after_cooldown_expires(
+    async_session: AsyncSession,
+    vault: Vault,
+    living_quarters: Room,
+    male_dweller: Dweller,
+    female_dweller: Dweller,
+):
+    """Test that mothers can conceive again once the postpartum cooldown expires."""
+    # Make them partners in living quarters
+    male_dweller.partner_id = female_dweller.id
+    female_dweller.partner_id = male_dweller.id
+    male_dweller.room_id = living_quarters.id
+    female_dweller.room_id = living_quarters.id
+    await async_session.commit()
+
+    # Deliver a pregnancy, then backdate the delivery outside the cooldown window
+    pregnancy = await BreedingService.create_pregnancy(
+        async_session,
+        female_dweller.id,
+        male_dweller.id,
+    )
+    pregnancy.due_at = datetime.utcnow() - timedelta(hours=1)
+    await async_session.commit()
+    await BreedingService.deliver_baby(async_session, pregnancy.id)
+
+    pregnancy.updated_at = datetime.utcnow() - timedelta(hours=game_config.breeding.birth_cooldown_hours + 1)
+    await async_session.commit()
+
+    with patch("random.random", return_value=0.0):
+        pregnancies = await BreedingService.check_for_conception(
+            async_session,
+            vault.id,
+        )
+
+    assert len(pregnancies) == 1
+    assert pregnancies[0].mother_id == female_dweller.id
+
+
+@pytest.mark.asyncio
 async def test_check_for_conception_only_one_in_living_quarters(
     async_session: AsyncSession,
     vault: Vault,
@@ -554,15 +629,42 @@ async def test_deliver_baby_inherits_name(
     pregnancy.due_at = datetime.utcnow() - timedelta(hours=1)
     await async_session.commit()
 
-    child = await BreedingService.deliver_baby(
-        async_session,
-        pregnancy.id,
-    )
+    with patch("random.random", return_value=0.99):
+        child = await BreedingService.deliver_baby(
+            async_session,
+            pregnancy.id,
+        )
 
     # First name should be from one of the parents
     assert child.first_name in [male_dweller.first_name, female_dweller.first_name]
 
-    # Last name should be mother's last name
+    # Father's last name is the default inheritance
+    assert child.last_name == male_dweller.last_name
+
+
+@pytest.mark.asyncio
+async def test_deliver_baby_inherits_mother_last_name_on_chance(
+    async_session: AsyncSession,
+    male_dweller: Dweller,
+    female_dweller: Dweller,
+):
+    """Test that baby occasionally inherits mother's last name."""
+    pregnancy = await BreedingService.create_pregnancy(
+        async_session,
+        female_dweller.id,
+        male_dweller.id,
+    )
+
+    pregnancy.due_at = datetime.utcnow() - timedelta(hours=1)
+    await async_session.commit()
+
+    # random.random < maternal_last_name_chance (0.2) triggers mother's last name
+    with patch("random.random", return_value=0.1):
+        child = await BreedingService.deliver_baby(
+            async_session,
+            pregnancy.id,
+        )
+
     assert child.last_name == female_dweller.last_name
 
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -606,7 +606,7 @@ lua = [
 
 [[package]]
 name = "fallout-shelter-fast-api"
-version = "2.41.1"
+version = "2.41.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosmtplib" },

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -11,32 +11,44 @@ AI-powered dweller interactions.
 
 **Current work:**
 
-- [x] **v2.32.0 planning** — Ruff lint cleanup + Google-style docstring convention enforcement.
-- [x] **v2.33.0 released** — Frontend type-aware linting and stale-request safety.
-- [x] **v2.33.2 patch released** — Automatic training-room assignments now create queue-visible training sessions.
-- [x] **v2.34.0 released** — Pydantic AI observability and structured-output reliability.
-- [x] **v2.35.0 released** — Automated release-version synchronization and Conventional Commit enforcement.
-- [x] **v2.38.0 released** — Server-owned room templates, visual equipment assets, and legendary boosted-vault fixtures.
+- [x] **v2.39.0–v2.39.4 released** — Resource production rate corrections (0.0003 → 0.1) for a livelier economy,
+      dweller thumbnail URL fix, release housekeeping.
+- [x] **v2.40.0 released** — Training tab UX (occupancy cards, live progress bars), UTC training timestamps, shared
+      training-room capacity helper.
+- [x] **v2.41.0 released** — Chat WebSocket streaming, vault event system, notification navigation, visual equipment
+      consistency, resource depletion warning, exploration rewards via SSE.
+- [x] **v2.41.1 released** — Frontend audit CRITICAL/MAJOR fixes (design-token migration, dead camelCase utilities,
+      router typing).
+- [x] **v2.41.2 released** — Quest storage 500 fix (ValueError → 404/409) and EventBus cross-loop asyncpg race fix.
+- [ ] **Postpartum breeding cooldown + last-name inheritance** — mothers can no longer re-conceive on the next tick
+      after delivery; newborns take the father's last name by default. (Branch `fix/breeding-cooldown-and-naming`.)
 
 ---
 
 ## Planned
 
-### Next Gameplay Balance Iteration — Resource Economy Baseline
+### Next Big Feature — Family Relations (Target: TBD)
 
-**Focus**: Make the existing 60-second resource tick create understandable staffing pressure before tuning broader
-economy systems.
+**Focus**: Make the existing breeding/relationship systems into a visible family experience: family trees,
+relationship depth, and legacy that persists across generations. This is the natural successor to the breeding
+cooldown and naming fixes.
 
-- ✅ **Define a starter-vault baseline** — two matching production workers are safe; reassigning one creates a
-  recoverable deficit on the next tick. See `docs/features/RESOURCE_ECONOMY_BALANCE.md` for the targets and tuning
-  sequence.
-- 🔄 **Calibrate production first** — reduce only the base production rate for the first pass; preserve room output
-  formulas, consumption, capacity, prices, thresholds, and rewards until live play-testing identifies the next lever.
-- 🔄 **Tune in isolated passes** — evaluate starter staffing, then population bands, then room tiers; change one
-  economic input per cycle and record the observed outcome.
+- 🔄 **Family tree visualization** — graph view of parents, children, siblings, and partners per dweller, building on
+  the existing `parent_1_id`/`parent_2_id`/`partner_id` fields and the world-map marker system.
+- 🔄 **Relationship depth** — affinity already gates conception; add visible relationship stages (acquaintance →
+  friends → partners → married) with event/notification hooks and stat bonuses.
+- 🔄 **Legacy & lineage** — surface generational data on dweller detail (house/family name, generation number,
+  inherited traits from `_calculate_inherited_stats`), and consider a "founder's vault" distinction.
+- 🔄 **Postpartum cooldown tuning** — after the cooldown ships, play-test the 6h default against high-affinity
+  couples and adjust `birth_cooldown_hours` before building on top of it.
 
-**Success criteria:** a player can see a resource trade-off within one 60-second tick, restore a healthy vault by
-staffing matching rooms, and identify the next expansion or training decision from the resource-rate feedback.
+**Guardrails:** delegate to the service layer (never CRUD directly) so events, notifications, and game-loop side
+effects fire exactly as they do for REST calls; respect the v2.35+ net-LOC-reduction constraint by extracting shared
+lineage/tree helpers instead of duplicating map-marker logic.
+
+**Success criteria:** a player can open any dweller's family tree, see relationship stage progression with
+notifications, and identify multi-generation lineage from the detail view — with backend coverage for the tree and
+stage-transition logic.
 
 ---
 
@@ -283,23 +295,37 @@ percentage change. Claims must be reproducible from committed commands or CI art
 as an improvement unless the release retains equivalent behaviour and test coverage. If the release is primarily a
 feature delivery, record its measurable non-functional impact rather than inventing an optimization claim.
 
-### v2.38.0 — Safe Room Construction & Visual Inventory (Released 2026-08-14)
+### v2.41.2 — Quest Storage & EventBus Race Fixes (Released 2026-08-19)
 
-**Focus**: Move room-definition authority to the backend and make the equipment and legendary-dweller systems easier
-to understand at a glance.
+**Focus**: Correct HTTP semantics on quest completion and eliminate a production cross-thread race that was
+poisoning the asyncpg connection pool.
 
-**Completed:**
+- ✅ **Quest storage 500 → 404/409** — `reward_service.grant_item` raises `ResourceNotFoundException` / `ResourceConflictException` instead of bare `ValueError`, so full-storage quest completion returns the right status.
+- ✅ **EventBus cross-loop race** — emit locks keyed by `(event_type, vault_id, event_loop)`; objective evaluators use
+  a loop-local session maker. Eliminates `InterfaceError: another operation is in progress` (324×/24h on Hetzner).
 
-- ✅ **Server-owned room templates** — builds now accept a template identity and grid coordinates; the backend derives
-  room economics, limits, capacities, and upgrade data. Buildable-room results are scoped to the active vault and the
-  grid and menu display the matching room artwork.
-- ✅ **Visual item and dweller assets** — storage and combat equipment views show outfit and weapon artwork;
-  legendary dwellers have full portraits and list/grid thumbnails. Existing records are backfilled by migration.
-- ✅ **Boosted-vault test fixtures** — boosted vaults receive a small equipped legendary team to make high-level
-  gameplay and asset checks immediately testable.
+### v2.41.0 — Chat Streaming, Vault Events & Notification UX (Released 2026-08-17)
 
-**Validation:** 36 focused backend tests cover the asset and boosted-vault flows; migration-head and changelog-parser
-checks pass. This was a feature release, so no performance claim is recorded.
+**Focus**: Real-time polish across chat, events, and notifications.
+
+- ✅ **Chat over WebSocket** — token streaming over the existing socket with automatic REST fallback.
+- ✅ **Vault event system** — weighted random events (resource cache, wanderer, raider scout) with caps/incidents.
+- ✅ **Notification navigation** — bell notifications route to the relevant view by type.
+- ✅ **Visual equipment consistency** — generated visuals constrained to equipped/owned items.
+- ✅ **Exploration rewards via SSE** — completion events publish to the vault channel the frontend subscribes to.
+
+### v2.40.0 — Training Tab UX (Released 2026-08-15)
+
+**Focus**: Make training rooms legible at a glance.
+
+- ✅ **Occupancy-card training rooms** — live capacity and per-room active training counts.
+- ✅ **Live progress bars** — fill even before the game-loop worker persists an update.
+- ✅ **UTC training timestamps** — consistent `Z`-suffixed ISO-8601 serialization.
+
+### v2.39.x — Resource Production Corrections (Released 2026-08-14)
+
+- ✅ **Livelier economy** — `base_production_rate` corrected 0.0003 → 0.01 → 0.1 across patch releases.
+- ✅ **Dweller thumbnail fix** — thumbnails resolve through `getStaticImageUrl` with the API base URL prepended.
 
 ### v2.33.2 — Training Queue Assignment Repair (Released 2026-08-13)
 
@@ -503,7 +529,7 @@ provide a way to retroactively fill gaps for existing active vaults.
 
 - Combat enhancements (statistics, log/replay)
 - Exploration enhancement (events with choices, journal)
-- Family visualization (relationship graph, family tree)
+- ~~Family visualization (relationship graph, family tree)~~ → **now the next big feature** (see Planned above)
 
 ### Phase 3: Endgame
 
@@ -564,6 +590,12 @@ provide a way to retroactively fill gaps for existing active vaults.
 
 | Version | Release      | Highlights                                                        |
 | ------- | ------------ | ----------------------------------------------------------------- |
+| v2.41.2 | Aug 19, 2026 | Quest storage 500 fix, EventBus cross-loop race fix               |
+| v2.41.1 | Aug 18, 2026 | Frontend audit CRITICAL/MAJOR fixes (design tokens)               |
+| v2.41.0 | Aug 17, 2026 | Chat WebSocket, vault events, notification navigation             |
+| v2.40.0 | Aug 15, 2026 | Training tab UX (occupancy cards, live progress)                  |
+| v2.39.x | Aug 14, 2026 | Resource production corrections, thumbnail URL fix                |
+| v2.38.0 | Aug 14, 2026 | Safe room construction, visual inventory                          |
 | v2.32.0 | Aug 12, 2026 | Ruff rule cleanup + Google-style docstrings                       |
 | v2.31.0 | Aug 12, 2026 | Map registration retry + failure notification, bio backfill fixes |
 | v2.30.0 | Aug 11, 2026 | Frontend refactor (async actions, SSE fallback, typecheck)        |
@@ -605,4 +637,4 @@ provide a way to retroactively fill gaps for existing active vaults.
 
 ---
 
-_Last updated: 2026-08-18_ (v2.40.0 released)
+_Last updated: 2026-08-19_ (v2.41.2 released; next focus: Family Relations)


### PR DESCRIPTION
## Summary

Fixes the prod "New Arrival" notification spam and the confusing identical-name births.

**Problem:** A high-affinity couple (e.g. affinity 100 → 100% conception chance per 60s tick) can conceive again on the very next tick after delivering. With a 3h pregnancy, the same couple produces a baby every 3 hours indefinitely, each emitting an identical-looking `New Arrival!` notification. Babies also always inherit the mother's last name plus a random parent first name, so a baby can routinely share the mother's exact full name ("April Hernandez gave birth to April Hernandez!").

## Changes

- `game_config.py`: `BreedingConfig` gains `birth_cooldown_hours` (default 6) and `maternal_last_name_chance` (default 0.2)
- `breeding_service.py`:
  - New `_get_postpartum_mother_ids()` — mothers who delivered within the cooldown window are excluded from `check_for_conception`
  - `deliver_baby` — newborn takes the **father's** last name by default, mother's at 20% chance
- `test_breeding_service.py`: 4 tests covering cooldown exclusion, cooldown expiry, father's last name default, and mother's-last-name chance branch

## Verification

- Full backend suite: **1584 passed, 3 skipped**
- `ruff check` + `ruff format` clean

## Docs

- `CHANGELOG.md`: backfilled empty 2.41.0–2.41.2 sections, added Unreleased entry for this fix
- `docs/ROADMAP.md`: refreshed through v2.41.2, promoted **Family Relations** as next big feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable postpartum cooldowns before a mother can conceive again.
  - Newborns now default to the father’s surname, with an option for the mother’s surname based on configured probability.
  - Added configuration controls for cooldown duration and surname inheritance.

- **Bug Fixes**
  - Documented fixes for quest storage, event handling, frontend tokens and themes, exploration updates, incidents, room relationships, and baby naming.

- **Documentation**
  - Updated the changelog and roadmap with recent releases and upcoming family-relations features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->