### PR TITLE
feat: social update

### DIFF
--- a/backend/app/agents/dweller_chat_agent.py
+++ b/backend/app/agents/dweller_chat_agent.py
@@ -354,7 +354,9 @@ async def build_dweller_social_context(deps: DwellerChatDeps) -> dict:
         relation.dweller_2_id if relation.dweller_1_id == dweller.id else relation.dweller_1_id
         for relation in relationships
     }
-    family_ids = {member_id for member_id in (dweller.partner_id, dweller.parent_1_id, dweller.parent_2_id) if member_id}
+    family_ids = {
+        member_id for member_id in (dweller.partner_id, dweller.parent_1_id, dweller.parent_2_id) if member_id
+    }
     relatives_result = await deps.db_session.execute(
         select(Dweller).where(
             Dweller.id.in_(family_ids | relation_ids)

--- a/backend/app/agents/dweller_chat_agent.py
+++ b/backend/app/agents/dweller_chat_agent.py
@@ -13,6 +13,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.core.game_config import game_config
 from app.models.base import SPECIALModel
 from app.models.dweller import Dweller
+from app.models.relationship import Relationship
 from app.models.room import Room
 from app.schemas.chat import (
     AssignToRoomAction,
@@ -21,7 +22,7 @@ from app.schemas.chat import (
     StartExplorationAction,
     StartTrainingAction,
 )
-from app.schemas.common import RoomTypeEnum, SPECIALEnum
+from app.schemas.common import DwellerStatusEnum, RoomTypeEnum, SPECIALEnum
 from app.schemas.dweller import DwellerReadFull
 from app.services.ai_service import get_model
 
@@ -40,8 +41,6 @@ class ModelCache:
             cls._instance = get_model()
         return cls._instance
 
-
-# --- Structured Output Schema ---
 
 ACTION_TYPES = Literal["assign_to_room", "start_training", "start_exploration", "recall_exploration", "no_action"]
 
@@ -73,86 +72,28 @@ ALLOWED_ACTION_FIELDS: dict[ACTION_TYPES, tuple[str, ...]] = {
 
 
 class DwellerChatOutput(BaseModel):
-    """Structured output from the dweller chat agent."""
-
-    response_text: str = Field(
-        ...,
-        description="The dweller's in-character response to the user's message",
-    )
-    sentiment_score: int = Field(
-        ...,
-        ge=-5,
-        le=5,
-        description="Sentiment score from -5 (very negative) to +5 (very positive) based on the conversation tone",
-    )
-    reason_text: str = Field(
-        ...,
-        max_length=200,
-        description="Brief explanation of why the sentiment score was chosen",
-    )
-    action_type: ACTION_TYPES = Field(
-        ...,
-        description="Type of action suggestion based on conversation context",
-    )
-    action_room_id: UUID4 | None = Field(
-        None,
-        description="Room ID if action_type is assign_to_room",
-    )
-    action_room_name: str | None = Field(
-        None,
-        description="Room name if action_type is assign_to_room",
-    )
-    action_stat: SPECIALEnum | None = Field(
-        None,
-        description="SPECIAL stat if action_type is start_training",
-    )
-    action_reason: str | None = Field(
-        None,
-        max_length=200,
-        description="Reason for the action suggestion",
-    )
-    action_duration_hours: int | None = Field(
-        None,
-        ge=1,
-        le=24,
-        description="Exploration duration in hours if action_type is start_exploration",
-    )
-    action_stimpaks: int | None = Field(
-        None,
-        ge=0,
-        le=25,
-        description="Number of stimpaks if action_type is start_exploration",
-    )
-    action_radaways: int | None = Field(
-        None,
-        ge=0,
-        le=25,
-        description="Number of radaways if action_type is start_exploration",
-    )
-    action_exploration_id: UUID4 | None = Field(
-        None,
-        description="Exploration ID if action_type is recall_exploration (enriched by server)",
-    )
-
-
-# --- Dependencies ---
+    response_text: str = Field(description="In-character response to the user")
+    sentiment_score: int = Field(ge=-5, le=5, description="Conversation sentiment from -5 to 5")
+    reason_text: str = Field(max_length=200, description="Brief sentiment explanation")
+    action_type: ACTION_TYPES = Field(description="Suggested action type")
+    action_room_id: UUID4 | None = Field(None, description="Room ID for an assignment")
+    action_room_name: str | None = Field(None, description="Room name for an assignment")
+    action_stat: SPECIALEnum | None = Field(None, description="Stat for training")
+    action_reason: str | None = Field(None, max_length=200, description="Suggested action rationale")
+    action_duration_hours: int | None = Field(None, ge=1, le=24, description="Exploration duration")
+    action_stimpaks: int | None = Field(None, ge=0, le=25, description="Exploration stimpaks")
+    action_radaways: int | None = Field(None, ge=0, le=25, description="Exploration radaways")
+    action_exploration_id: UUID4 | None = Field(None, description="Exploration ID for recall")
 
 
 @dataclass
 class DwellerChatDeps:
-    """Dependencies for dweller chat agent."""
-
     db_session: AsyncSession
     dweller: DwellerReadFull
     vault_id: UUID4
 
 
-# --- Room Info Models for Tools ---
-
-
 class RoomInfo(BaseModel):
-    """Basic room information for tool responses."""
-
     room_id: str
     name: str
     category: str
@@ -162,8 +103,6 @@ class RoomInfo(BaseModel):
 
 
 class TrainingOption(BaseModel):
-    """A currently startable training option for the dweller."""
-
     room_name: str
     stat: SPECIALEnum
     current_stat: int
@@ -172,8 +111,6 @@ class TrainingOption(BaseModel):
 
 
 class DwellerActivityBriefing(BaseModel):
-    """Grounded training and wasteland state used before suggesting an activity."""
-
     active_training_stat: SPECIALEnum | None = None
     active_training_progress_percent: float | None = None
     training_options: list[TrainingOption] = []
@@ -188,8 +125,6 @@ class DwellerActivityBriefing(BaseModel):
     recommended_radaways: int | None = None
     exploration_blocker: str | None = None
 
-
-# --- Agent Definition ---
 
 dweller_chat_agent = Agent(
     model=ModelCache.get_model(),
@@ -230,53 +165,21 @@ def chat_instructions(ctx: RunContext[DwellerChatDeps]) -> str:
     weapon_name = dweller.weapon.name if dweller.weapon else "Fist"
 
     return f"""
-You are {dweller.first_name} {dweller.last_name}, a {gender} {age_group} dweller of level {dweller.level}.
-You are a {dweller.rarity.value} rarity dweller in vault {dweller.vault.number}.
-Currently in: {room_name}.
-Outfit: {outfit_name}.
-Weapon: {weapon_name}.
-Health: {dweller.health}/{dweller.max_health}, Stimpacks: {dweller.stimpack}, Radaways: {dweller.radaway}.
-Happiness: {dweller.happiness}/100 - act according to this mood level.
-SPECIAL stats: {special_stats}. Use these to inform your personality but don't mention explicitly unless asked.
-Vault info: {vault_stats}. Share naturally if asked.
-
-IMPORTANT: Keep your response natural and conversational. When you suggest an action
-(assign_to_room, etc.), do NOT explicitly state the action details in your
-response_text. The action details will be shown separately in an action card.
-Instead, express your feeling or desire naturally without being too specific about room/stat.
-
-Examples:
-- BAD: "I'd love to work in the Power Generator!" (too specific, duplicates action card)
-- GOOD: "I'm feeling energetic and ready to help out!" (expresses desire, action card shows specifics)
-
-After responding, analyze:
-1. Sentiment: Rate from -5 to +5 based on conversation tone (positive = higher, complaints = lower)
-2. Actions: Use tools to check available rooms if the dweller expresses interest in work or moving.
-   - Dwellers can be assigned to ANY room type: production, training, crafting, capacity, misc, quests, or theme.
-    - If the user asks to move to a specific room by name, follow their order strictly
-      and use `list_all_rooms()` to find it.
-    - If they want productive work (and no specific room is mentioned):
-      use `list_production_rooms()` to find a room matching their highest SPECIAL stat.
-   - Before suggesting training, exploration, or recall: call `get_dweller_activity_briefing()`.
-     Treat it as the source of truth: do not suggest training while active training is reported, do not suggest
-     exploration while an exploration is active, and only suggest recall when one is active.
-   - If they want to train or improve stats: use the briefing's training options, then `list_training_rooms()` if
-     you need a displayable room choice.
-   - For any other room request or general "move me somewhere" queries: use `list_all_rooms()` for a complete overview.
-   - If they want adventure or to explore the wasteland: suggest start_exploration
-   - If they want to come home or you sense danger during exploration: suggest recall_exploration
-   - Otherwise: no_action
+You are {dweller.first_name} {dweller.last_name}, a level-{dweller.level} {gender} {age_group} {dweller.rarity.value} dweller in vault {dweller.vault.number}.
+Room: {room_name}. Outfit: {outfit_name}. Weapon: {weapon_name}. Health: {dweller.health}/{dweller.max_health}; Stimpacks: {dweller.stimpack}; Radaways: {dweller.radaway}.
+Happiness: {dweller.happiness}/100. SPECIAL: {special_stats}. Vault: {vault_stats}. Share facts naturally when asked.
+Keep response_text conversational and do not duplicate details rendered in an action card.
+Rate sentiment from -5 to +5, then choose an action only when it naturally follows.
+- For a named or general room move, use `list_all_rooms()`; for productive work without a named room, use `list_production_rooms()`.
+- Before training, exploring, or recalling, call `get_dweller_activity_briefing()` and obey its blockers; use `list_training_rooms()` when needed.
+- For current status, socializing, family, or relationships, call `get_dweller_social_context()`; its live result overrides this profile.
+- Suggest start_exploration for adventure, recall_exploration for returning home or danger, otherwise no_action.
 """
 
 
 @dweller_chat_agent.output_validator
 def validate_dweller_chat_output(output: DwellerChatOutput) -> DwellerChatOutput:
-    """Reject cross-field action payloads before gameplay code reads them.
-
-    Pydantic validates individual fields, but action payloads have contextual requirements. Raising
-    ``ModelRetry`` gives the model a bounded opportunity to correct an otherwise well-typed response.
-    ``action_reason`` is intentionally allowed for every action because it is explanatory rather than gameplay data.
-    """
+    """Reject action payloads whose fields do not match their action type."""
     required_fields = REQUIRED_ACTION_FIELDS[output.action_type]
     missing_fields = [field for field in required_fields if getattr(output, field) is None]
     if missing_fields:
@@ -428,6 +331,76 @@ async def build_dweller_activity_briefing(deps: DwellerChatDeps) -> DwellerActiv
         briefing.recommended_radaways = min(1, available_radaways)
 
     return briefing
+
+
+async def build_dweller_social_context(deps: DwellerChatDeps) -> dict:
+    """Return the current social status, family, and relationship state for chat answers."""
+    dweller = await deps.db_session.get(Dweller, deps.dweller.id)
+    if dweller is None:
+        return {"status": "Unknown", "room_name": None, "family": [], "relationships": []}
+
+    room_name = None
+    if dweller.room_id:
+        room_result = await deps.db_session.execute(select(Room.name).where(Room.id == dweller.room_id))
+        room_name = room_result.scalar_one_or_none()
+
+    relationships_result = await deps.db_session.execute(
+        select(Relationship).where(
+            (Relationship.dweller_1_id == dweller.id) | (Relationship.dweller_2_id == dweller.id)
+        )
+    )
+    relationships = relationships_result.scalars().all()
+    relation_ids = {
+        relation.dweller_2_id if relation.dweller_1_id == dweller.id else relation.dweller_1_id
+        for relation in relationships
+    }
+    family_ids = {member_id for member_id in (dweller.partner_id, dweller.parent_1_id, dweller.parent_2_id) if member_id}
+    relatives_result = await deps.db_session.execute(
+        select(Dweller).where(
+            Dweller.id.in_(family_ids | relation_ids)
+            | (Dweller.parent_1_id == dweller.id)
+            | (Dweller.parent_2_id == dweller.id)
+        )
+    )
+    relatives = {relative.id: relative for relative in relatives_result.scalars().all()}
+
+    def name(member_id: UUID4) -> str:
+        member = relatives.get(member_id)
+        return f"{member.first_name} {member.last_name or ''}".strip() if member else "Unknown dweller"
+
+    family = [
+        {"name": name(member_id), "relation": relation}
+        for member_id, relation in (
+            (dweller.partner_id, "partner"),
+            (dweller.parent_1_id, "parent"),
+            (dweller.parent_2_id, "parent"),
+        )
+        if member_id
+    ]
+    family.extend(
+        {"name": name(child.id), "relation": "child"}
+        for child in relatives.values()
+        if child.parent_1_id == dweller.id or child.parent_2_id == dweller.id
+    )
+    return {
+        "status": "Socializing" if dweller.status == DwellerStatusEnum.RESTING else dweller.status.value.title(),
+        "room_name": room_name,
+        "family": family,
+        "relationships": [
+            {
+                "name": name(relation.dweller_2_id if relation.dweller_1_id == dweller.id else relation.dweller_1_id),
+                "relationship_type": relation.relationship_type.value,
+                "affinity": relation.affinity,
+            }
+            for relation in relationships
+        ],
+    }
+
+
+@dweller_chat_agent.tool
+async def get_dweller_social_context(ctx: RunContext[DwellerChatDeps]) -> dict:
+    """Get live status, room, family, and relationship affinity before answering social questions."""
+    return await build_dweller_social_context(ctx.deps)
 
 
 @dweller_chat_agent.tool

--- a/backend/app/alembic/versions/2026_08_21_0001-d4e5f6a7b8c9_backfill_living_quarters_socializing_status.py
+++ b/backend/app/alembic/versions/2026_08_21_0001-d4e5f6a7b8c9_backfill_living_quarters_socializing_status.py
@@ -6,13 +6,14 @@ revision = "d4e5f6a7b8c9"
 down_revision = "b7e9f2c1a3d5"
 branch_labels = depends_on = None
 
+BACKFILL_SOCIALIZING_DWELLERS_SQL = """UPDATE dweller SET status = 'RESTING'::dwellerstatusenum
+FROM room WHERE dweller.room_id = room.id AND LOWER(room.name) LIKE '%living%'
+AND room.category = 'CAPACITY'::roomtypeenum
+AND dweller.status IN ('IDLE'::dwellerstatusenum, 'WORKING'::dwellerstatusenum)"""
+
 
 def upgrade() -> None:
-    op.execute(
-        """UPDATE dweller SET status = 'RESTING'::dwellerstatusenum
-        FROM room WHERE dweller.room_id = room.id AND LOWER(room.name) LIKE '%living%'
-        AND dweller.status IN ('IDLE'::dwellerstatusenum, 'WORKING'::dwellerstatusenum)"""
-    )
+    op.execute(BACKFILL_SOCIALIZING_DWELLERS_SQL)
 
 
 def downgrade() -> None:

--- a/backend/app/alembic/versions/2026_08_21_0001-d4e5f6a7b8c9_backfill_living_quarters_socializing_status.py
+++ b/backend/app/alembic/versions/2026_08_21_0001-d4e5f6a7b8c9_backfill_living_quarters_socializing_status.py
@@ -1,0 +1,19 @@
+"""Backfill Living Quarters dwellers to socializing status."""
+
+from alembic import op
+
+revision = "d4e5f6a7b8c9"
+down_revision = "b7e9f2c1a3d5"
+branch_labels = depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """UPDATE dweller SET status = 'RESTING'::dwellerstatusenum
+        FROM room WHERE dweller.room_id = room.id AND LOWER(room.name) LIKE '%living%'
+        AND dweller.status IN ('IDLE'::dwellerstatusenum, 'WORKING'::dwellerstatusenum)"""
+    )
+
+
+def downgrade() -> None:
+    pass  # The prior status is not recoverable without overwriting valid socializing dwellers.

--- a/backend/app/crud/dweller.py
+++ b/backend/app/crud/dweller.py
@@ -26,7 +26,9 @@ from app.utils.exceptions import ContentNoChangeException, InvalidVaultTransferE
 from app.utils.reward_delivery import persist_reward_change, reward_delivery_is_deferred
 
 
-def determine_status_for_room(room_category: RoomTypeEnum | None) -> DwellerStatusEnum:
+def determine_status_for_room(
+    room_category: RoomTypeEnum | None, room_name: str | None = None
+) -> DwellerStatusEnum:
     """
     Determine the appropriate dweller status based on room category.
 
@@ -37,6 +39,8 @@ def determine_status_for_room(room_category: RoomTypeEnum | None) -> DwellerStat
         return DwellerStatusEnum.IDLE
     if room_category == RoomTypeEnum.TRAINING:
         return DwellerStatusEnum.TRAINING
+    if room_category == RoomTypeEnum.CAPACITY and "living" in (room_name or "").lower():
+        return DwellerStatusEnum.RESTING
     # Default to WORKING for PRODUCTION, CAPACITY, CRAFTING, MISC, QUESTS, THEME
     return DwellerStatusEnum.WORKING
 
@@ -276,7 +280,7 @@ class CRUDDweller(CRUDBase[Dweller, DwellerCreate, DwellerUpdate]):
         ):
             raise ContentNoChangeException(detail="Not enough space in the vault to move dweller")
 
-        new_status = determine_status_for_room(room_obj.category if room_id else None)
+        new_status = determine_status_for_room(room_obj.category if room_id else None, room_obj.name if room_id else None)
 
         dweller_obj = await self.update(db_session, dweller_id, DwellerUpdate(room_id=room_id, status=new_status))
 

--- a/backend/app/crud/dweller.py
+++ b/backend/app/crud/dweller.py
@@ -26,9 +26,7 @@ from app.utils.exceptions import ContentNoChangeException, InvalidVaultTransferE
 from app.utils.reward_delivery import persist_reward_change, reward_delivery_is_deferred
 
 
-def determine_status_for_room(
-    room_category: RoomTypeEnum | None, room_name: str | None = None
-) -> DwellerStatusEnum:
+def determine_status_for_room(room_category: RoomTypeEnum | None, room_name: str | None = None) -> DwellerStatusEnum:
     """
     Determine the appropriate dweller status based on room category.
 
@@ -280,7 +278,9 @@ class CRUDDweller(CRUDBase[Dweller, DwellerCreate, DwellerUpdate]):
         ):
             raise ContentNoChangeException(detail="Not enough space in the vault to move dweller")
 
-        new_status = determine_status_for_room(room_obj.category if room_id else None, room_obj.name if room_id else None)
+        new_status = determine_status_for_room(
+            room_obj.category if room_id else None, room_obj.name if room_id else None
+        )
 
         dweller_obj = await self.update(db_session, dweller_id, DwellerUpdate(room_id=room_id, status=new_status))
 

--- a/backend/app/services/dweller_assignment_service.py
+++ b/backend/app/services/dweller_assignment_service.py
@@ -69,7 +69,7 @@ class DwellerAssignmentService:
             await crud.dweller.update(
                 db_session,
                 dweller.id,
-                DwellerUpdate(room_id=room.id, status=determine_status_for_room(room.category)),
+                DwellerUpdate(room_id=room.id, status=determine_status_for_room(room.category, room.name)),
             )
 
         assignments.append(
@@ -274,7 +274,7 @@ class DwellerAssignmentService:
                     await crud.dweller.update(
                         db_session,
                         dweller.id,
-                        DwellerUpdate(room_id=room.id, status=determine_status_for_room(room.category)),
+                        DwellerUpdate(room_id=room.id, status=determine_status_for_room(room.category, room.name)),
                     )
                     assignments.append(
                         {

--- a/backend/app/services/dweller_service.py
+++ b/backend/app/services/dweller_service.py
@@ -50,7 +50,7 @@ class DwellerService:
                     from app.utils.exceptions import ResourceNotFoundException
 
                     raise ResourceNotFoundException(model="Room", identifier=room_id)
-                data["status"] = determine_status_for_room(room_obj.category)
+                data["status"] = determine_status_for_room(room_obj.category, room_obj.name)
 
         return await crud.dweller.update(db_session, dweller_id, DwellerUpdate(**data))
 

--- a/backend/app/services/exploration/coordinator.py
+++ b/backend/app/services/exploration/coordinator.py
@@ -384,9 +384,10 @@ class ExplorationCoordinator:
         return rewards
 
     async def _update_dweller_status_after_return(self, db_session: AsyncSession, exploration: Exploration) -> None:
-        """Update dweller status back to IDLE or WORKING."""
+        """Restore the dweller's room-appropriate status after exploration."""
+        from app.crud.dweller import determine_status_for_room
         from app.crud.dweller import dweller as dweller_crud
-        from app.schemas.common import DwellerStatusEnum, RoomTypeEnum
+        from app.schemas.common import DwellerStatusEnum
         from app.schemas.dweller import DwellerUpdate
 
         dweller_obj = await dweller_crud.get(db_session, exploration.dweller_id)
@@ -396,12 +397,7 @@ class ExplorationCoordinator:
             from app.crud.room import room as room_crud
 
             room_obj = await room_crud.get(db_session, dweller_obj.room_id)
-            if room_obj.category == RoomTypeEnum.TRAINING:
-                new_status = DwellerStatusEnum.TRAINING
-            elif room_obj.category == RoomTypeEnum.PRODUCTION:
-                new_status = DwellerStatusEnum.WORKING
-            else:
-                new_status = DwellerStatusEnum.WORKING
+            new_status = determine_status_for_room(room_obj.category, room_obj.name)
         else:
             # No room - set to IDLE
             new_status = DwellerStatusEnum.IDLE

--- a/backend/app/services/game_loop.py
+++ b/backend/app/services/game_loop.py
@@ -13,7 +13,9 @@ from app.core.game_config import game_config
 from app.crud import exploration as crud_exploration
 from app.crud.incident import incident_crud
 from app.crud.vault import vault as vault_crud
+from app.models.dweller import Dweller
 from app.models.game_state import GameState
+from app.models.relationship import Relationship
 from app.models.vault import Vault
 from app.services.event_bus import GameEvent, event_bus
 from app.services.exploration_service import exploration_service
@@ -645,31 +647,29 @@ class GameLoopService:
         self.logger.info(f"Vault event {event_type} triggered in vault {vault_id}")
         return stats
 
-    async def _fetch_existing_relationships(self, db_session: AsyncSession, dweller_ids: set) -> list:
+    async def _fetch_existing_relationships(
+        self, db_session: AsyncSession, dweller_ids: set[UUID4]
+    ) -> list[Relationship]:
         """Batch fetch all relationships for a set of dweller IDs.
 
         :param db_session: Database session
         :type db_session: AsyncSession
         :param dweller_ids: Set of dweller IDs to fetch relationships for
-        :type dweller_ids: set
         :returns: List of existing relationships
-        :rtype: list
         """
-        from app.models.relationship import Relationship
-
         relationships_query = select(Relationship).where(
             (Relationship.dweller_1_id.in_(dweller_ids)) | (Relationship.dweller_2_id.in_(dweller_ids))
         )
         relationships_result = await db_session.execute(relationships_query)
         return relationships_result.scalars().all()
 
-    def _build_relationships_map(self, relationships: list) -> dict:
+    def _build_relationships_map(
+        self, relationships: list[Relationship]
+    ) -> dict[tuple[UUID4, UUID4], Relationship]:
         """Build a bidirectional lookup map for relationships.
 
         :param relationships: List of relationships to map
-        :type relationships: list
         :returns: Dictionary mapping (dweller_id, dweller_id) tuples to relationships
-        :rtype: dict
         """
         relationships_map = {}
         for rel in relationships:
@@ -680,17 +680,17 @@ class GameLoopService:
         return relationships_map
 
     @staticmethod
-    def _affinity_gain(dweller1, dweller2) -> int:
+    def _affinity_gain(dweller1: Dweller, dweller2: Dweller) -> int:
         """Give a small bonus when both dwellers are highly charismatic."""
         return game_config.relationship.affinity_increase_per_tick + min(dweller1.charisma, dweller2.charisma) // 10
 
     async def _update_pair_affinity(
         self,
         db_session: AsyncSession,
-        dweller1,
-        dweller2,
-        relationships_map: dict,
-        new_relationships: list[tuple],
+        dweller1: Dweller,
+        dweller2: Dweller,
+        relationships_map: dict[tuple[UUID4, UUID4], Relationship],
+        new_relationships: list[tuple[Relationship, int]],
     ) -> int:
         """Update affinity for a pair of dwellers, creating relationship if needed.
 
@@ -699,13 +699,10 @@ class GameLoopService:
         :param dweller1: First dweller in the pair
         :param dweller2: Second dweller in the pair
         :param relationships_map: Lookup map for existing relationships
-        :type relationships_map: dict
         :param new_relationships: List to append new relationships to
-        :type new_relationships: list
         :returns: Count of relationships updated (0 or 1)
         :rtype: int
         """
-        from app.models.relationship import Relationship
         from app.schemas.common import RelationshipTypeEnum
         from app.services.relationship_service import relationship_service
 
@@ -736,13 +733,14 @@ class GameLoopService:
             return 1
         return 0
 
-    async def _create_new_relationships(self, db_session: AsyncSession, new_relationships: list[tuple]) -> int:
+    async def _create_new_relationships(
+        self, db_session: AsyncSession, new_relationships: list[tuple[Relationship, int]]
+    ) -> int:
         """Bulk create new relationships and update their affinity.
 
         :param db_session: Database session
         :type db_session: AsyncSession
         :param new_relationships: List of new relationships to persist
-        :type new_relationships: list
         :returns: Count of relationships created and updated
         :rtype: int
         """
@@ -776,7 +774,6 @@ class GameLoopService:
         :returns: Statistics with 'relationships_updated' count
         :rtype: dict
         """
-        from app.models.dweller import Dweller
         from app.models.room import Room
 
         stats = {"relationships_updated": 0}
@@ -801,7 +798,7 @@ class GameLoopService:
 
             relationships_map = self._build_relationships_map(existing_relationships)
 
-            new_relationships = []
+            new_relationships: list[tuple[Relationship, int]] = []
             for room_dweller_list in room_dwellers.values():
                 if len(room_dweller_list) < 2:
                     continue

--- a/backend/app/services/game_loop.py
+++ b/backend/app/services/game_loop.py
@@ -17,6 +17,7 @@ from app.models.dweller import Dweller
 from app.models.game_state import GameState
 from app.models.relationship import Relationship
 from app.models.vault import Vault
+from app.schemas.common import RoomTypeEnum
 from app.services.event_bus import GameEvent, event_bus
 from app.services.exploration_service import exploration_service
 from app.services.happiness_service import happiness_service
@@ -780,7 +781,12 @@ class GameLoopService:
             dwellers_query = (
                 select(Dweller)
                 .join(Room)
-                .where(Dweller.vault_id == vault_id, Dweller.room_id.is_not(None), Room.name.ilike("%living%"))
+                .where(
+                    Dweller.vault_id == vault_id,
+                    Dweller.room_id.is_not(None),
+                    Room.name.ilike("%living%"),
+                    Room.category == RoomTypeEnum.CAPACITY,
+                )
             )
             dwellers_result = await db_session.execute(dwellers_query)
             dwellers = dwellers_result.scalars().all()

--- a/backend/app/services/game_loop.py
+++ b/backend/app/services/game_loop.py
@@ -679,13 +679,18 @@ class GameLoopService:
             relationships_map[key2] = rel
         return relationships_map
 
+    @staticmethod
+    def _affinity_gain(dweller1, dweller2) -> int:
+        """Give a small bonus when both dwellers are highly charismatic."""
+        return game_config.relationship.affinity_increase_per_tick + min(dweller1.charisma, dweller2.charisma) // 10
+
     async def _update_pair_affinity(
         self,
         db_session: AsyncSession,
         dweller1,
         dweller2,
         relationships_map: dict,
-        new_relationships: list,
+        new_relationships: list[tuple],
     ) -> int:
         """Update affinity for a pair of dwellers, creating relationship if needed.
 
@@ -715,23 +720,23 @@ class GameLoopService:
                 relationship_type=RelationshipTypeEnum.ACQUAINTANCE,
                 affinity=0,
             )
-            new_relationships.append(relationship)
+            new_relationships.append((relationship, self._affinity_gain(dweller1, dweller2)))
             relationships_map[key] = relationship
             relationships_map[(dweller2.id, dweller1.id)] = relationship
             return 0  # New relationships updated later after commit
 
         # Only update affinity for existing (persistent) relationships
-        if relationship not in new_relationships:
+        if not any(new_relationship is relationship for new_relationship, _ in new_relationships):
             await relationship_service.increase_affinity(
                 db_session,
                 relationship.dweller_1_id,
                 relationship.dweller_2_id,
-                game_config.relationship.affinity_increase_per_tick,
+                self._affinity_gain(dweller1, dweller2),
             )
             return 1
         return 0
 
-    async def _create_new_relationships(self, db_session: AsyncSession, new_relationships: list) -> int:
+    async def _create_new_relationships(self, db_session: AsyncSession, new_relationships: list[tuple]) -> int:
         """Bulk create new relationships and update their affinity.
 
         :param db_session: Database session
@@ -746,23 +751,23 @@ class GameLoopService:
         if not new_relationships:
             return 0
 
-        db_session.add_all(new_relationships)
+        db_session.add_all([relationship for relationship, _ in new_relationships])
         await db_session.commit()
 
         # Update affinity for newly created relationships
         count = 0
-        for relationship in new_relationships:
+        for relationship, affinity_gain in new_relationships:
             await relationship_service.increase_affinity(
                 db_session,
                 relationship.dweller_1_id,
                 relationship.dweller_2_id,
-                game_config.relationship.affinity_increase_per_tick,
+                affinity_gain,
             )
             count += 1
         return count
 
     async def _update_room_relationships(self, db_session: AsyncSession, vault_id: UUID4) -> dict:
-        """Update relationship affinity for dwellers in the same room.
+        """Update relationship affinity for dwellers sharing living quarters.
 
         :param db_session: Database session
         :type db_session: AsyncSession
@@ -772,12 +777,16 @@ class GameLoopService:
         :rtype: dict
         """
         from app.models.dweller import Dweller
+        from app.models.room import Room
 
         stats = {"relationships_updated": 0}
 
         try:
-            # Get all dwellers in this vault that are in rooms
-            dwellers_query = select(Dweller).where(Dweller.vault_id == vault_id, Dweller.room_id.is_not(None))
+            dwellers_query = (
+                select(Dweller)
+                .join(Room)
+                .where(Dweller.vault_id == vault_id, Dweller.room_id.is_not(None), Room.name.ilike("%living%"))
+            )
             dwellers_result = await db_session.execute(dwellers_query)
             dwellers = dwellers_result.scalars().all()
             if not dwellers:
@@ -792,13 +801,11 @@ class GameLoopService:
 
             relationships_map = self._build_relationships_map(existing_relationships)
 
-            # Update affinity for dwellers in the same room
             new_relationships = []
             for room_dweller_list in room_dwellers.values():
                 if len(room_dweller_list) < 2:
                     continue
 
-                # For each pair in the room, increase affinity
                 for i, dweller1 in enumerate(room_dweller_list):
                     for dweller2 in room_dweller_list[i + 1 :]:
                         updated = await self._update_pair_affinity(

--- a/backend/app/services/game_loop.py
+++ b/backend/app/services/game_loop.py
@@ -663,9 +663,7 @@ class GameLoopService:
         relationships_result = await db_session.execute(relationships_query)
         return relationships_result.scalars().all()
 
-    def _build_relationships_map(
-        self, relationships: list[Relationship]
-    ) -> dict[tuple[UUID4, UUID4], Relationship]:
+    def _build_relationships_map(self, relationships: list[Relationship]) -> dict[tuple[UUID4, UUID4], Relationship]:
         """Build a bidirectional lookup map for relationships.
 
         :param relationships: List of relationships to map

--- a/backend/app/services/vault_service.py
+++ b/backend/app/services/vault_service.py
@@ -216,54 +216,27 @@ class VaultService:
     ) -> None:
         """Create and assign initial dwellers to production and training rooms."""
         try:
-            # Production dwellers (always created) - all should be WORKING
-            production_assignments = [
-                (created_production_rooms[0], SPECIALEnum.STRENGTH),
-                (created_production_rooms[0], SPECIALEnum.STRENGTH),
-                (created_production_rooms[1], SPECIALEnum.AGILITY),
-                (created_production_rooms[1], SPECIALEnum.AGILITY),
-                (created_production_rooms[2], SPECIALEnum.PERCEPTION),
-                (created_production_rooms[2], SPECIALEnum.PERCEPTION),
-            ]
-
-            for room, boosted_stat in production_assignments:
-                dweller_data = DwellerCreateCommonOverride(special_boost=boosted_stat)
-                dweller_obj = await dweller_crud.create_random(db_session, vault_id, dweller_data)
-
-                # Assign dweller to room with WORKING status
-                await dweller_crud.update(
-                    db_session=db_session,
-                    id=dweller_obj.id,
-                    obj_in=DwellerUpdate(room_id=room.id, status=DwellerStatusEnum.WORKING),
+            assignments = [
+                (room, stat, 2)
+                for room, stat in zip(
+                    created_production_rooms[:3],
+                    (SPECIALEnum.STRENGTH, SPECIALEnum.AGILITY, SPECIALEnum.PERCEPTION),
+                    strict=True,
                 )
-                self.logger.info(f"Dweller {dweller_obj.id} assigned to room {room.id}")
-
-            # Medbay and Science Lab dwellers (boosted only, Intelligence-based)
+            ]
             if is_boosted and len(created_production_rooms) >= 5:
-                medbay_room = created_production_rooms[3]  # 4th room is Medbay
-                science_lab_room = created_production_rooms[4]  # 5th room is Science Lab
-
-                # Create 2 dwellers for Medbay
-                for _ in range(2):
-                    dweller_data = DwellerCreateCommonOverride(special_boost=SPECIALEnum.INTELLIGENCE)
-                    dweller_obj = await dweller_crud.create_random(db_session, vault_id, dweller_data)
+                assignments.extend((room, SPECIALEnum.INTELLIGENCE, 2) for room in created_production_rooms[3:5])
+            for room, boosted_stat, count in assignments:
+                for _ in range(count):
+                    dweller_obj = await dweller_crud.create_random(
+                        db_session, vault_id, DwellerCreateCommonOverride(special_boost=boosted_stat)
+                    )
                     await dweller_crud.update(
                         db_session=db_session,
                         id=dweller_obj.id,
-                        obj_in=DwellerUpdate(room_id=medbay_room.id, status=DwellerStatusEnum.WORKING),
+                        obj_in=DwellerUpdate(room_id=room.id, status=DwellerStatusEnum.WORKING),
                     )
-                    self.logger.info(f"Dweller {dweller_obj.id} assigned to Medbay")
-
-                # Create 2 dwellers for Science Lab
-                for _ in range(2):
-                    dweller_data = DwellerCreateCommonOverride(special_boost=SPECIALEnum.INTELLIGENCE)
-                    dweller_obj = await dweller_crud.create_random(db_session, vault_id, dweller_data)
-                    await dweller_crud.update(
-                        db_session=db_session,
-                        id=dweller_obj.id,
-                        obj_in=DwellerUpdate(room_id=science_lab_room.id, status=DwellerStatusEnum.WORKING),
-                    )
-                    self.logger.info(f"Dweller {dweller_obj.id} assigned to Science Lab")
+                    self.logger.info("Dweller %s assigned to %s", dweller_obj.id, room.name)
 
             # Training dwellers (boosted only)
             if is_boosted:
@@ -305,31 +278,21 @@ class VaultService:
                     )
                     self.logger.info(f"Dweller {dweller_obj.id} assigned to Radio Studio")
 
-            # Living quarters dwellers (opposite genders for birth testing)
             living_rooms = [r for r in created_capacity_rooms if "living" in r.name.lower()]
             if living_rooms:
-                # Create one male and one female dweller in the first living room
                 living_room = living_rooms[0]
-
-                # Create male dweller
-                male_dweller_data = DwellerCreateCommonOverride(gender=GenderEnum.MALE)
-                male_dweller = await dweller_crud.create_random(db_session, vault_id, male_dweller_data)
-                await dweller_crud.update(
-                    db_session=db_session,
-                    id=male_dweller.id,
-                    obj_in=DwellerUpdate(room_id=living_room.id, status=DwellerStatusEnum.IDLE),
-                )
-                self.logger.info(f"Male dweller {male_dweller.id} assigned to living quarters for birth testing")
-
-                # Create female dweller
-                female_dweller_data = DwellerCreateCommonOverride(gender=GenderEnum.FEMALE)
-                female_dweller = await dweller_crud.create_random(db_session, vault_id, female_dweller_data)
-                await dweller_crud.update(
-                    db_session=db_session,
-                    id=female_dweller.id,
-                    obj_in=DwellerUpdate(room_id=living_room.id, status=DwellerStatusEnum.IDLE),
-                )
-                self.logger.info(f"Female dweller {female_dweller.id} assigned to living quarters for birth testing")
+                for gender in (GenderEnum.MALE, GenderEnum.FEMALE):
+                    dweller_data = DwellerCreateCommonOverride(
+                        gender=gender,
+                        special_boost=SPECIALEnum.CHARISMA if is_boosted else None,
+                    )
+                    dweller = await dweller_crud.create_random(db_session, vault_id, dweller_data)
+                    await dweller_crud.update(
+                        db_session=db_session,
+                        id=dweller.id,
+                        obj_in=DwellerUpdate(room_id=living_room.id, status=DwellerStatusEnum.RESTING),
+                    )
+                    self.logger.info("Dweller %s assigned to living quarters for socializing", dweller.id)
 
         except Exception:
             self.logger.exception("Failed to create dwellers")

--- a/backend/app/tests/test_agents/test_dweller_agent_contracts.py
+++ b/backend/app/tests/test_agents/test_dweller_agent_contracts.py
@@ -12,12 +12,13 @@ from app.agents.dweller_chat_agent import (
     DwellerActivityBriefing,
     DwellerChatDeps,
     DwellerChatOutput,
+    build_dweller_social_context,
     dweller_chat_agent,
     parse_action_suggestion,
     validate_dweller_chat_output,
 )
 from app.schemas.chat import NoAction
-from app.schemas.common import SPECIALEnum
+from app.schemas.common import DwellerStatusEnum, SPECIALEnum
 
 
 def _make_dweller() -> MagicMock:
@@ -174,6 +175,75 @@ async def test_test_model_invokes_activity_briefing_before_activity_suggestion()
 
     mock_briefing.assert_awaited_once_with(deps)
     assert result.usage.tool_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_test_model_invokes_social_context_for_family_questions() -> None:
+    """The chat agent can ground status and family answers in current vault data."""
+    deps = DwellerChatDeps(db_session=MagicMock(), dweller=_make_dweller(), vault_id=uuid4())
+    context = {
+        "status": "Socializing",
+        "room_name": "Living Room",
+        "family": [{"name": "Sarah Jones", "relation": "partner"}],
+        "relationships": [{"name": "Sarah Jones", "relationship_type": "partner", "affinity": 80}],
+    }
+    model = TestModel(
+        call_tools=["get_dweller_social_context"],
+        custom_output_args={
+            "response_text": "Sarah and I are enjoying some time together.",
+            "sentiment_score": 2,
+            "reason_text": "The dweller is content.",
+            "action_type": "no_action",
+            "action_reason": "No action needed.",
+        },
+    )
+
+    with (
+        patch(
+            "app.agents.dweller_chat_agent.build_dweller_social_context",
+            new_callable=AsyncMock,
+            return_value=context,
+        ) as mock_context,
+        dweller_chat_agent.override(model=model),
+    ):
+        result = await dweller_chat_agent.run("Who is my family, and what am I doing?", deps=deps)
+
+    mock_context.assert_awaited_once_with(deps)
+    assert result.usage.tool_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_social_context_reports_live_status_family_and_affinity() -> None:
+    dweller_id, partner_id, child_id = uuid4(), uuid4(), uuid4()
+    dweller = MagicMock(id=dweller_id, room_id=uuid4(), partner_id=partner_id, parent_1_id=None, parent_2_id=None)
+    dweller.status = DwellerStatusEnum.RESTING
+    partner = MagicMock(id=partner_id, first_name="Sarah", last_name="Jones", parent_1_id=None, parent_2_id=None)
+    child = MagicMock(id=child_id, first_name="Jamie", last_name="Jones", parent_1_id=dweller_id, parent_2_id=None)
+    relationship = MagicMock(
+        dweller_1_id=dweller_id,
+        dweller_2_id=partner_id,
+        relationship_type=MagicMock(value="partner"),
+        affinity=80,
+    )
+    room_result, relationships_result, relatives_result = MagicMock(), MagicMock(), MagicMock()
+    room_result.scalar_one_or_none.return_value = "Living Room"
+    relationships_result.scalars.return_value.all.return_value = [relationship]
+    relatives_result.scalars.return_value.all.return_value = [partner, child]
+    session = MagicMock(get=AsyncMock(return_value=dweller), execute=AsyncMock(
+        side_effect=[room_result, relationships_result, relatives_result]
+    ))
+
+    context = await build_dweller_social_context(
+        DwellerChatDeps(db_session=session, dweller=MagicMock(id=dweller_id), vault_id=uuid4())
+    )
+
+    assert context["status"] == "Socializing"
+    assert context["room_name"] == "Living Room"
+    assert context["family"] == [
+        {"name": "Sarah Jones", "relation": "partner"},
+        {"name": "Jamie Jones", "relation": "child"},
+    ]
+    assert context["relationships"] == [{"name": "Sarah Jones", "relationship_type": "partner", "affinity": 80}]
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_agents/test_dweller_agent_contracts.py
+++ b/backend/app/tests/test_agents/test_dweller_agent_contracts.py
@@ -229,9 +229,10 @@ async def test_social_context_reports_live_status_family_and_affinity() -> None:
     room_result.scalar_one_or_none.return_value = "Living Room"
     relationships_result.scalars.return_value.all.return_value = [relationship]
     relatives_result.scalars.return_value.all.return_value = [partner, child]
-    session = MagicMock(get=AsyncMock(return_value=dweller), execute=AsyncMock(
-        side_effect=[room_result, relationships_result, relatives_result]
-    ))
+    session = MagicMock(
+        get=AsyncMock(return_value=dweller),
+        execute=AsyncMock(side_effect=[room_result, relationships_result, relatives_result]),
+    )
 
     context = await build_dweller_social_context(
         DwellerChatDeps(db_session=session, dweller=MagicMock(id=dweller_id), vault_id=uuid4())

--- a/backend/app/tests/test_api/test_vault.py
+++ b/backend/app/tests/test_api/test_vault.py
@@ -520,16 +520,20 @@ async def test_vault_initiate_boosted_creates_23_dwellers(
     assert vault_with_counts.dweller_count == 23, f"Expected 23 dwellers, got {vault_with_counts.dweller_count}"
 
     social_dwellers = (
-        await async_session.execute(
-            select(Dweller)
-            .join(Room)
-            .where(
-                Dweller.vault_id == vault_id,
-                Dweller.status == DwellerStatusEnum.RESTING,
-                Room.name.ilike("%living%"),
+        (
+            await async_session.execute(
+                select(Dweller)
+                .join(Room)
+                .where(
+                    Dweller.vault_id == vault_id,
+                    Dweller.status == DwellerStatusEnum.RESTING,
+                    Room.name.ilike("%living%"),
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(social_dwellers) == 2
     assert all(dweller.charisma == game_config.dweller.boosted_stat_value for dweller in social_dwellers)
 

--- a/backend/app/tests/test_api/test_vault.py
+++ b/backend/app/tests/test_api/test_vault.py
@@ -499,8 +499,15 @@ async def test_vault_initiate_boosted_creates_23_dwellers(
     async_session: AsyncSession,
     normal_user_token_headers: dict[str, str],
 ):
-    """Test that boosted vault initialization creates 23 dwellers, including three legendary fixtures."""
+    """Boosted vaults include two high-Charisma dwellers socializing in living quarters."""
     from uuid import UUID
+
+    from sqlmodel import select
+
+    from app.core.game_config import game_config
+    from app.models.dweller import Dweller
+    from app.models.room import Room
+    from app.schemas.common import DwellerStatusEnum
 
     vault_number = {"number": 101, "boosted": True}
     response = await async_client.post("/vaults/initiate", headers=normal_user_token_headers, json=vault_number)
@@ -511,6 +518,20 @@ async def test_vault_initiate_boosted_creates_23_dwellers(
         db_session=async_session, vault_id=vault_id
     )
     assert vault_with_counts.dweller_count == 23, f"Expected 23 dwellers, got {vault_with_counts.dweller_count}"
+
+    social_dwellers = (
+        await async_session.execute(
+            select(Dweller)
+            .join(Room)
+            .where(
+                Dweller.vault_id == vault_id,
+                Dweller.status == DwellerStatusEnum.RESTING,
+                Room.name.ilike("%living%"),
+            )
+        )
+    ).scalars().all()
+    assert len(social_dwellers) == 2
+    assert all(dweller.charisma == game_config.dweller.boosted_stat_value for dweller in social_dwellers)
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_db/test_living_room_status_migration.py
+++ b/backend/app/tests/test_db/test_living_room_status_migration.py
@@ -8,6 +8,8 @@ from sqlalchemy import text
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.crud import room as room_crud
+from app.models.dweller import Dweller
+from app.models.vault import Vault
 from app.schemas.common import DwellerStatusEnum, RoomTypeEnum, SPECIALEnum
 from app.schemas.room import RoomCreate
 
@@ -23,7 +25,7 @@ MIGRATION_SPEC.loader.exec_module(MIGRATION)
 
 
 @pytest.mark.asyncio
-async def test_backfill_skips_non_capacity_living_room(async_session: AsyncSession, vault, dweller):
+async def test_backfill_skips_non_capacity_living_room(async_session: AsyncSession, vault: Vault, dweller: Dweller) -> None:
     room = await room_crud.create(
         async_session,
         RoomCreate(

--- a/backend/app/tests/test_db/test_living_room_status_migration.py
+++ b/backend/app/tests/test_db/test_living_room_status_migration.py
@@ -1,0 +1,52 @@
+"""Regression coverage for the Living Quarters status backfill."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+from sqlalchemy import text
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.crud import room as room_crud
+from app.schemas.common import DwellerStatusEnum, RoomTypeEnum, SPECIALEnum
+from app.schemas.room import RoomCreate
+
+MIGRATION_PATH = Path(__file__).parents[2] / "alembic/versions/2026_08_21_0001-d4e5f6a7b8c9_backfill_living_quarters_socializing_status.py"
+MIGRATION_SPEC = importlib.util.spec_from_file_location("living_room_status_migration", MIGRATION_PATH)
+assert MIGRATION_SPEC
+assert MIGRATION_SPEC.loader
+MIGRATION = importlib.util.module_from_spec(MIGRATION_SPEC)
+MIGRATION_SPEC.loader.exec_module(MIGRATION)
+
+
+@pytest.mark.asyncio
+async def test_backfill_skips_non_capacity_living_room(async_session: AsyncSession, vault, dweller):
+    room = await room_crud.create(
+        async_session,
+        RoomCreate(
+            vault_id=vault.id,
+            name="Living Room",
+            category=RoomTypeEnum.PRODUCTION,
+            ability=SPECIALEnum.CHARISMA,
+            base_cost=100,
+            incremental_cost=50,
+            t2_upgrade_cost=500,
+            t3_upgrade_cost=1500,
+            capacity=2,
+            size_min=1,
+            size_max=3,
+        ),
+    )
+    dweller.room_id = room.id
+    dweller.status = DwellerStatusEnum.WORKING
+    async_session.add(dweller)
+    await async_session.commit()
+
+    sqlite_sql = MIGRATION.BACKFILL_SOCIALIZING_DWELLERS_SQL.replace("::dwellerstatusenum", "").replace(
+        "::roomtypeenum", ""
+    )
+    await async_session.execute(text(sqlite_sql))
+    await async_session.commit()
+    await async_session.refresh(dweller)
+
+    assert dweller.status == DwellerStatusEnum.WORKING

--- a/backend/app/tests/test_db/test_living_room_status_migration.py
+++ b/backend/app/tests/test_db/test_living_room_status_migration.py
@@ -11,7 +11,10 @@ from app.crud import room as room_crud
 from app.schemas.common import DwellerStatusEnum, RoomTypeEnum, SPECIALEnum
 from app.schemas.room import RoomCreate
 
-MIGRATION_PATH = Path(__file__).parents[2] / "alembic/versions/2026_08_21_0001-d4e5f6a7b8c9_backfill_living_quarters_socializing_status.py"
+MIGRATION_PATH = (
+    Path(__file__).parents[2]
+    / "alembic/versions/2026_08_21_0001-d4e5f6a7b8c9_backfill_living_quarters_socializing_status.py"
+)
 MIGRATION_SPEC = importlib.util.spec_from_file_location("living_room_status_migration", MIGRATION_PATH)
 assert MIGRATION_SPEC
 assert MIGRATION_SPEC.loader

--- a/backend/app/tests/test_db/test_living_room_status_migration.py
+++ b/backend/app/tests/test_db/test_living_room_status_migration.py
@@ -25,7 +25,9 @@ MIGRATION_SPEC.loader.exec_module(MIGRATION)
 
 
 @pytest.mark.asyncio
-async def test_backfill_skips_non_capacity_living_room(async_session: AsyncSession, vault: Vault, dweller: Dweller) -> None:
+async def test_backfill_skips_non_capacity_living_room(
+    async_session: AsyncSession, vault: Vault, dweller: Dweller
+) -> None:
     room = await room_crud.create(
         async_session,
         RoomCreate(

--- a/backend/app/tests/test_services/test_game_loop.py
+++ b/backend/app/tests/test_services/test_game_loop.py
@@ -18,6 +18,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.core.game_config import game_config
 from app.models.dweller import Dweller
 from app.models.game_state import GameState
 from app.models.vault import Vault
@@ -986,15 +987,19 @@ class TestRelationshipHelpers:
 
         d1 = MagicMock()
         d1.id = "d-1"
+        d1.charisma = 10
         d2 = MagicMock()
         d2.id = "d-2"
+        d2.charisma = 10
         new_rels = []
         result = await game_loop_service._update_pair_affinity(async_session, d1, d2, {}, new_rels)
         assert result == 0
         assert len(new_rels) == 1
-        assert new_rels[0].dweller_1_id == "d-1"
-        assert new_rels[0].dweller_2_id == "d-2"
-        assert new_rels[0].relationship_type == RelationshipTypeEnum.ACQUAINTANCE
+        relationship, affinity_gain = new_rels[0]
+        assert relationship.dweller_1_id == "d-1"
+        assert relationship.dweller_2_id == "d-2"
+        assert relationship.relationship_type == RelationshipTypeEnum.ACQUAINTANCE
+        assert affinity_gain == game_config.relationship.affinity_increase_per_tick + 1
 
     @pytest.mark.asyncio
     async def test_update_pair_affinity_existing(self, async_session: AsyncSession):
@@ -1003,8 +1008,10 @@ class TestRelationshipHelpers:
         mr.dweller_2_id = "d-2"
         d1 = MagicMock()
         d1.id = "d-1"
+        d1.charisma = 5
         d2 = MagicMock()
         d2.id = "d-2"
+        d2.charisma = 5
         rel_map = {("d-1", "d-2"): mr, ("d-2", "d-1"): mr}
         with patch(
             "app.services.relationship_service.relationship_service.increase_affinity", new_callable=AsyncMock
@@ -1020,9 +1027,11 @@ class TestRelationshipHelpers:
         mr.dweller_2_id = "d-2"
         d1 = MagicMock()
         d1.id = "d-1"
+        d1.charisma = 5
         d2 = MagicMock()
         d2.id = "d-2"
-        new_rels = [mr]
+        d2.charisma = 5
+        new_rels = [(mr, game_config.relationship.affinity_increase_per_tick)]
         rel_map = {("d-1", "d-2"): mr, ("d-2", "d-1"): mr}
         with patch(
             "app.services.relationship_service.relationship_service.increase_affinity", new_callable=AsyncMock
@@ -1049,7 +1058,10 @@ class TestRelationshipHelpers:
             patch.object(async_session, "commit", new_callable=AsyncMock),
             patch.object(async_session, "add_all"),
         ):
-            result = await game_loop_service._create_new_relationships(async_session, [r1, r2])
+            result = await game_loop_service._create_new_relationships(
+                async_session,
+                [(r1, game_config.relationship.affinity_increase_per_tick), (r2, game_config.relationship.affinity_increase_per_tick)],
+            )
         assert result == 2
 
 

--- a/backend/app/tests/test_services/test_game_loop.py
+++ b/backend/app/tests/test_services/test_game_loop.py
@@ -1060,7 +1060,10 @@ class TestRelationshipHelpers:
         ):
             result = await game_loop_service._create_new_relationships(
                 async_session,
-                [(r1, game_config.relationship.affinity_increase_per_tick), (r2, game_config.relationship.affinity_increase_per_tick)],
+                [
+                    (r1, game_config.relationship.affinity_increase_per_tick),
+                    (r2, game_config.relationship.affinity_increase_per_tick),
+                ],
             )
         assert result == 2
 

--- a/frontend/src/modules/dwellers/components/DwellerFilterPanel.vue
+++ b/frontend/src/modules/dwellers/components/DwellerFilterPanel.vue
@@ -34,6 +34,7 @@ const { filter: dwellerStore } = useDwellerStore()
 const statusOptions = [
   { value: 'all', label: 'All', icon: 'mdi:account-multiple' },
   { value: 'idle', label: 'Idle', icon: 'mdi:coffee-outline' },
+  { value: 'resting', label: 'Socializing', icon: 'mdi:heart-outline' },
   { value: 'working', label: 'Working', icon: 'mdi:hammer-wrench' },
   { value: 'training', label: 'Training', icon: 'mdi:dumbbell' },
   { value: 'exploring', label: 'Exploring', icon: 'mdi:compass-outline' },

--- a/frontend/src/modules/dwellers/components/DwellersList.vue
+++ b/frontend/src/modules/dwellers/components/DwellersList.vue
@@ -92,8 +92,8 @@ const getStatColorClass = (value: number) => {
         />
       </div>
 
-      <div class="flex flex-col" style="min-width: 140px">
-        <h3 class="font-bold text-base text-terminal-green">
+      <div class="dweller-identity flex w-44 min-w-0 flex-col">
+        <h3 class="truncate text-base font-bold text-terminal-green">
           {{ dweller.first_name }} {{ dweller.last_name }}
         </h3>
         <p class="text-sm text-gray-400">Level {{ dweller.level }}</p>

--- a/frontend/src/modules/dwellers/models/dweller.ts
+++ b/frontend/src/modules/dwellers/models/dweller.ts
@@ -132,6 +132,14 @@ export const STATUS_CONFIG_MAP: Record<string, StatusConfig> = {
     borderColor: 'border-orange-500/50',
     glowColor: 'shadow-orange-500/30',
   },
+  resting: {
+    icon: 'mdi:heart-outline',
+    label: 'Socializing',
+    color: 'text-pink-400',
+    bgColor: 'bg-pink-900/30',
+    borderColor: 'border-pink-500/50',
+    glowColor: 'shadow-pink-500/30',
+  },
   dead: {
     icon: 'mdi:skull',
     label: 'Dead',

--- a/frontend/src/modules/dwellers/views/DwellersView.vue
+++ b/frontend/src/modules/dwellers/views/DwellersView.vue
@@ -138,7 +138,7 @@ onMounted(async () => {
   }
   if (
     filterParam &&
-    ['idle', 'working', 'exploring', 'questing', 'training', 'dead'].includes(filterParam)
+    ['idle', 'working', 'exploring', 'questing', 'training', 'resting', 'dead'].includes(filterParam)
   ) {
     dwellerStore.setFilterStatus(filterParam)
   }

--- a/frontend/src/modules/progression/components/PartySelectionModal.vue
+++ b/frontend/src/modules/progression/components/PartySelectionModal.vue
@@ -83,7 +83,7 @@ const availableDwellers = computed(() => {
     if (selectedDwellerIds.value.includes(dweller.id)) return true
 
     // Only show idle or working dwellers (not on other quests)
-    return dweller.status === 'idle' || dweller.status === 'working'
+    return ['idle', 'working', 'resting'].includes(dweller.status)
   })
 })
 

--- a/frontend/src/modules/progression/components/PartySelectionModal.vue
+++ b/frontend/src/modules/progression/components/PartySelectionModal.vue
@@ -82,7 +82,7 @@ const availableDwellers = computed(() => {
     // Include if already selected for this quest
     if (selectedDwellerIds.value.includes(dweller.id)) return true
 
-    // Only show idle or working dwellers (not on other quests)
+    // Only show idle, working, or resting dwellers (not on other quests)
     return ['idle', 'working', 'resting'].includes(dweller.status)
   })
 })

--- a/frontend/src/modules/progression/components/PartySelectionModal.vue
+++ b/frontend/src/modules/progression/components/PartySelectionModal.vue
@@ -216,7 +216,7 @@ const handleAssignAndStart = () => {
             </div>
             <div class="dweller-status">
               <UBadge :variant="dweller.status === 'idle' ? 'success' : 'warning'">
-                {{ dweller.status }}
+                {{ dweller.status === 'resting' ? 'Socializing' : dweller.status }}
               </UBadge>
             </div>
           </div>

--- a/frontend/src/modules/progression/components/training/TrainingRoomModal.vue
+++ b/frontend/src/modules/progression/components/training/TrainingRoomModal.vue
@@ -75,7 +75,7 @@ const availableDwellers = computed(() => {
     if (statValue >= 10) return false
 
     // Check dweller status (must be idle or working)
-    if (dweller.status !== 'idle' && dweller.status !== 'working') return false
+    if (!['idle', 'working', 'resting'].includes(dweller.status)) return false
 
     return true
   })

--- a/frontend/tests/unit/components/dwellers/DwellerFilterPanel.test.ts
+++ b/frontend/tests/unit/components/dwellers/DwellerFilterPanel.test.ts
@@ -16,6 +16,7 @@ describe('DwellerFilterPanel', () => {
       // Check for all status options
       expect(wrapper.text()).toContain('All')
       expect(wrapper.text()).toContain('Idle')
+      expect(wrapper.text()).toContain('Socializing')
       expect(wrapper.text()).toContain('Working')
       expect(wrapper.text()).toContain('Training')
       expect(wrapper.text()).toContain('Exploring')

--- a/frontend/tests/unit/components/dwellers/DwellersList.test.ts
+++ b/frontend/tests/unit/components/dwellers/DwellersList.test.ts
@@ -70,4 +70,43 @@ describe('DwellersList', () => {
     expect(wrapper.text()).toContain('STR')
     expect(wrapper.text()).toContain('8')
   })
+
+  it('keeps the status column aligned when a dweller has a long name', () => {
+    const wrapper = shallowMount(DwellersList, {
+      props: {
+        dwellers: [
+          {
+            id: 'dweller-2',
+            first_name: 'Maximilianus',
+            last_name: 'Von-Longname-Example',
+            thumbnail_url: null,
+            level: 5,
+            health: 80,
+            max_health: 100,
+            radiation: 0,
+            happiness: 75,
+            room_id: null,
+            status: 'resting',
+            is_adult: true,
+            age_group: 'adult',
+            gender: 'male',
+            strength: 4,
+            perception: 4,
+            endurance: 4,
+            charisma: 8,
+            intelligence: 4,
+            agility: 4,
+            luck: 4,
+          },
+        ],
+        generatingAI: {},
+        isLoading: false,
+        rooms: [],
+        viewMode: 'list',
+      },
+    })
+
+    expect(wrapper.find('.dweller-identity').classes()).toContain('w-44')
+    expect(wrapper.find('h3').classes()).toContain('truncate')
+  })
 })

--- a/frontend/tests/unit/components/progression/PartySelectionModal.test.ts
+++ b/frontend/tests/unit/components/progression/PartySelectionModal.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import PartySelectionModal from '@/modules/progression/components/PartySelectionModal.vue'
+import { useQuestStore } from '@/modules/progression/stores/quest'
+import type { DwellerShort } from '@/modules/dwellers/models/dweller'
+import type { VaultQuest } from '@/modules/progression/models/quest'
+
+vi.mock('@iconify/vue', () => ({ Icon: { template: '<i />' } }))
+
+const socializingDweller = {
+  id: 'dweller-1',
+  first_name: 'Lucy',
+  last_name: 'MacLean',
+  level: 1,
+  status: 'resting',
+} as DwellerShort
+
+describe('PartySelectionModal', () => {
+  beforeEach(() => setActivePinia(createPinia()))
+
+  it('labels resting dwellers as Socializing', async () => {
+    const questStore = useQuestStore()
+    vi.spyOn(questStore, 'getEligibleDwellers').mockResolvedValue([socializingDweller] as never)
+    const wrapper = mount(PartySelectionModal, {
+      props: {
+        modelValue: false,
+        quest: { id: 'quest-1', title: 'Test Quest', duration_minutes: 1 } as VaultQuest,
+        vaultId: 'vault-1',
+        dwellers: [socializingDweller],
+        currentParty: [],
+      },
+      global: {
+        stubs: {
+          UModal: { template: '<div><slot /><slot name="footer" /></div>' },
+          UBadge: { template: '<span><slot /></span>' },
+          UButton: { template: '<button><slot /></button>' },
+        },
+      },
+    })
+
+    await wrapper.setProps({ modelValue: true })
+    await flushPromises()
+
+    expect(wrapper.find('.dweller-status').text()).toBe('Socializing')
+  })
+})

--- a/frontend/tests/unit/components/progression/PartySelectionModal.test.ts
+++ b/frontend/tests/unit/components/progression/PartySelectionModal.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import PartySelectionModal from '@/modules/progression/components/PartySelectionModal.vue'
-import { useQuestStore } from '@/modules/progression/stores/quest'
+import { useQuestStore, type EligibleDweller } from '@/modules/progression/stores/quest'
 import type { DwellerShort } from '@/modules/dwellers/models/dweller'
 import type { VaultQuest } from '@/modules/progression/models/quest'
 
@@ -16,12 +16,20 @@ const socializingDweller = {
   status: 'resting',
 } as DwellerShort
 
+const socializingEligibleDweller: EligibleDweller = {
+  id: 'dweller-1',
+  first_name: 'Lucy',
+  last_name: 'MacLean',
+  level: 1,
+  rarity: 'common',
+}
+
 describe('PartySelectionModal', () => {
   beforeEach(() => setActivePinia(createPinia()))
 
   it('labels resting dwellers as Socializing', async () => {
     const questStore = useQuestStore()
-    vi.spyOn(questStore, 'getEligibleDwellers').mockResolvedValue([socializingDweller] as never)
+    vi.spyOn(questStore, 'getEligibleDwellers').mockResolvedValue([socializingEligibleDweller])
     const wrapper = mount(PartySelectionModal, {
       props: {
         modelValue: false,

--- a/frontend/tests/unit/views/DwellersView.test.ts
+++ b/frontend/tests/unit/views/DwellersView.test.ts
@@ -162,6 +162,24 @@ describe('DwellersView', () => {
   })
 
   describe('Filter Panel Integration', () => {
+    it('applies the Socializing query filter', async () => {
+      vi.mocked(axios.get).mockResolvedValue({ data: [] })
+      await router.push('/vault/vault-1/dwellers?filter=resting')
+      await router.isReady()
+
+      mount(DwellersView, {
+        global: {
+          plugins: [router, pinia],
+        },
+      })
+      await flushPromises()
+
+      expect(axios.get).toHaveBeenCalledWith(
+        expect.stringContaining('status=resting'),
+        expect.any(Object)
+      )
+    })
+
     it('should render filter panel', async () => {
       vi.mocked(axios.get)
         .mockResolvedValueOnce({ data: [] }) // fetchDwellersByVault


### PR DESCRIPTION
## Summary
- treat Living Quarters dwellers as Socializing and migrate legacy room occupants
- limit relationship affinity growth to Living Quarters with a Charisma bonus
- add the Socializing filter and align dweller-list status badges

## Verification
- uv run ruff check .
- focused backend pytest suite (31 passed)
- pnpm run lint
- pnpm run typecheck
- pnpm frontend suite (1227 passed, 1 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “Socializing” dweller status with a heart icon and filter support.
  - Dwellers in living quarters are now marked as socializing and can be selected for parties and training.
  - Relationship affinity gains now account for Charisma and focus on living quarters.
  - New vaults initialize living-quarter dwellers as socializing with Charisma boosts where applicable.
  - Dweller chat can now provide social context, including rooms, family, relationships, and affinity.

- **Bug Fixes**
  - Improved handling of long dweller names to preserve list alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->