### PR TITLE
fix(map): use a globally identical neighbor-signal roster

### DIFF
--- a/backend/app/services/map_service.py
+++ b/backend/app/services/map_service.py
@@ -382,7 +382,7 @@ class MapService:
             )
 
         # --- computed vault markers ---
-        specs = seeded_vault_specs(vault.id, vault.number)
+        specs = seeded_vault_specs(vault.number)
         vault_markers = [
             VaultMarkerRead(
                 name=s.name,

--- a/backend/app/tests/test_services/test_map_service.py
+++ b/backend/app/tests/test_services/test_map_service.py
@@ -214,16 +214,13 @@ async def test_get_vault_map_seeds_home_marker_once(async_session: AsyncSession,
 
 @pytest.mark.asyncio
 async def test_get_vault_map_returns_vault_markers(async_session: AsyncSession, vault: Vault) -> None:
-    """get_vault_map returns computed VaultMarkerRead items (3-7, excluding home)."""
+    """get_vault_map returns the globally consistent computed signal roster."""
     response = await map_service.get_vault_map(async_session, vault)
 
     assert response.vault_markers is not None
     assert 3 <= len(response.vault_markers) <= 7
 
-    # None of the computed markers should match the home vault
-    home_name = f"Vault {vault.number:03}"
     for marker in response.vault_markers:
-        assert marker.name != home_name
         assert marker.type == "vault"
         assert "Unexplored vault signal" in marker.description
 

--- a/backend/app/tests/test_utils/test_places.py
+++ b/backend/app/tests/test_utils/test_places.py
@@ -1,7 +1,5 @@
 """Tests for deterministic world-map place utilities."""
 
-from uuid import UUID
-
 from app.utils.places import (
     GENERIC_ORIGIN_SKIP,
     collision_nudge,
@@ -95,45 +93,38 @@ class TestCollisionNudge:
 class TestSeededVaultSpecs:
     """Tests for seeded_vault_specs."""
 
-    VAULT_1 = UUID("00000000-0000-0000-0000-000000000001")
-
     def test_count_in_range(self) -> None:
-        for i in range(20):
-            specs = seeded_vault_specs(UUID(int=i + 1), home_number=1)
+        for home in range(1, 21):
+            specs = seeded_vault_specs(home_number=home)
             assert 3 <= len(specs) <= 7
 
     def test_deterministic_across_calls(self) -> None:
-        first = seeded_vault_specs(self.VAULT_1, home_number=1)
-        second = seeded_vault_specs(self.VAULT_1, home_number=1)
-        assert first == second
+        assert seeded_vault_specs(home_number=1) == seeded_vault_specs(home_number=1)
 
-    def test_numbers_distinct_and_exclude_home(self) -> None:
-        for i in range(10):
-            home = i + 1
-            specs = seeded_vault_specs(UUID(int=i + 100), home_number=home)
+    def test_numbers_are_distinct_and_valid(self) -> None:
+        for home in range(1, 11):
+            specs = seeded_vault_specs(home_number=home)
             numbers = [int(seed.name.split()[-1]) for seed in specs]
             assert len(numbers) == len(set(numbers))
-            assert home not in numbers
             for number in numbers:
                 assert 1 <= number <= 999
 
     def test_names_formatted(self) -> None:
-        specs = seeded_vault_specs(self.VAULT_1, home_number=1)
-        for seed in specs:
+        for seed in seeded_vault_specs(home_number=1):
             assert seed.name == f"Vault {int(seed.name.split()[-1]):03}"
 
     def test_coords_within_bounds(self) -> None:
-        specs = seeded_vault_specs(self.VAULT_1, home_number=1)
-        for seed in specs:
+        for seed in seeded_vault_specs(home_number=1):
             assert 0.0 <= seed.coord_x <= 100.0
             assert 0.0 <= seed.coord_y <= 100.0
 
     def test_coords_avoid_home_origin_and_each_other(self) -> None:
-        specs = seeded_vault_specs(self.VAULT_1, home_number=1)
+        specs = seeded_vault_specs(home_number=1)
         coords = {(seed.coord_x, seed.coord_y) for seed in specs}
         assert len(coords) == len(specs)
         assert (50.0, 50.0) not in coords
 
-    def test_different_vaults_differ(self) -> None:
-        other = UUID("00000000-0000-0000-0000-000000000002")
-        assert seeded_vault_specs(self.VAULT_1, home_number=1) != seeded_vault_specs(other, home_number=1)
+    def test_viewer_independent_shared_world(self) -> None:
+        roster = seeded_vault_specs(home_number=1)
+        for home_number in range(2, 1_000):
+            assert seeded_vault_specs(home_number=home_number) == roster

--- a/backend/app/utils/places.py
+++ b/backend/app/utils/places.py
@@ -2,17 +2,14 @@
 
 Pure functions only: no DB access, no randomness, no time, no I/O. The same
 input always yields the same output across calls and processes, so map
-markers derived from place names and vault ids are stable and reproducible.
+markers derived from place names and a fixed world seed are stable and
+reproducible — and identical for every viewer (shared world).
 """
 
 from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from uuid import UUID
 
 #: Place origins that should never produce a map marker.
 GENERIC_ORIGIN_SKIP: frozenset[str] = frozenset({"", "wasteland", "the wasteland", "unknown"})
@@ -90,16 +87,24 @@ class VaultSeed:
     coord_y: float
 
 
-def seeded_vault_specs(vault_id: UUID, home_number: int) -> list[VaultSeed]:
-    """Generate 3-7 deterministic vault marker specs from a vault UUID.
+#: Fixed global seed — viewer-independent so every player sees the same wasteland.
+#: Never derive this from a viewer's vault id.
+_NEIGHBOR_VAULT_SEED = b"wasteland:neighbor-vaults"
 
-    Numbers are drawn in the 1-999 range, distinct from each other and from
-    ``home_number``, from a chained sha256 stream seeded by the vault id
-    (each digest is re-hashed with an appended counter byte for entropy).
+
+def seeded_vault_specs(home_number: int | None = None) -> list[VaultSeed]:
+    """Generate 3-7 deterministic neighbor-vault marker specs for the shared world.
+
+    Numbers are drawn in the 1-999 range from a chained sha256 stream seeded by
+    a fixed global constant (not the viewer's vault id), so every player sees
+    the same neighbor vaults at the same coordinates. ``home_number`` is
+    retained only for call-site compatibility and does not affect the roster.
+
     Coordinates come from the schematic hash of the vault name, nudged away
-    from every previously seeded marker and from the home-vault origin.
+    from the home-vault origin (50, 50) and from every previously seeded marker.
     """
-    digest = hashlib.sha256(str(vault_id).encode("utf-8")).digest()
+    del home_number
+    digest = hashlib.sha256(_NEIGHBOR_VAULT_SEED).digest()
     count = 3 + digest[0] % 5
     specs: list[VaultSeed] = []
     occupied: set[tuple[float, float]] = {(50.0, 50.0)}
@@ -109,7 +114,7 @@ def seeded_vault_specs(vault_id: UUID, home_number: int) -> list[VaultSeed]:
         number = int.from_bytes(digest[:2], "big") % 999 + 1
         digest = hashlib.sha256(digest + bytes([counter])).digest()
         counter += 1
-        if number in numbers or number == home_number:
+        if number in numbers:
             continue
         numbers.add(number)
         name = f"Vault {number:03}"


### PR DESCRIPTION
## Summary
- derive temporary vault signals from a fixed global roster
- retain the legacy home-number argument without letting it change output
- add coverage across every valid vault number

## Verification
- uv run pytest app/tests/test_utils/test_places.py
- uv run ruff check app