### PR TITLE
feat(overseer): activity and incident outcome reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## Unreleased
 
-## [2.44.0](https://github.com/ElderEvil/falloutProject/compare/v2.43.0...v2.44.0) (2026-08-21)
-
 ### Features
 
 - **Overseer Reports** — long-running dweller activities end in a visible outcome instead of a silent state change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,44 +3,82 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## Unreleased
+
+## [2.44.0](https://github.com/ElderEvil/falloutProject/compare/v2.43.0...v2.44.0) (2026-08-21)
+
+### Features
+
+- **Overseer Reports** — long-running dweller activities end in a visible outcome instead of a silent state change.
+  Training completion now sends a persistent `training_complete` notification carrying the stat change (`stat_name`,
+  `old_value`, `new_value`); clicking it opens the dweller's Stats tab with the improved SPECIAL stat highlighted
+  (+1 badge, reduced-motion aware). Exploration completion notifications carry the full rewards payload, and reward
+  reports are queued durably in localStorage (`usePendingReports`, survive reload/offline) and re-shown as the
+  rewards modal on the next visit to the exploration view until acknowledged
+- **Incident outcome reports** — resolving an incident now sends a `combat_victory` or `combat_defeat` notification
+  carrying the outcome summary (`caps_earned`, `loot` in `meta_data`), so attacks and fires report their result
+  instead of ending silently; clicking the notification opens the vault view
+
+### Fixed
+
+- **Breeding at population capacity** — `check_for_conception` no longer starts a new pregnancy when the vault
+  population has reached `population_max`; already-committed pregnancies reserve their slot, and a single free slot
+  can only be consumed by one new conception per game tick (regression coverage in `test_breeding_service.py`)
+
+### Changed
+
+- **Notification plumbing compaction** — a shared `notify_owner` helper centralizes the vault-owner lookup and
+  best-effort delivery across the training, death, and incident services, and the exploration report queue now
+  uses VueUse `useStorage` instead of hand-rolled localStorage sync (unused `consumePendingReport`/
+  `clearPendingReports` exports removed)
+
 ## [2.43.0](https://github.com/ElderEvil/falloutProject/compare/v2.42.0...v2.43.0) (2026-08-21)
 
 ### Features
 
-* social update ([#448](https://github.com/ElderEvil/falloutProject/issues/448)) ([0e7175d](https://github.com/ElderEvil/falloutProject/commit/0e7175dc4e3538d6df37a7c3718f975b5a7e3ea1))
+- **Living quarters socializing** — dwellers assigned to living quarters now rest instead of idling: the new
+  `RESTING` status renders as "Socializing" (heart badge plus a filter option), and the game loop raises affinity
+  only between dwellers sharing living-quarters rooms rather than any shared room. Charismatic pairs bond faster
+  (+`min(charisma)/10` bonus per tick). A backfill migration sets `RESTING` on dwellers already living in living
+  quarters, and boosted starter vaults spawn a charisma-boosted male/female pair resting there
+- **Dweller social context chat tool** — the chat agent gained `get_dweller_social_context()`, so questions about a
+  dweller's mood, family, or relationships are answered from live status, room, family members, and relationship
+  affinities instead of a static profile
 
 ## [2.42.0](https://github.com/ElderEvil/falloutProject/compare/v2.41.3...v2.42.0) (2026-08-20)
 
 ### Features
 
-* **family:** married stage, lineage API, and family tree UI ([#447](https://github.com/ElderEvil/falloutProject/issues/447)) ([f0ab891](https://github.com/ElderEvil/falloutProject/commit/f0ab891d9459921983d9158d716f47bc94ea0fed))
-
-## Unreleased
-
-### Features
-
-- **Incident response** — dispatch healthy adult dwellers to an active incident room; combat now resolves in bounded,
-  online vault rounds instead of allowing a manual instant-win action
 - **MARRIED relationship stage** — partners at the marriage threshold (affinity ≥ 85) can marry via
-  `PUT /relationships/{id}/marry`; marriage grants a happiness bonus and fires a notification; `break_up` now also
-  clears married couples
-- **Lineage API + family tree** — `GET /dwellers/{id}/lineage` returns parents, children, siblings, partners, and a
-  computed generation; the dweller detail page adds a "Family" tab rendering the family tree (clickable nodes)
+  `PUT /relationships/{id}/marry`; marriage grants a one-time happiness bonus and fires a notification, auto-marry
+  triggers when affinity reaches the threshold, and `break_up` now also clears married couples
+- **Lineage API** — `GET /dwellers/{id}/lineage` returns parents, children, siblings, partners, and a computed
+  generation; results are vault-scoped and immune to cycles, cross-vault links, and soft-deleted ancestors
+- **Family tree UI** — the dweller detail page adds a "Family" tab rendering the family tree with clickable nodes,
+  a siblings row, dead/age/partner-stage+affinity labels, and error/retry + refresh states
+- **Relationship UI polish** — relationship cards show milestone hints toward the next stage, couples render a
+  compact family diagram, and cards share consistent backgrounds with fixed-position affinity
+- **Family scenario tooling** — a `family_scenario` CLI command plus `family_scenario_service` seed test couples and
+  multi-generation families (co-location, pairing, births) for balance testing
 
 ### Changed
 
-- **Incident balance** — use configured threat weights and difficulty ranges; unsupported client-only incident types
-  are removed from the interface
-- **Development server** — `./scripts/dev-up.sh --reload` enables backend hot reload; every launcher run already
-  replaces the managed frontend and backend sessions
-- **Debug controls removed** — Quick-Pair ("Irradiated Cupid") button + backend endpoint, Process Breeding button,
-  and the PregnancyDebugPanel were removed from the relationships UI
+- **Release tooling** — root `package.json`/lockfile removed; semantic-release runs from CI via a pinned `npx`
+  invocation so frontend deps stay in `frontend/` (pnpm) and backend deps in `backend/` (uv)
+- **Docs cleanup** — ROADMAP pruned to future plans (history lives here); TrueNAS deployment docs, examples, and
+  redeploy script removed; `docs/features/FAMILY_SYSTEM.md` documents the family domain
+- **Debug controls removed** — PregnancyDebugPanel and its pregnancy store slice were removed from the social UI
 
 ### Fixed
 
-- **Migration-safety CI** — `backend-coverage.yml` now runs `alembic check` + `alembic current --check-heads` against a
-  live PostgreSQL service container; a migration (`b7e9f2c1a3d5`) drops two stale schema objects so `alembic check`
+- **Migration-safety CI** — `backend-coverage.yml` now runs `alembic check` + `alembic current --check-heads` against
+  a live PostgreSQL service container; migration (`b7e9f2c1a3d5`) drops two stale schema objects so `alembic check`
   passes
+- **Marriage integrity** — the relationship update and happiness bonus apply atomically (bonus failure rolls back the
+  whole transition, surfaced as HTTP 400), and a conditional `PARTNER→MARRIED` update makes concurrent marry requests
+  single-winner so the bonus/notification can never fire twice; the enum downgrade normalizes rows back to `partner`
+- **Stale detail responses** — DwellerDetailView tracks the requested dweller id with a monotonic load sequence so
+  out-of-order completions cannot clobber a newer dweller's state
 
 ## [2.41.3](https://github.com/ElderEvil/falloutProject/compare/v2.41.2...v2.41.3) (2026-08-19)
 

--- a/backend/app/services/breeding_service.py
+++ b/backend/app/services/breeding_service.py
@@ -10,9 +10,11 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.game_config import game_config
+from app.crud import vault as vault_crud
 from app.models.dweller import Dweller
 from app.models.pregnancy import Pregnancy
 from app.models.room import Room
+from app.models.vault import Vault
 from app.schemas.common import (
     AgeGroupEnum,
     GenderEnum,
@@ -276,6 +278,23 @@ class BreedingService:
         if not living_quarters:
             return []
 
+        # Capacity reservation: a full vault cannot start new conceptions, and
+        # already-committed pregnancies reserve one population slot each, so at
+        # most (population_max - population - active_pregnancies) new babies may
+        # be conceived this tick. population_max=None means unbounded (legacy).
+        population_max = (
+            await db_session.execute(select(Vault.population_max).where(Vault.id == vault_id))
+        ).scalar_one_or_none()
+
+        if population_max is not None:
+            population = await vault_crud.get_population(db_session=db_session, vault_id=vault_id)
+            if population >= population_max:
+                return []
+            active_pregnancies = await BreedingService.get_active_pregnancies(db_session, vault_id)
+            available_slots = max(0, population_max - population - len(active_pregnancies))
+        else:
+            available_slots = None
+
         living_quarters_ids = [room.id for room in living_quarters]
         dwellers = await BreedingService._get_eligible_dwellers(db_session, vault_id, living_quarters_ids)
         pregnant_mother_ids = await BreedingService._get_pregnant_mother_ids(db_session)
@@ -286,6 +305,9 @@ class BreedingService:
         checked_pairs: set[tuple[str, str]] = set()
 
         for dweller in dwellers:
+            if available_slots is not None and available_slots <= 0:
+                break
+
             if not BreedingService._is_pair_eligible(dweller, unavailable_mother_ids, checked_pairs):
                 continue
 
@@ -306,6 +328,8 @@ class BreedingService:
 
             if pregnancy:
                 new_pregnancies.append(pregnancy)
+                if available_slots is not None:
+                    available_slots -= 1
 
         return new_pregnancies
 

--- a/backend/app/services/death_service.py
+++ b/backend/app/services/death_service.py
@@ -78,25 +78,20 @@ class DeathService:
         )
 
         # Broadcast WebSocket event (best-effort, don't fail death flow)
-        vault = await vault_crud.get(db_session, dweller.vault_id)
-        if vault and vault.user_id:
-            try:
-                await notification_service.notify_dweller_died(
-                    db_session,
-                    user_id=vault.user_id,
-                    vault_id=dweller.vault_id,
-                    dweller_id=dweller.id,
-                    dweller_name=f"{dweller.first_name} {dweller.last_name or ''}".strip(),
-                    cause=cause.value,
-                    meta_data={"cause": cause.value, "vault_id": str(dweller.vault_id)},
-                )
-            except Exception:
-                logger.exception(
-                    "Failed to send death notification for dweller %s (vault %s, cause: %s)",
-                    dweller.id,
-                    dweller.vault_id,
-                    cause.value,
-                )
+        await notification_service.notify_owner(
+            db_session,
+            dweller.vault_id,
+            context=f"dweller_died vault={dweller.vault_id} dweller={dweller.id} cause={cause.value}",
+            sender=lambda user_id: notification_service.notify_dweller_died(
+                db_session,
+                user_id=user_id,
+                vault_id=dweller.vault_id,
+                dweller_id=dweller.id,
+                dweller_name=f"{dweller.first_name} {dweller.last_name or ''}".strip(),
+                cause=cause.value,
+                meta_data={"cause": cause.value, "vault_id": str(dweller.vault_id)},
+            ),
+        )
 
         return updated_dweller
 

--- a/backend/app/services/exploration/coordinator.py
+++ b/backend/app/services/exploration/coordinator.py
@@ -328,6 +328,9 @@ class ExplorationCoordinator:
                         "caps_earned": rewards.caps,
                         "xp_earned": rewards.experience,
                         "items_found": len(rewards.items),
+                        "dweller_id": str(dweller.id),
+                        "dweller_name": f"{dweller.first_name} {dweller.last_name or ''}".strip(),
+                        "rewards": rewards.model_dump(mode="json"),
                     },
                 )
         except Exception:

--- a/backend/app/services/incident_service.py
+++ b/backend/app/services/incident_service.py
@@ -9,10 +9,10 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.game_config import game_config
 from app.crud.incident import incident_crud
-from app.crud.vault import vault as vault_crud
 from app.models.dweller import Dweller
 from app.models.game_state import GameState
 from app.models.incident import Incident, IncidentStatus, IncidentType
+from app.models.notification import NotificationPriority, NotificationType
 from app.models.room import Room
 from app.schemas.common import AgeGroupEnum, DwellerStatusEnum
 from app.schemas.incident import IncidentRoundResult
@@ -22,6 +22,15 @@ from app.services.stream_manager import sse_manager
 from app.utils.exceptions import AccessDeniedException, ResourceNotFoundException, ValidationException
 
 logger = logging.getLogger(__name__)
+
+_INCIDENT_NAMES: dict[IncidentType, str] = {
+    IncidentType.FIRE: "🔥 Fire",
+    IncidentType.RADROACH_INFESTATION: "🪳 Radroach Infestation",
+    IncidentType.RAIDER_ATTACK: "💀 Raider Attack",
+    IncidentType.DEATHCLAW_ATTACK: "👹 Deathclaw Attack",
+    IncidentType.MOLE_RAT_ATTACK: "🐀 Mole Rat Attack",
+    IncidentType.FERAL_GHOUL_ATTACK: "🧟 Feral Ghoul Attack",
+}
 
 
 class IncidentService:
@@ -183,47 +192,28 @@ class IncidentService:
         )
 
         # Send notification (non-critical, don't break incident creation on failure)
-        try:
-            vault = await vault_crud.get(db_session, vault_id)
-            if vault and vault.user_id:
-                incident_names = {
-                    IncidentType.FIRE: "🔥 Fire",
-                    IncidentType.RADROACH_INFESTATION: "🪳 Radroach Infestation",
-                    IncidentType.RAIDER_ATTACK: "💀 Raider Attack",
-                    IncidentType.DEATHCLAW_ATTACK: "👹 Deathclaw Attack",
-                    IncidentType.MOLE_RAT_ATTACK: "🐀 Mole Rat Attack",
-                    IncidentType.FERAL_GHOUL_ATTACK: "🧟 Feral Ghoul Attack",
-                }
-                incident_name = incident_names.get(incident_type, str(incident_type))
-
-                from app.models.notification import NotificationPriority, NotificationType
-
-                await notification_service.create_and_send(
-                    db_session,
-                    user_id=vault.user_id,
-                    vault_id=vault_id,
-                    notification_type=NotificationType.COMBAT_STARTED,
-                    priority=NotificationPriority.HIGH,
-                    title=f"Incident: {incident_name}",
-                    message=f"{incident_name} in {target_room.name}! Send dwellers to defend.",
-                    meta_data={
-                        "incident_id": str(incident.id),
-                        "room_id": str(target_room.id),
-                        "room_name": target_room.name,
-                        "incident_type": incident_type.value,
-                        "difficulty": difficulty,
-                    },
-                )
-        except Exception:
-            self.logger.exception(
-                "Failed to send incident notification: incident_id=%s, vault_id=%s, "
-                "incident_type=%s, room_id=%s, room_name=%s",
-                incident.id,
-                vault_id,
-                incident_type.value,
-                target_room.id,
-                target_room.name,
-            )
+        incident_name = _INCIDENT_NAMES.get(incident_type, str(incident_type))
+        await notification_service.notify_owner(
+            db_session,
+            vault_id,
+            context=f"combat_started incident={incident.id} vault={vault_id}",
+            sender=lambda user_id: notification_service.create_and_send(
+                db_session,
+                user_id=user_id,
+                vault_id=vault_id,
+                notification_type=NotificationType.COMBAT_STARTED,
+                priority=NotificationPriority.HIGH,
+                title=f"Incident: {incident_name}",
+                message=f"{incident_name} in {target_room.name}! Send dwellers to defend.",
+                meta_data={
+                    "incident_id": str(incident.id),
+                    "room_id": str(target_room.id),
+                    "room_name": target_room.name,
+                    "incident_type": incident_type.value,
+                    "difficulty": difficulty,
+                },
+            ),
+        )
 
         try:
             await sse_manager.publish(
@@ -305,6 +295,7 @@ class IncidentService:
                 db_session.add(incident)
                 await db_session.commit()
                 await self._publish_event(incident, "incident_resolved", success=False)
+                await self._notify_resolution(db_session, incident, success=False)
             return IncidentRoundResult(no_defenders=True)
 
         # Calculate combat power
@@ -366,6 +357,7 @@ class IncidentService:
         await db_session.commit()
 
         if transitioned:
+            await self._notify_resolution(db_session, incident, success=True, caps_earned=caps_earned)
             await self._publish_event(incident, "incident_resolved", success=True)
 
         return IncidentRoundResult(
@@ -375,6 +367,41 @@ class IncidentService:
             dwellers_killed=deaths_count,
             enemies_defeated=enemies_this_tick,
             caps_earned=caps_earned,
+        )
+
+    async def _notify_resolution(
+        self, db_session: AsyncSession, incident: Incident, *, success: bool, caps_earned: int = 0
+    ) -> None:
+        """Best-effort: notify the owner that an incident was resolved."""
+        incident_name = _INCIDENT_NAMES.get(incident.type, str(incident.type))
+        if success:
+            title = f"Victory: {incident_name}"
+            message = f"Your dwellers defeated the attackers and recovered {caps_earned} caps!"
+            notification_type = NotificationType.COMBAT_VICTORY
+        else:
+            title = f"Incident Lost: {incident_name}"
+            message = f"Your dwellers failed to contain the {incident_name}."
+            notification_type = NotificationType.COMBAT_DEFEAT
+
+        await notification_service.notify_owner(
+            db_session,
+            incident.vault_id,
+            context=f"incident_resolved incident={incident.id} vault={incident.vault_id} success={success}",
+            sender=lambda user_id: notification_service.create_and_send(
+                db_session,
+                user_id=user_id,
+                vault_id=incident.vault_id,
+                notification_type=notification_type,
+                priority=NotificationPriority.HIGH,
+                title=title,
+                message=message,
+                meta_data={
+                    "incident_id": str(incident.id),
+                    "incident_type": incident.type.value,
+                    "loot": incident.loot,
+                    "caps_earned": caps_earned,
+                },
+            ),
         )
 
     async def get_incident_for_vault(self, db_session: AsyncSession, incident_id: UUID4, vault_id: UUID4) -> Incident:

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Awaitable, Callable
 from typing import Any
 from uuid import UUID
 
@@ -107,6 +108,32 @@ class NotificationService:
             # Best-effort delivery: persistence should succeed even if SSE send fails.
 
         return notification
+
+    @staticmethod
+    async def notify_owner(
+        db: AsyncSession,
+        vault_id: UUID | None,
+        *,
+        sender: Callable[[UUID], Awaitable[Any]],
+        context: str,
+    ) -> None:
+        """Best-effort: resolve ``vault_id``'s owner and run ``sender(user_id)``.
+
+        No-ops when the vault is missing or unowned, and logs (never raises) on
+        delivery failure so a broken notification cannot fail the gameplay
+        action that triggered it.
+        """
+        if not vault_id:
+            return
+        from app.crud import vault as crud_vault
+
+        try:
+            vault = await crud_vault.get(db, vault_id)
+            if not vault or not vault.user_id:
+                return
+            await sender(vault.user_id)
+        except Exception:
+            logger.exception("Failed to notify vault owner (%s)", context)
 
     # Convenience methods for common notification types
 

--- a/backend/app/services/training_service.py
+++ b/backend/app/services/training_service.py
@@ -16,6 +16,7 @@ from app.models.room import Room
 from app.models.training import Training, TrainingStatus
 from app.schemas.common import DwellerStatusEnum, RoomTypeEnum
 from app.services.event_bus import GameEvent, event_bus
+from app.services.notification_service import notification_service
 from app.utils.exceptions import ResourceConflictException, ResourceNotFoundException, VaultOperationException
 
 
@@ -292,6 +293,27 @@ class TrainingService:
                 "dweller_id": str(dweller.id),
                 "stat_trained": training.stat_being_trained.value,
             },
+        )
+
+        # Send notification (non-critical, don't break completion on failure)
+        await notification_service.notify_owner(
+            db_session,
+            dweller.vault_id,
+            context=f"training_complete vault={dweller.vault_id} dweller={dweller.id}",
+            sender=lambda user_id: notification_service.notify_training_complete(
+                db_session,
+                user_id=user_id,
+                vault_id=dweller.vault_id,
+                dweller_id=dweller.id,
+                dweller_name=f"{dweller.first_name} {dweller.last_name or ''}".strip(),
+                stat_name=training.stat_being_trained.value,
+                meta_data={
+                    "dweller_id": str(dweller.id),
+                    "stat_name": training.stat_being_trained.value,
+                    "old_value": current_value,
+                    "new_value": new_value,
+                },
+            ),
         )
 
         self.logger.info(

--- a/backend/app/tests/test_incident_sse.py
+++ b/backend/app/tests/test_incident_sse.py
@@ -130,8 +130,9 @@ async def test_process_incident_publishes_only_on_transition(async_session: Asyn
     with patch("app.services.incident_service.sse_manager.publish", new_callable=AsyncMock) as mock_publish:
         result = await incident_service.process_incident(async_session, incident_resolve, 60)
         assert result.skipped is False
-        mock_publish.assert_awaited_once()
-        call_args = mock_publish.call_args
+        incident_calls = [c for c in mock_publish.call_args_list if c[0][1] == "incidents"]
+        assert len(incident_calls) == 1
+        call_args = incident_calls[0]
         assert call_args[0][1] == "incidents"
         payload = call_args[0][2]
         assert payload["type"] == "incident_resolved"
@@ -206,7 +207,8 @@ async def test_undefended_max_spread_publishes_failed_resolution(async_session: 
     await async_session.refresh(incident)
     assert result.no_defenders is True
     assert incident.status == IncidentStatus.FAILED
-    mock_publish.assert_awaited_once()
-    payload = mock_publish.call_args.args[2]
+    incident_calls = [c for c in mock_publish.call_args_list if c[0][1] == "incidents"]
+    assert len(incident_calls) == 1
+    payload = incident_calls[0][0][2]
     assert payload["type"] == "incident_resolved"
     assert payload["success"] is False

--- a/backend/app/tests/test_services/test_breeding_service.py
+++ b/backend/app/tests/test_services/test_breeding_service.py
@@ -132,6 +132,33 @@ async def female_dweller_fixture(async_session: AsyncSession, vault: Vault) -> D
     return await crud.dweller.create(db_session=async_session, obj_in=dweller_in)
 
 
+@pytest_asyncio.fixture(name="female_dweller_2")
+async def female_dweller_2_fixture(async_session: AsyncSession, vault: Vault) -> Dweller:
+    """Create a second female dweller for population-capacity breeding tests."""
+    dweller_data = {
+        "first_name": "Sarah",
+        "last_name": "Rogers",
+        "gender": GenderEnum.FEMALE,
+        "rarity": RarityEnum.COMMON,
+        "age_group": AgeGroupEnum.ADULT,
+        "level": 6,
+        "experience": 60,
+        "max_health": 100,
+        "health": 100,
+        "radiation": 0,
+        "happiness": 65,
+        "strength": 5,
+        "perception": 6,
+        "endurance": 5,
+        "charisma": 7,
+        "intelligence": 5,
+        "agility": 6,
+        "luck": 5,
+    }
+    dweller_in = DwellerCreate(**dweller_data, vault_id=vault.id)
+    return await crud.dweller.create(db_session=async_session, obj_in=dweller_in)
+
+
 @pytest.mark.asyncio
 async def test_create_pregnancy(
     async_session: AsyncSession,
@@ -484,6 +511,186 @@ async def test_check_for_conception_only_one_in_living_quarters(
         )
 
     assert pregnancies == []
+
+
+@pytest.mark.asyncio
+async def test_check_for_conception_at_capacity(
+    async_session: AsyncSession,
+    vault: Vault,
+    living_quarters: Room,
+    male_dweller: Dweller,
+    female_dweller: Dweller,
+):
+    """No new conception when the vault population is exactly at capacity.
+
+    Regression guard: check_for_conception must refuse new conceptions once
+    the vault population reaches population_max, even for an eligible couple
+    with a guaranteed-successful conception roll.
+    """
+    # Make them partners in living quarters (eligible couple)
+    male_dweller.partner_id = female_dweller.id
+    female_dweller.partner_id = male_dweller.id
+    male_dweller.room_id = living_quarters.id
+    female_dweller.room_id = living_quarters.id
+    await async_session.commit()
+
+    # The vault holds exactly these 2 dwellers -> population_max of 2 is at capacity
+    vault.population_max = 2
+    async_session.add(vault)
+    await async_session.commit()
+
+    with patch("random.random", return_value=0.0):
+        pregnancies = await BreedingService.check_for_conception(
+            async_session,
+            vault.id,
+        )
+
+    assert pregnancies == []
+
+
+@pytest.mark.asyncio
+async def test_check_for_conception_over_capacity(
+    async_session: AsyncSession,
+    vault: Vault,
+    living_quarters: Room,
+    male_dweller: Dweller,
+    female_dweller: Dweller,
+):
+    """No new conception when the vault population is already over capacity."""
+    # Make them partners in living quarters (eligible couple)
+    male_dweller.partner_id = female_dweller.id
+    female_dweller.partner_id = male_dweller.id
+    male_dweller.room_id = living_quarters.id
+    female_dweller.room_id = living_quarters.id
+    await async_session.commit()
+
+    # 2 dwellers with population_max of 1 -> over capacity
+    vault.population_max = 1
+    async_session.add(vault)
+    await async_session.commit()
+
+    with patch("random.random", return_value=0.0):
+        pregnancies = await BreedingService.check_for_conception(
+            async_session,
+            vault.id,
+        )
+
+    assert pregnancies == []
+
+
+@pytest.mark.asyncio
+async def test_check_for_conception_one_slot_allows_single(
+    async_session: AsyncSession,
+    vault: Vault,
+    living_quarters: Room,
+    male_dweller: Dweller,
+    female_dweller: Dweller,
+):
+    """Exactly one free population slot allows exactly one conception."""
+    # Make them partners in living quarters (eligible couple)
+    male_dweller.partner_id = female_dweller.id
+    female_dweller.partner_id = male_dweller.id
+    male_dweller.room_id = living_quarters.id
+    female_dweller.room_id = living_quarters.id
+    await async_session.commit()
+
+    # 2 dwellers, population_max of 3 -> exactly one free slot
+    vault.population_max = 3
+    async_session.add(vault)
+    await async_session.commit()
+
+    with patch("random.random", return_value=0.0):
+        pregnancies = await BreedingService.check_for_conception(
+            async_session,
+            vault.id,
+        )
+
+    assert len(pregnancies) == 1
+    assert pregnancies[0].mother_id == female_dweller.id
+    assert pregnancies[0].father_id == male_dweller.id
+
+
+@pytest.mark.asyncio
+async def test_check_for_conception_reserves_for_committed_pregnancies(
+    async_session: AsyncSession,
+    vault: Vault,
+    living_quarters: Room,
+    male_dweller: Dweller,
+    female_dweller: Dweller,
+    male_dweller_2: Dweller,
+    female_dweller_2: Dweller,
+):
+    """A committed pregnancy reserves the last free population slot.
+
+    The eligible couple (male+female) would otherwise conceive, but the vault
+    already has a PREGNANT mother whose committed pregnancy counts toward
+    capacity: one free slot minus one committed pregnancy leaves no room, so
+    no new conception may occur.
+    """
+    # Eligible couple in living quarters
+    male_dweller.partner_id = female_dweller.id
+    female_dweller.partner_id = male_dweller.id
+    male_dweller.room_id = living_quarters.id
+    female_dweller.room_id = living_quarters.id
+    await async_session.commit()
+
+    # Second mother is already carrying a committed pregnancy
+    await BreedingService.create_pregnancy(
+        async_session,
+        female_dweller_2.id,
+        male_dweller_2.id,
+    )
+
+    # 4 dwellers, population_max of 5 -> one free slot, consumed by the committed pregnancy
+    vault.population_max = 5
+    async_session.add(vault)
+    await async_session.commit()
+
+    with patch("random.random", return_value=0.0):
+        pregnancies = await BreedingService.check_for_conception(
+            async_session,
+            vault.id,
+        )
+
+    assert pregnancies == []
+
+
+@pytest.mark.asyncio
+async def test_check_for_conception_single_slot_limits_pairs(
+    async_session: AsyncSession,
+    vault: Vault,
+    living_quarters: Room,
+    male_dweller: Dweller,
+    female_dweller: Dweller,
+    male_dweller_2: Dweller,
+    female_dweller_2: Dweller,
+):
+    """A single free slot allows at most one conception even with two couples."""
+    # Two eligible couples in the same living quarters
+    male_dweller.partner_id = female_dweller.id
+    female_dweller.partner_id = male_dweller.id
+    male_dweller_2.partner_id = female_dweller_2.id
+    female_dweller_2.partner_id = male_dweller_2.id
+    male_dweller.room_id = living_quarters.id
+    female_dweller.room_id = living_quarters.id
+    male_dweller_2.room_id = living_quarters.id
+    female_dweller_2.room_id = living_quarters.id
+    await async_session.commit()
+
+    # 4 dwellers, population_max of 5 -> exactly one free slot
+    vault.population_max = 5
+    async_session.add(vault)
+    await async_session.commit()
+
+    with patch("random.random", return_value=0.0):
+        pregnancies = await BreedingService.check_for_conception(
+            async_session,
+            vault.id,
+        )
+
+    # Both couples have guaranteed-successful rolls, but the single free slot
+    # caps the tick at exactly one conception.
+    assert len(pregnancies) == 1
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_services/test_notification_integrations.py
+++ b/backend/app/tests/test_services/test_notification_integrations.py
@@ -1,5 +1,6 @@
 """Tests for notification integrations in game services."""
 
+from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -8,8 +9,10 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app import crud
 from app.models.exploration import ExplorationStatus
 from app.models.incident import IncidentStatus, IncidentType
+from app.models.notification import NotificationType
 from app.services.exploration.coordinator import ExplorationCoordinator
 from app.services.incident_service import IncidentService
+from app.services.notification_service import NotificationService
 from app.services.radio_service import RadioService
 
 
@@ -174,3 +177,137 @@ class TestIncidentNotifications:
                     incident.status = IncidentStatus.RESOLVED
                     async_session.add(incident)
                     await async_session.commit()
+
+    @pytest.mark.asyncio
+    async def test_incident_victory_sends_notification(
+        self,
+        async_session: AsyncSession,
+        user_with_vault: tuple,
+        dweller_in_vault,
+        room_in_vault,
+    ):
+        """Resolving an incident successfully fires a COMBAT_VICTORY notification."""
+        _, vault = user_with_vault
+
+        dweller_in_vault.room_id = room_in_vault.id
+        async_session.add(dweller_in_vault)
+        await async_session.commit()
+
+        incident = await crud.incident_crud.create(
+            async_session,
+            vault_id=vault.id,
+            room_id=room_in_vault.id,
+            incident_type=IncidentType.RADROACH_INFESTATION,
+            difficulty=1,
+        )
+        incident.enemies_defeated = 10  # force immediate victory
+        async_session.add(incident)
+        await async_session.commit()
+        await async_session.refresh(incident)
+
+        incident_service = IncidentService()
+
+        with patch("app.services.incident_service.notification_service.create_and_send") as mock_notify:
+            mock_notify.return_value = AsyncMock()
+
+            await incident_service.process_incident(async_session, incident, 60)
+
+        mock_notify.assert_called_once()
+        call_args = mock_notify.call_args
+        assert call_args.kwargs["notification_type"] == NotificationType.COMBAT_VICTORY
+        assert call_args.kwargs["vault_id"] == vault.id
+        assert call_args.kwargs["meta_data"]["caps_earned"] >= 0
+        assert "loot" in call_args.kwargs["meta_data"]
+
+    @pytest.mark.asyncio
+    async def test_incident_defeat_sends_notification(
+        self,
+        async_session: AsyncSession,
+        user_with_vault: tuple,
+        room_in_vault,
+    ):
+        """An incident that cannot be contained fires a COMBAT_DEFEAT notification."""
+        _, vault = user_with_vault
+
+        incident = await crud.incident_crud.create(
+            async_session,
+            vault_id=vault.id,
+            room_id=room_in_vault.id,
+            incident_type=IncidentType.FIRE,
+            difficulty=1,
+        )
+        incident.start_time = datetime.utcnow() - timedelta(seconds=incident.duration)
+        async_session.add(incident)
+        await async_session.commit()
+        await async_session.refresh(incident)
+
+        incident_service = IncidentService()
+
+        with patch("app.services.incident_service.notification_service.create_and_send") as mock_notify:
+            mock_notify.return_value = AsyncMock()
+
+            await incident_service.process_incident(async_session, incident, 60)
+
+        mock_notify.assert_called_once()
+        call_args = mock_notify.call_args
+        assert call_args.kwargs["notification_type"] == NotificationType.COMBAT_DEFEAT
+        assert call_args.kwargs["vault_id"] == vault.id
+
+    @pytest.mark.asyncio
+    async def test_incident_victory_no_notification_when_commit_fails(
+        self,
+        async_session: AsyncSession,
+        user_with_vault: tuple,
+        dweller_in_vault,
+        room_in_vault,
+    ):
+        """A resolution notification is not sent if the incident commit fails."""
+        _, vault = user_with_vault
+
+        dweller_in_vault.room_id = room_in_vault.id
+        async_session.add(dweller_in_vault)
+        await async_session.commit()
+
+        incident = await crud.incident_crud.create(
+            async_session,
+            vault_id=vault.id,
+            room_id=room_in_vault.id,
+            incident_type=IncidentType.RADROACH_INFESTATION,
+            difficulty=1,
+        )
+        incident.enemies_defeated = 10
+        async_session.add(incident)
+        await async_session.commit()
+        await async_session.refresh(incident)
+
+        async def fail_commit():  # type: ignore[no-untyped-def]
+            raise RuntimeError("commit failed")
+
+        async_session.commit = fail_commit  # type: ignore[method-assign]
+
+        incident_service = IncidentService()
+
+        with (
+            patch("app.services.incident_service.notification_service.create_and_send") as mock_notify,
+            pytest.raises(RuntimeError),
+        ):
+            await incident_service.process_incident(async_session, incident, 60)
+
+        mock_notify.assert_not_called()
+
+
+class TestNotificationService:
+    """Tests for the notification service helper."""
+
+    @pytest.mark.asyncio
+    async def test_notify_owner_survives_lookup_failure(self, async_session: AsyncSession, user_with_vault: tuple):
+        """A failed vault-owner lookup does not propagate out of notify_owner."""
+        _, vault = user_with_vault
+
+        with patch("app.crud.vault.vault.get", side_effect=RuntimeError("db down")):
+            await NotificationService.notify_owner(
+                async_session,
+                vault.id,
+                context="test",
+                sender=lambda user_id: None,
+            )

--- a/backend/app/utils/version.py
+++ b/backend/app/utils/version.py
@@ -80,7 +80,7 @@ def parse_changelog(changelog_path: Path) -> list[dict]:
                 current_category = line[4:].strip()
                 continue
 
-            if line.startswith("- ") and current_category:
+            if line.startswith(("- ", "* ")) and current_category:
                 changes.append({"category": current_category, "description": line[2:].strip()})
 
         try:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -55,6 +55,35 @@ stage-transition logic.
 
 ---
 
+### Overseer Reports — CodeRabbit Review Follow-ups (Target: TBD)
+
+**Focus**: Follow-ups from the CodeRabbit review of the Overseer Reports PR (#449). The two stability fixes shipped
+with the PR (incident victory notification now fires only after the incident commit succeeds; `notify_owner`
+swallows vault-owner lookup failures). The remaining items were deferred or recommended for a follow-up.
+
+- 🔄 **Breeding capacity concurrency** — `check_for_conception` reads `available_slots` without locking, so two
+  concurrent ticks can each reserve the last free slot and over-commit pregnancies. Enforce the capacity check and
+  the pregnancy insert in one transaction (`SELECT ... FOR UPDATE` on the vault row), at the `create_pregnancy`
+  boundary so every conception path is covered. Heavy lift; the in-memory SQLite test harness cannot exercise row
+  locks today.
+- 🔄 **Pending-report dedup by `exploration_id`** — `usePendingReports` deduplicates by dweller + rewards content, so
+  two identical completions from the same dweller are collapsed. Propagate the SSE `exploration_id` through the
+  notification metadata and dedup on it instead. Heavy lift (backend metadata change).
+- 🔄 **DwellerPanel query-prop sync** — clicking the same dweller's `training_complete` notification again (query-only
+  `?tab=stats&stat=X` change) does not update the active tab or badge because the component instance is reused
+  without re-running setup. Watch `initialTab`/`highlightStat` props and restart the badge timer on change.
+- 🔄 **ExplorationView vault filter** — pending reports are global (single `localStorage` key), so reports from one
+  vault can surface while viewing another. Scope selection/acknowledgement to the active `vaultId`.
+- 🔄 **DwellerStats animations → Tailwind utilities** — move the scoped `stat-pulse`/`badge-fade` keyframes into
+  `tailwind.css` as utilities with motion-reduce variants (aligns with the Tailwind-utilities-only guideline).
+- ⚪ **Nitpicks (optional)** — route exploration-completion notifications through `notify_owner` for consistency with
+  the other flows; wrap a >100-char line in `exploration.ts`.
+
+**Guardrails:** keep the resolution-notification ordering fix (notify only after a successful commit) intact when
+touching incident handling; any breeding change must keep `population_max=None` unbounded.
+
+---
+
 ### v2.34.0 — Pydantic AI Reliability & Observability (Target: TBD)
 
 **Focus**: Make existing dweller agents easier to debug and more reliable at the boundary between structured model
@@ -396,4 +425,4 @@ recorded per D8. No gaps found; no future ROADMAP items added from this workstre
 
 ---
 
-_Last updated: 2026-08-20_ (v2.41.3 released; most low-hanging fruit implemented; next focus: Family Relations, Pydantic AI Gateway activation)
+_Last updated: 2026-08-21_ (Overseer Reports PR #449 in review; CodeRabbit follow-ups tracked under Planned; next focus: Family Relations, Pydantic AI Gateway activation)

--- a/frontend/src/modules/dwellers/components/DwellerPanel.vue
+++ b/frontend/src/modules/dwellers/components/DwellerPanel.vue
@@ -18,6 +18,8 @@ interface Props {
   isAnyGenerating?: boolean
   vaultId?: string
   placeLinks?: MapPlaceLink[]
+  initialTab?: string
+  highlightStat?: string
 }
 
 const props = defineProps<Props>()
@@ -31,7 +33,7 @@ const emit = defineEmits<{
   'navigate-dweller': [dwellerId: string]
 }>()
 
-const activeTab = ref('profile')
+const activeTab = ref(props.initialTab ?? 'profile')
 
 const tabs = [
   { key: 'profile', label: 'Profile' },
@@ -77,6 +79,7 @@ const tabs = [
             :I="dweller.I"
             :A="dweller.A"
             :L="dweller.L"
+            :highlight-stat="props.highlightStat"
           />
           <DwellerEquipment
             v-else-if="currentTab === 'equipment'"

--- a/frontend/src/modules/dwellers/components/stats/DwellerStats.vue
+++ b/frontend/src/modules/dwellers/components/stats/DwellerStats.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+
 interface Props {
   S: number
   P: number
@@ -7,11 +9,12 @@ interface Props {
   I: number
   A: number
   L: number
+  highlightStat?: string
 }
 
 const props = defineProps<Props>()
 
-const statValue = (key: keyof Props): number => props[key] ?? 0
+const statValue = (key: keyof Props): number => (props[key] as number) ?? 0
 
 const stats: Array<{ key: keyof Props; label: string; description: string }> = [
   { key: 'S', label: 'Strength', description: 'Physical power and melee damage' },
@@ -22,16 +25,51 @@ const stats: Array<{ key: keyof Props; label: string; description: string }> = [
   { key: 'A', label: 'Agility', description: 'Speed and weapon reload' },
   { key: 'L', label: 'Luck', description: 'Critical hits and loot quality' },
 ]
+
+const statKeyByLowercase: Record<string, keyof Props> = {
+  strength: 'S',
+  perception: 'P',
+  endurance: 'E',
+  charisma: 'C',
+  intelligence: 'I',
+  agility: 'A',
+  luck: 'L',
+}
+
+const highlightedKey = computed<keyof Props | undefined>(() => {
+  if (!props.highlightStat) return undefined
+  return statKeyByLowercase[props.highlightStat.toLowerCase()]
+})
+
+const showBadge = ref(!!highlightedKey.value)
+
+onMounted(() => {
+  if (showBadge.value) {
+    setTimeout(() => {
+      showBadge.value = false
+    }, 2500)
+  }
+})
+
+const isHighlighted = (key: keyof Props) => highlightedKey.value === key
 </script>
 
 <template>
   <div class="dweller-stats">
     <h3 class="stats-title">S.P.E.C.I.A.L.</h3>
     <div class="stats-grid">
-      <div v-for="stat in stats" :key="stat.key" class="stat-item">
+      <div
+        v-for="stat in stats"
+        :key="stat.key"
+        class="stat-item"
+        :class="{ 'stat-highlighted': isHighlighted(stat.key) }"
+      >
         <div class="stat-header">
           <span class="stat-label">{{ stat.label }}</span>
-          <span class="stat-value">{{ statValue(stat.key) }}</span>
+          <span class="stat-value-group">
+            <span class="stat-value">{{ statValue(stat.key) }}</span>
+            <span v-if="isHighlighted(stat.key) && showBadge" class="stat-badge">+1</span>
+          </span>
         </div>
         <div class="stat-bar">
           <div class="stat-fill" :style="{ width: `${statValue(stat.key) * 10}%` }"></div>
@@ -127,5 +165,69 @@ const stats: Array<{ key: keyof Props; label: string; description: string }> = [
   opacity: 0.6;
   text-shadow: 0 0 2px var(--color-theme-glow);
   line-height: 1.3;
+}
+
+.stat-value-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.stat-badge {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  color: var(--color-theme-accent);
+  text-shadow: 0 0 6px var(--color-theme-glow);
+  animation: badge-fade 2.5s ease-out forwards;
+}
+
+.stat-highlighted {
+  border-left-color: var(--color-theme-accent);
+  background: rgba(0, 255, 0, 0.06);
+  animation: stat-pulse 2.5s ease-out forwards;
+}
+
+@keyframes stat-pulse {
+  0% {
+    box-shadow: 0 0 12px var(--color-theme-glow);
+    filter: brightness(1.3);
+  }
+  40% {
+    box-shadow:
+      0 0 20px var(--color-theme-glow),
+      0 0 30px var(--color-theme-glow);
+    filter: brightness(1.5);
+  }
+  100% {
+    box-shadow: 0 0 6px var(--color-theme-glow);
+    filter: brightness(1);
+  }
+}
+
+@keyframes badge-fade {
+  0% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  70% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stat-highlighted {
+    animation: none;
+    box-shadow: 0 0 12px var(--color-theme-glow);
+  }
+
+  .stat-badge {
+    animation: none;
+    opacity: 1;
+  }
 }
 </style>

--- a/frontend/src/modules/dwellers/views/DwellerDetailView.vue
+++ b/frontend/src/modules/dwellers/views/DwellerDetailView.vue
@@ -67,6 +67,16 @@ const revivalLoading = ref(false)
 const isDead = computed(() => dweller.value?.is_dead === true)
 const placeLinks = ref<MapPlaceLink[]>([])
 
+const queryTab = computed(() => {
+  const tab = route.query.tab
+  return typeof tab === 'string' ? tab : undefined
+})
+
+const queryStat = computed(() => {
+  const stat = route.query.stat
+  return typeof stat === 'string' ? stat.toLowerCase() : undefined
+})
+
 async function loadDweller() {
   if (!authStore.isAuthenticated || !dwellerId.value) return
   const requestedId = dwellerId.value
@@ -476,6 +486,8 @@ const saveNewName = async () => {
                 :is-any-generating="isAnyGenerating"
                 :vault-id="vaultId"
                 :place-links="placeLinks"
+                :initial-tab="queryTab"
+                :highlight-stat="queryStat"
                 @refresh="handleRefresh"
                 @generate-bio="generateDwellerBio"
                 @generate-appearance="generateDwellerAppearance"

--- a/frontend/src/modules/exploration/composables/usePendingReports.ts
+++ b/frontend/src/modules/exploration/composables/usePendingReports.ts
@@ -1,0 +1,58 @@
+import { useStorage } from '@vueuse/core'
+import type { RewardsSummary } from '../stores/exploration'
+
+const STORAGE_KEY = 'vault.pendingExplorationReports'
+
+export interface PendingExplorationReport {
+  id: string
+  vaultId: string
+  dwellerId: string
+  dwellerName: string
+  rewards: RewardsSummary
+  createdAt: string
+}
+
+/**
+ * Durable, offline-safe queue of completed exploration reward reports that
+ * have not yet been acknowledged by the Overseer.
+ *
+ * Exploration completions that happen while the player is elsewhere (or while
+ * the app is closed) must not be lost — the reward screen has to be visible at
+ * least once. Reports are persisted to localStorage via `useStorage` (survive
+ * reload/offline) and surfaced on the next visit to the exploration view, one
+ * at a time, and removed only when the player acknowledges the modal.
+ *
+ * The module-scoped ref is the single shared in-memory queue, so the
+ * notification bell and the exploration view always read the same state.
+ */
+const pendingReports = useStorage<PendingExplorationReport[]>(STORAGE_KEY, [])
+
+/**
+ * Add a report to the pending queue. Deduplicates by dweller + rewards content
+ * so the same completion enqueued both by the notification bell and the SSE
+ * stream is stored once, while a later distinct completion is kept.
+ */
+export function addPendingReport(report: Omit<PendingExplorationReport, 'id' | 'createdAt'>): void {
+  const rewardsSignature = JSON.stringify(report.rewards)
+  if (
+    pendingReports.value.some(
+      (r) => r.dwellerId === report.dwellerId && JSON.stringify(r.rewards) === rewardsSignature
+    )
+  ) {
+    return
+  }
+  pendingReports.value = [
+    ...pendingReports.value,
+    { ...report, id: `${report.dwellerId}-${Date.now()}`, createdAt: new Date().toISOString() },
+  ]
+}
+
+/** Remove a specific report once it has been acknowledged. */
+export function removePendingReport(reportId: string): void {
+  pendingReports.value = pendingReports.value.filter((r) => r.id !== reportId)
+}
+
+/** Reactive read access to the shared pending queue. */
+export function usePendingReports(): { pendingReports: typeof pendingReports } {
+  return { pendingReports }
+}

--- a/frontend/src/modules/exploration/stores/exploration.ts
+++ b/frontend/src/modules/exploration/stores/exploration.ts
@@ -4,6 +4,8 @@ import axios from '@/core/plugins/axios'
 import { handleStoreError } from '@/core/utils/errorHandler'
 import { useToast } from '@/core/composables/useToast'
 import { useSse } from '@/core/composables/useEventStream'
+import { addPendingReport } from '../composables/usePendingReports'
+import { useDwellerStore } from '@/modules/dwellers/stores/dweller'
 
 export interface ExplorationEvent {
   type: string
@@ -80,6 +82,7 @@ export interface RewardsSummary {
 
 export const useExplorationStore = defineStore('exploration', () => {
   const toast = useToast()
+  const { filter: dwellerFilter } = useDwellerStore()
 
   // State
   const explorations = ref<Exploration[]>([])
@@ -89,6 +92,7 @@ export const useExplorationStore = defineStore('exploration', () => {
   const isLoading = ref(false)
   const error = ref<string | null>(null)
   let sseInstance: ReturnType<typeof useSse> | null = null
+  let currentVaultId = ''
 
   // Getters
   function getExplorationByDwellerId(dwellerId: string) {
@@ -105,6 +109,7 @@ export const useExplorationStore = defineStore('exploration', () => {
 
   function startSseSubscription(vaultId: string, token: string): void {
     stopSseSubscription()
+    currentVaultId = vaultId
 
     const apiBase = import.meta.env.VITE_API_BASE_URL ?? ''
     sseInstance = useSse(`${apiBase}/api/v1/stream/exploration/${vaultId}`, {
@@ -119,9 +124,15 @@ export const useExplorationStore = defineStore('exploration', () => {
         const data = evt.data as Record<string, unknown> | undefined
         if (!data || typeof data.type !== 'string') return
         if (data.type === 'exploration_complete' || data.type === 'exploration_recalled') {
-          pendingSseRewards.value = {
-            rewards: (data.rewards ?? { caps: 0, items: [], experience: 0, distance: 0 }) as RewardsSummary,
-            dwellerId: (data.dweller_id as string) ?? '',
+          const rewards = (data.rewards ?? { caps: 0, items: [], experience: 0, distance: 0 }) as RewardsSummary
+          const dwellerId = (data.dweller_id as string) ?? ''
+          pendingSseRewards.value = { rewards, dwellerId }
+
+          // Persist to durable queue for offline/elsewhere viewing
+          if (dwellerId) {
+            const dweller = dwellerFilter.dwellers.find((d) => d.id === dwellerId)
+            const dwellerName = dweller ? `${dweller.first_name} ${dweller.last_name}` : 'Dweller'
+            addPendingReport({ vaultId: currentVaultId, dwellerId, dwellerName, rewards })
           }
         }
       }

--- a/frontend/src/modules/exploration/views/ExplorationView.vue
+++ b/frontend/src/modules/exploration/views/ExplorationView.vue
@@ -20,6 +20,7 @@ import UCard from '@/core/components/ui/UCard.vue'
 import UButton from '@/core/components/ui/UButton.vue'
 import { useExplorationStore } from '../stores/exploration'
 import type { RewardsSummary } from '../stores/exploration'
+import { usePendingReports, removePendingReport } from '../composables/usePendingReports'
 
 const route = useRoute()
 const authStore = useAuthStore()
@@ -41,6 +42,19 @@ const { isLoading: explorationLoading, error: explorationError } = storeToRefs(e
 const showRewardsModal = ref(false)
 const completedExplorationRewards = ref<RewardsSummary | null>(null)
 const completedDwellerName = ref('')
+const activeQueuedReportId = ref<string | null>(null)
+
+const { pendingReports } = usePendingReports()
+
+function showNextPendingReport(): void {
+  const next = pendingReports.value[0]
+  if (next) {
+    activeQueuedReportId.value = next.id
+    completedExplorationRewards.value = next.rewards
+    completedDwellerName.value = next.dwellerName
+    showRewardsModal.value = true
+  }
+}
 
 // Centralized data loading function
 const loadData = async () => {
@@ -67,6 +81,9 @@ onMounted(async () => {
   if (vaultId.value && authStore.token) {
     explorationStore.startSseSubscription(vaultId.value, authStore.token)
   }
+  if (pendingReports.value.length > 0) {
+    showNextPendingReport()
+  }
 })
 
 onUnmounted(() => {
@@ -78,6 +95,7 @@ watch(
   () => explorationStore.pendingSseRewards,
   (pending) => {
     if (!pending) return
+    activeQueuedReportId.value = null
     const dweller = getDwellerById(pending.dwellerId)
     completedExplorationRewards.value = pending.rewards
     completedDwellerName.value = dweller ? `${dweller.first_name} ${dweller.last_name}` : 'Dweller'
@@ -214,6 +232,14 @@ const handleRecallExploration = async (explorationId: string) => {
 }
 
 const closeRewardsModal = () => {
+  if (activeQueuedReportId.value) {
+    removePendingReport(activeQueuedReportId.value)
+    activeQueuedReportId.value = null
+    if (pendingReports.value.length > 0) {
+      showNextPendingReport()
+      return
+    }
+  }
   showRewardsModal.value = false
   completedExplorationRewards.value = null
   completedDwellerName.value = ''

--- a/frontend/src/modules/vault/components/shell/NotificationBell.vue
+++ b/frontend/src/modules/vault/components/shell/NotificationBell.vue
@@ -5,6 +5,7 @@ import { Icon } from '@iconify/vue'
 import { useAuthStore } from '@/modules/auth/stores/auth'
 import { useSse, type SseEvent } from '@/core/composables/useEventStream'
 import { useAsyncAction } from '@/core/composables/useAsyncAction'
+import { addPendingReport } from '@/modules/exploration/composables/usePendingReports'
 import axios from '@/core/plugins/axios'
 
 interface Notification {
@@ -161,13 +162,24 @@ const getNotificationRoute = (notification: Notification): string | null => {
     case 'exploration_complete':
     case 'exploration_update':
       return `${vaultPath}/exploration`
-    case 'training_complete':
+    case 'training_complete': {
+      if (dwellerId) {
+        const statName = notification.meta_data?.stat_name as string | undefined
+        const statParam = statName ? `?tab=stats&stat=${statName}` : '?tab=stats'
+        return `${vaultPath}/dwellers/${dwellerId}${statParam}`
+      }
+      return `${vaultPath}/training`
+    }
     case 'training_started':
       return `${vaultPath}/training`
     case 'quest_complete':
       return `${vaultPath}/quests`
     case 'level_up':
       return dwellerId ? `${vaultPath}/dwellers/${dwellerId}` : `${vaultPath}/dwellers`
+    case 'combat_started':
+    case 'combat_victory':
+    case 'combat_defeat':
+      return vaultPath
     case 'dweller_died':
     case 'dweller_injured':
     case 'baby_born':
@@ -182,9 +194,22 @@ const getNotificationRoute = (notification: Notification): string | null => {
   }
 }
 
+const enqueuePendingReport = (notification: Notification): void => {
+  if (notification.notification_type !== 'exploration_complete') return
+  const rewards = notification.meta_data?.rewards
+  if (!rewards || !notification.vault_id) return
+  addPendingReport({
+    vaultId: notification.vault_id,
+    dwellerId: notification.meta_data!.dweller_id,
+    dwellerName: notification.meta_data!.dweller_name,
+    rewards,
+  })
+}
+
 const handleNotificationClick = async (notification: Notification) => {
   if (!notification.is_read) await markAsRead(notification.id)
   showPopup.value = false
+  enqueuePendingReport(notification)
   const route = getNotificationRoute(notification)
   if (route) await router.push(route)
 }
@@ -197,7 +222,9 @@ const getNotificationIcon = (type: string): string => {
     exploration_update: 'mdi:map-marker',
     level_up: 'mdi:arrow-up-bold',
     training_complete: 'mdi:school',
+    combat_started: 'mdi:sword-cross',
     combat_victory: 'mdi:sword',
+    combat_defeat: 'mdi:skull-crossbones',
     radio_new_dweller: 'mdi:radio',
     resource_low: 'mdi:alert',
   }

--- a/frontend/tests/unit/components/dwellers/DwellerStats.test.ts
+++ b/frontend/tests/unit/components/dwellers/DwellerStats.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import DwellerStats from '@/modules/dwellers/components/stats/DwellerStats.vue'
+
+const defaultProps = {
+  S: 5,
+  P: 4,
+  E: 6,
+  C: 3,
+  I: 7,
+  A: 2,
+  L: 8,
+}
+
+describe('DwellerStats', () => {
+  describe('Rendering', () => {
+    it('should render all seven SPECIAL stat rows', () => {
+      const wrapper = mount(DwellerStats, { props: defaultProps })
+
+      const items = wrapper.findAll('.stat-item')
+      expect(items).toHaveLength(7)
+    })
+
+    it('should render stat labels', () => {
+      const wrapper = mount(DwellerStats, { props: defaultProps })
+
+      const labels = wrapper.findAll('.stat-label')
+      const text = labels.map((l) => l.text())
+      expect(text).toEqual([
+        'Strength',
+        'Perception',
+        'Endurance',
+        'Charisma',
+        'Intelligence',
+        'Agility',
+        'Luck',
+      ])
+    })
+
+    it('should render stat values', () => {
+      const wrapper = mount(DwellerStats, { props: defaultProps })
+
+      const values = wrapper.findAll('.stat-value')
+      expect(values[0].text()).toBe('5')
+      expect(values[1].text()).toBe('4')
+      expect(values[6].text()).toBe('8')
+    })
+  })
+
+  describe('Highlight Stat', () => {
+    it('should add stat-highlighted class to the matching row when highlightStat is set', () => {
+      const wrapper = mount(DwellerStats, {
+        props: { ...defaultProps, highlightStat: 'strength' },
+      })
+
+      const items = wrapper.findAll('.stat-item')
+      expect(items[0].classes()).toContain('stat-highlighted')
+      expect(items[1].classes()).not.toContain('stat-highlighted')
+    })
+
+    it('should show +1 badge on the highlighted row', () => {
+      const wrapper = mount(DwellerStats, {
+        props: { ...defaultProps, highlightStat: 'strength' },
+      })
+
+      const badge = wrapper.find('.stat-badge')
+      expect(badge.exists()).toBe(true)
+      expect(badge.text()).toBe('+1')
+    })
+
+    it('should not show +1 badge when highlightStat is not provided', () => {
+      const wrapper = mount(DwellerStats, { props: defaultProps })
+
+      const badge = wrapper.find('.stat-badge')
+      expect(badge.exists()).toBe(false)
+    })
+
+    it('should not add stat-highlighted class when highlightStat is not provided', () => {
+      const wrapper = mount(DwellerStats, { props: defaultProps })
+
+      const items = wrapper.findAll('.stat-item')
+      items.forEach((item) => {
+        expect(item.classes()).not.toContain('stat-highlighted')
+      })
+    })
+
+    it('should handle case-insensitive stat names', () => {
+      const wrapper = mount(DwellerStats, {
+        props: { ...defaultProps, highlightStat: 'STRENGTH' },
+      })
+
+      const items = wrapper.findAll('.stat-item')
+      expect(items[0].classes()).toContain('stat-highlighted')
+    })
+
+    it('should highlight the correct stat for each SPECIAL letter', () => {
+      const statMap = [
+        { stat: 'perception', index: 1 },
+        { stat: 'endurance', index: 2 },
+        { stat: 'charisma', index: 3 },
+        { stat: 'intelligence', index: 4 },
+        { stat: 'agility', index: 5 },
+        { stat: 'luck', index: 6 },
+      ]
+
+      statMap.forEach(({ stat, index }) => {
+        const wrapper = mount(DwellerStats, {
+          props: { ...defaultProps, highlightStat: stat },
+        })
+
+        const items = wrapper.findAll('.stat-item')
+        expect(items[index].classes()).toContain('stat-highlighted')
+        // Other rows should not be highlighted
+        items.forEach((item, i) => {
+          if (i !== index) {
+            expect(item.classes()).not.toContain('stat-highlighted')
+          }
+        })
+      })
+    })
+  })
+})

--- a/frontend/tests/unit/stores/exploration.test.ts
+++ b/frontend/tests/unit/stores/exploration.test.ts
@@ -1,9 +1,35 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
+import { ref, nextTick } from 'vue'
 import { useExplorationStore } from '@/modules/exploration/stores/exploration'
 import axios from '@/core/plugins/axios'
+import { addPendingReport } from '@/modules/exploration/composables/usePendingReports'
 
 vi.mock('@/core/plugins/axios')
+vi.mock('@/modules/exploration/composables/usePendingReports', () => ({
+  addPendingReport: vi.fn(),
+}))
+
+const mockSseEvent = ref<Record<string, unknown> | null>(null)
+
+vi.mock('@/core/composables/useEventStream', () => ({
+  useSse: vi.fn(() => ({
+    start: vi.fn().mockResolvedValue(undefined),
+    stopReconnect: vi.fn(),
+    close: vi.fn(),
+    event: mockSseEvent,
+  })),
+}))
+
+vi.mock('@/modules/dwellers/stores/dweller', () => ({
+  useDwellerStore: vi.fn(() => ({
+    filter: {
+      dwellers: [
+        { id: 'dweller-1', first_name: 'Amata', last_name: 'Almodovar' },
+      ],
+    },
+  })),
+}))
 
 describe('Exploration Store', () => {
   beforeEach(() => {
@@ -449,6 +475,75 @@ describe('Exploration Store', () => {
       expect(store.explorations[0].total_caps_found).toBe(100)
       expect(store.activeExplorations['exploration-1'].total_caps_found).toBe(100)
       expect(store.explorations[0].events).toHaveLength(1)
+    })
+  })
+
+  describe('SSE Rewards Enqueuing', () => {
+    it('should enqueue rewards via addPendingReport on completion SSE', async () => {
+      const store = useExplorationStore()
+      store.startSseSubscription('vault-1', 'test-token')
+
+      mockSseEvent.value = {
+        event: 'exploration',
+        data: {
+          type: 'exploration_complete',
+          dweller_id: 'dweller-1',
+          rewards: mockRewardsSummary,
+        },
+      }
+
+      await nextTick()
+
+      expect(addPendingReport).toHaveBeenCalledWith({
+        vaultId: 'vault-1',
+        dwellerId: 'dweller-1',
+        dwellerName: 'Amata Almodovar',
+        rewards: mockRewardsSummary,
+      })
+    })
+
+    it('should use fallback dweller name when dweller not found', async () => {
+      const store = useExplorationStore()
+      store.startSseSubscription('vault-1', 'test-token')
+
+      mockSseEvent.value = {
+        event: 'exploration',
+        data: {
+          type: 'exploration_complete',
+          dweller_id: 'unknown-dweller',
+          rewards: mockRewardsSummary,
+        },
+      }
+
+      await nextTick()
+
+      expect(addPendingReport).toHaveBeenCalledWith({
+        vaultId: 'vault-1',
+        dwellerId: 'unknown-dweller',
+        dwellerName: 'Dweller',
+        rewards: mockRewardsSummary,
+      })
+    })
+
+    it('should still set pendingSseRewards for live display', async () => {
+      const store = useExplorationStore()
+      store.startSseSubscription('vault-1', 'test-token')
+
+      mockSseEvent.value = {
+        event: 'exploration',
+        data: {
+          type: 'exploration_complete',
+          dweller_id: 'dweller-1',
+          rewards: mockRewardsSummary,
+        },
+      }
+
+      await nextTick()
+
+      expect(store.pendingSseRewards).toEqual({
+        rewards: mockRewardsSummary,
+        dwellerId: 'dweller-1',
+      })
     })
   })
 })


### PR DESCRIPTION
## Summary

**Overseer Reports** — long-running dweller activities now end in a visible, durable, click-through outcome instead of a silent state change, and combat incidents report their resolution.

## Changes

### Features
- **Training completion reports** — `training_complete` notifications carry the stat change (`stat_name`, `old_value`, `new_value`); clicking opens the dweller's Stats tab with the improved SPECIAL stat highlighted (+1 badge, reduced-motion aware).
- **Exploration reward reports** — completion notifications carry the full rewards payload, and reward reports are queued durably in `localStorage` (`usePendingReports`, survive reload/offline) and re-shown as the rewards modal on the next visit to the exploration view until acknowledged.
- **Incident outcome reports** — resolving an incident sends a `combat_victory` or `combat_defeat` notification with the outcome summary (`caps_earned`, `loot` in `meta_data`); clicking opens the vault view.

### Fixes
- **Breeding at population capacity** — `check_for_conception` no longer starts a new pregnancy when the vault population has reached `population_max`; already-committed pregnancies reserve their slot, and a single free slot can only be consumed by one new conception per game tick.

### Refactor
- **Notification plumbing compaction** — a shared `notify_owner` helper centralizes the vault-owner lookup + best-effort delivery across the training, death, and incident services; the exploration report queue uses VueUse `useStorage` instead of hand-rolled localStorage sync (unused `consumePendingReport`/`clearPendingReports` removed).

## Tests
- Backend: 2 new tests (`test_incident_victory_sends_notification`, `test_incident_defeat_sends_notification`); ruff clean; 62 related tests green.
- Frontend: exploration store + DwellerStats tests green (39); lint + `vue-tsc` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added notifications for training completion, exploration rewards, dweller deaths, and incident victories or defeats.
  - Exploration rewards now remain available until acknowledged, including after reconnecting.
  - Combat notifications include dedicated status icons and navigation to the relevant vault.
  - Training notifications can open the affected dweller’s stats.
  - Dweller stat increases display a temporary “+1” highlight.
- **Bug Fixes**
  - Breeding now respects vault population limits and reserves capacity for existing pregnancies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->