### PR TITLE
feat(exploration): add the Wasteland Journal

### DIFF
--- a/backend/app/crud/wasteland_location.py
+++ b/backend/app/crud/wasteland_location.py
@@ -57,6 +57,7 @@ class CRUDWastelandLocation:
         type: str,
         description: str | None = None,
         exploration_id: UUID4 | None = None,
+        commit: bool = True,
     ) -> WastelandLocation:
         """Get or create a location row with race-safe upsert.
 
@@ -66,7 +67,9 @@ class CRUDWastelandLocation:
         the exact documented pattern from ``CRUDUserProfile.create_for_user``.
 
         Distinguishes name conflicts (return existing row) from coordinate
-        conflicts (re-derive fresh coords, bounded retry).
+        conflicts (re-derive fresh coords, bounded retry). When ``commit`` is
+        false, inserts are flushed and remain part of the caller's outer
+        transaction.
         """
         normalized = normalize_place_name(name)
 
@@ -101,8 +104,13 @@ class CRUDWastelandLocation:
                 vault_id=vault_id,
                 exploration_id=exploration_id,
             )
-            db_session.add(obj)
+            if not commit:
+                db_session.add(obj)
+                await db_session.flush()
+                return obj
+
             try:
+                db_session.add(obj)
                 await db_session.commit()
             except IntegrityError:
                 # Race: another request already inserted this name

--- a/backend/app/models/exploration.py
+++ b/backend/app/models/exploration.py
@@ -115,7 +115,16 @@ class Exploration(BaseUUIDModel, ExplorationBase, TimeStampMixin, table=True):
         self.end_time = datetime.utcnow()
 
     def add_event(
-        self, event_type: str, description: str, loot: dict | None = None, location_name: str | None = None
+        self,
+        event_type: str,
+        description: str,
+        loot: dict | None = None,
+        location_name: str | None = None,
+        location_id: UUID4 | None = None,
+        coord_x: float | None = None,
+        coord_y: float | None = None,
+        health_loss: int | None = None,
+        health_restored: int | None = None,
     ) -> dict:
         """Add an event to the journey log.
 
@@ -131,6 +140,16 @@ class Exploration(BaseUUIDModel, ExplorationBase, TimeStampMixin, table=True):
             event["loot"] = loot
         if location_name:
             event["location_name"] = location_name
+        if location_id is not None:
+            event["location_id"] = str(location_id)
+        if coord_x is not None:
+            event["coord_x"] = coord_x
+        if coord_y is not None:
+            event["coord_y"] = coord_y
+        if health_loss is not None:
+            event["health_loss"] = health_loss
+        if health_restored is not None:
+            event["health_restored"] = health_restored
         self.events.append(event)
         # Flag the field as modified so SQLAlchemy tracks the change
         orm.attributes.flag_modified(self, "events")

--- a/backend/app/services/exploration/coordinator.py
+++ b/backend/app/services/exploration/coordinator.py
@@ -79,7 +79,31 @@ class ExplorationCoordinator:
         if not event:
             return exploration
 
-        # Add event to exploration
+        # Resolve a discovery's world-map location before persisting so the event
+        # can carry location_id + coordinates for deep-linking and route drawing.
+        location_name = getattr(event, "location_name", None)
+        location_id = None
+        coord_x = None
+        coord_y = None
+        if location_name:
+            try:
+                from app.services.map_service import map_service
+
+                location = await map_service.register_discovery(
+                    db_session, exploration.vault_id, exploration.id, location_name
+                )
+                if location is not None:
+                    location_id = location.id
+                    coord_x = location.coord_x
+                    coord_y = location.coord_y
+            except Exception:
+                logger.exception(
+                    "Failed to register discovery: vault=%s exploration=%s location=%r",
+                    exploration.vault_id,
+                    exploration.id,
+                    location_name,
+                )
+
         # Convert loot schema to dict for JSON storage
         loot_dict = None
         if hasattr(event, "loot") and event.loot:
@@ -89,7 +113,12 @@ class ExplorationCoordinator:
             event_type=event.type,
             description=event.description,
             loot=loot_dict,
-            location_name=getattr(event, "location_name", None),
+            location_name=location_name,
+            location_id=location_id,
+            coord_x=coord_x,
+            coord_y=coord_y,
+            health_loss=getattr(event, "health_loss", None),
+            health_restored=getattr(event, "health_restored", None),
         )
         db_session.add(exploration)
         event_records = [event_record]
@@ -118,21 +147,6 @@ class ExplorationCoordinator:
         db_session.add(exploration)
         await db_session.commit()
         await db_session.refresh(exploration)
-
-        # Register discovery on the world map (best-effort, non-critical)
-        location_name = getattr(event, "location_name", None)
-        if location_name:
-            try:
-                from app.services.map_service import map_service
-
-                await map_service.register_discovery(db_session, exploration.vault_id, exploration.id, location_name)
-            except Exception:
-                logger.exception(
-                    "Failed to register discovery: vault=%s exploration=%s location=%r",
-                    exploration.vault_id,
-                    exploration.id,
-                    location_name,
-                )
 
         dweller_obj = await dweller_crud.get(db_session, exploration.dweller_id)
 
@@ -257,6 +271,7 @@ class ExplorationCoordinator:
                 exploration.add_event(
                     event_type=ExplorationEventType.ITEM_USE,
                     description=f"Dweller used a Stimpak. Healed {healing} HP. {exploration.stimpaks} left.",
+                    health_restored=healing,
                 )
             )
             db_session.add(dweller_obj)

--- a/backend/app/services/map_service.py
+++ b/backend/app/services/map_service.py
@@ -266,17 +266,25 @@ class MapService:
         vault_id: UUID4,
         exploration_id: UUID4,
         location_name: str,
-    ) -> None:
-        """Upsert a DISCOVERY location row for an exploration — best-effort."""
+    ) -> WastelandLocation | None:
+        """Upsert a DISCOVERY location row for an exploration — best-effort.
+
+        Returns the location row (with id and coordinates) when successful, else None.
+        """
         try:
-            await wl_crud.get_or_create(
+            return await wl_crud.get_or_create(
                 db_session,
                 vault_id=vault_id,
                 name=location_name[:64],
                 type=LocationTypeEnum.DISCOVERY,
                 exploration_id=exploration_id,
+                commit=False,
             )
         except Exception:
+            # A failed flush leaves SQLAlchemy's transaction unusable. This
+            # registration is best-effort and runs before the event mutation,
+            # so reset it and let the discovery event continue without a link.
+            await db_session.rollback()
             logger.exception(
                 "register_discovery failed: vault=%s exploration=%s name=%r",
                 vault_id,

--- a/backend/app/tests/test_services/test_discovery_events.py
+++ b/backend/app/tests/test_services/test_discovery_events.py
@@ -18,6 +18,7 @@ from app.models.wasteland_location import LocationTypeEnum, WastelandLocation
 from app.schemas.exploration_event import DiscoveryEventSchema, ExplorationEvent
 from app.services.exploration.event_generator import event_generator
 from app.services.exploration_service import exploration_service
+from app.services.map_service import map_service
 
 
 def _make_expired_exploration(exploration: Exploration) -> None:
@@ -88,6 +89,49 @@ async def test_add_event_persists_location_name(
     persisted = exploration.events[-1]
     assert persisted["type"] == "discovery"
     assert persisted["location_name"] == "Rusty Depot"
+
+
+@pytest.mark.asyncio
+async def test_map_routes_preserve_repeated_discoveries_from_event_history(
+    async_session: AsyncSession,
+    vault: Vault,
+    dweller: Dweller,
+):
+    """The map route comes from events, not the de-duplicated location row."""
+    exploration = await crud.exploration.create_with_dweller_stats(
+        async_session,
+        vault_id=vault.id,
+        dweller_id=dweller.id,
+        duration=4,
+    )
+    location = await map_service.register_discovery(async_session, vault.id, exploration.id, "Rusty Depot")
+    assert location is not None
+
+    exploration.add_event(
+        "discovery",
+        "First discovery.",
+        location_name=location.name,
+        location_id=location.id,
+        coord_x=location.coord_x,
+        coord_y=location.coord_y,
+    )
+    exploration.add_event(
+        "discovery",
+        "Rediscovered on a later leg.",
+        location_name=location.name,
+        location_id=location.id,
+        coord_x=location.coord_x,
+        coord_y=location.coord_y,
+    )
+    async_session.add(exploration)
+    await async_session.commit()
+
+    map_payload = await map_service.get_vault_map(async_session, vault)
+    assert len(map_payload.discovery_routes) == 1
+    route = map_payload.discovery_routes[0]
+    assert route.exploration_id == exploration.id
+    assert [point.location_id for point in route.points] == [location.id, location.id]
+    assert route.points[0].coord_x == round(location.coord_x * 1.6, 1)
 
 
 @pytest.mark.asyncio
@@ -232,9 +276,6 @@ async def test_process_event_registers_discovery_location(
 
     await async_session.refresh(result)
 
-    # Event persisted with location_name
-    assert result.events[0]["location_name"] == "Rusty Depot"
-
     # DISCOVERY WastelandLocation row exists
     location_stmt = select(WastelandLocation).where(
         WastelandLocation.type == LocationTypeEnum.DISCOVERY,
@@ -244,6 +285,12 @@ async def test_process_event_registers_discovery_location(
     assert len(locations) == 1
     assert locations[0].exploration_id == exploration.id
     assert locations[0].name == "Rusty Depot"
+
+    event = result.events[0]
+    assert event["location_name"] == "Rusty Depot"
+    assert event["location_id"] == str(locations[0].id)
+    assert event["coord_x"] == locations[0].coord_x
+    assert event["coord_y"] == locations[0].coord_y
 
     # No LLMInteraction rows created
     llm_count_stmt = select(LLMInteraction)

--- a/backend/app/tests/test_services/test_map_service.py
+++ b/backend/app/tests/test_services/test_map_service.py
@@ -1,6 +1,7 @@
 """Tests for MapService — registration and map assembly."""
 
 from unittest.mock import AsyncMock, patch
+from uuid import uuid4
 
 import pytest
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
@@ -228,6 +229,24 @@ async def test_get_vault_map_returns_vault_markers(async_session: AsyncSession, 
     assert len(response.locations) >= 1
     home_locs = [loc for loc in response.locations if loc.type == LocationTypeEnum.HOME_VAULT]
     assert len(home_locs) == 1
+
+
+@pytest.mark.asyncio
+async def test_register_discovery_rolls_back_with_callers_transaction(async_session: AsyncSession, vault: Vault) -> None:
+    """Discovery registration must not commit before its event can be persisted."""
+    location = await map_service.register_discovery(async_session, vault.id, uuid4(), "Rollback Depot")
+    assert location is not None
+
+    await async_session.rollback()
+
+    rows = (
+        await async_session.execute(
+            select(WastelandLocation).where(
+                WastelandLocation.normalized_name == normalize_place_name("Rollback Depot")
+            )
+        )
+    ).scalars().all()
+    assert rows == []
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_services/test_map_service.py
+++ b/backend/app/tests/test_services/test_map_service.py
@@ -232,7 +232,9 @@ async def test_get_vault_map_returns_vault_markers(async_session: AsyncSession, 
 
 
 @pytest.mark.asyncio
-async def test_register_discovery_rolls_back_with_callers_transaction(async_session: AsyncSession, vault: Vault) -> None:
+async def test_register_discovery_rolls_back_with_callers_transaction(
+    async_session: AsyncSession, vault: Vault
+) -> None:
     """Discovery registration must not commit before its event can be persisted."""
     location = await map_service.register_discovery(async_session, vault.id, uuid4(), "Rollback Depot")
     assert location is not None
@@ -240,12 +242,16 @@ async def test_register_discovery_rolls_back_with_callers_transaction(async_sess
     await async_session.rollback()
 
     rows = (
-        await async_session.execute(
-            select(WastelandLocation).where(
-                WastelandLocation.normalized_name == normalize_place_name("Rollback Depot")
+        (
+            await async_session.execute(
+                select(WastelandLocation).where(
+                    WastelandLocation.normalized_name == normalize_place_name("Rollback Depot")
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert rows == []
 
 

--- a/frontend/src/modules/exploration/components/ExplorationEventLog.vue
+++ b/frontend/src/modules/exploration/components/ExplorationEventLog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
 import { Icon } from '@iconify/vue'
 import { getEventIcon, getEventColor } from '@/modules/exploration/models/exploration'
 import type { ExplorationEvent } from '@/modules/exploration/stores/exploration'
@@ -14,6 +15,13 @@ const props = withDefaults(defineProps<Props>(), {
   reverse: false,
   showLoot: true,
 })
+
+const router = useRouter()
+const route = useRoute()
+
+const goToLocation = (locationId: string) => {
+  router.push(`/vault/${route.params.id}/map?place=${locationId}`)
+}
 
 const orderedEvents = computed(() => {
   if (!props.reverse) return props.events
@@ -99,6 +107,14 @@ const getLootDisplay = (event: ExplorationEvent): string => {
             <span class="text-[0.8125rem] leading-[1.4] text-theme-primary/90">{{
               event.description
             }}</span>
+            <button
+              v-if="event.type === 'discovery' && event.location_id"
+              class="inline-flex items-center gap-1 self-start rounded-[3px] border border-theme-primary/40 bg-theme-primary/10 px-1.5 py-0.5 text-[0.75rem] font-semibold text-theme-primary transition-colors duration-150 hover:bg-theme-primary/20"
+              @click="goToLocation(event.location_id)"
+            >
+              <Icon icon="mdi:map-marker" class="h-3.5 w-3.5" />
+              View on map
+            </button>
             <div
               v-if="showLoot && hasLoot(event)"
               class="loot-line inline-flex items-center gap-1 self-start rounded-[3px] border border-rarity-legendary/30 bg-rarity-legendary/10 px-1.5 py-0.5 text-[0.75rem] font-semibold text-rarity-legendary"

--- a/frontend/src/modules/exploration/components/ExplorationLootList.vue
+++ b/frontend/src/modules/exploration/components/ExplorationLootList.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import type { LootItem } from '../stores/exploration'
+import { getRarityColor } from '../models/exploration'
+
+defineProps<{ items: LootItem[] }>()
+</script>
+
+<template>
+  <div
+    v-if="items.length > 0"
+    class="mb-4 rounded-lg border-2 border-theme-primary bg-terminal-background p-4 shadow-[0_0_20px_var(--color-theme-glow)]"
+  >
+    <h3 class="section-title mb-2 flex items-center text-base font-bold text-theme-primary">
+      <Icon icon="mdi:package-variant" class="mr-2" />
+      Loot Found ({{ items.length }})
+    </h3>
+    <ul class="flex max-h-[220px] flex-col gap-2 overflow-y-auto">
+      <li
+        v-for="(item, i) in items"
+        :key="`${item.item_name}-${item.found_at}-${i}`"
+        class="flex items-center justify-between rounded border-l-[3px] bg-terminal-background p-2.5 transition-all duration-200 hover:bg-theme-primary/10"
+        :style="{ borderLeftColor: getRarityColor(item.rarity) }"
+      >
+        <div class="flex items-center gap-2">
+          <Icon
+            icon="mdi:treasure-chest"
+            class="h-5 w-5"
+            :style="{ color: getRarityColor(item.rarity) }"
+          />
+          <span class="text-sm font-semibold" :style="{ color: getRarityColor(item.rarity) }">
+            {{ item.item_name }}
+          </span>
+        </div>
+        <div class="flex items-center gap-2 text-xs">
+          <span class="font-semibold" :style="{ color: getRarityColor(item.rarity) }">
+            {{ item.rarity }}
+          </span>
+          <span class="text-theme-primary/70">x{{ item.quantity }}</span>
+        </div>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/frontend/src/modules/exploration/components/ExplorationRewardsModal.vue
+++ b/frontend/src/modules/exploration/components/ExplorationRewardsModal.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue'
 import { Icon } from '@iconify/vue'
 import type { RewardsSummary } from '@/modules/exploration/stores/exploration'
+import { getRarityColor } from '@/modules/exploration/models/exploration'
 
 interface Props {
   rewards: RewardsSummary | null
@@ -27,18 +28,6 @@ const safeRewards = computed(
 const emit = defineEmits<{
   close: []
 }>()
-
-const getRarityColor = (rarity?: string): string => {
-  const colors: Record<string, string> = {
-    Common: 'var(--color-rarity-common)',
-    Rare: 'var(--color-rarity-rare)',
-    Legendary: 'var(--color-rarity-legendary)',
-  }
-  if (rarity && colors[rarity]) {
-    return colors[rarity]!
-  }
-  return colors.Common!
-}
 </script>
 
 <template>

--- a/frontend/src/modules/exploration/models/exploration.ts
+++ b/frontend/src/modules/exploration/models/exploration.ts
@@ -44,3 +44,13 @@ export function getEventIcon(eventType: string): string {
 export function getEventColor(eventType: string): string {
   return EVENT_COLOR_MAP[eventType as ExplorationEventType] ?? DEFAULT_COLOR
 }
+
+const RARITY_COLOR_MAP: Record<string, string> = {
+  Common: 'var(--color-rarity-common)',
+  Rare: 'var(--color-rarity-rare)',
+  Legendary: 'var(--color-rarity-legendary)',
+}
+
+export function getRarityColor(rarity?: string): string {
+  return (rarity && RARITY_COLOR_MAP[rarity]) || RARITY_COLOR_MAP.Common!
+}

--- a/frontend/src/modules/exploration/stores/exploration.ts
+++ b/frontend/src/modules/exploration/stores/exploration.ts
@@ -14,6 +14,11 @@ export interface ExplorationEvent {
   timestamp: string
   time_elapsed_hours: number
   location_name?: string
+  location_id?: string
+  coord_x?: number
+  coord_y?: number
+  health_loss?: number
+  health_restored?: number
   loot?: {
     item: {
       name: string

--- a/frontend/src/modules/exploration/views/ExplorationDetailView.vue
+++ b/frontend/src/modules/exploration/views/ExplorationDetailView.vue
@@ -11,11 +11,13 @@ import { useToast } from '@/core/composables/useToast'
 import BackButton from '@/core/components/common/BackButton.vue'
 import SidePanel from '@/core/components/common/SidePanel.vue'
 import { useExplorationStore } from '../stores/exploration'
+import { useExplorationProgress } from '../composables/useExplorationProgress'
 import ExplorationRewardsModal from '../components/ExplorationRewardsModal.vue'
 import ExplorerNavbar from '../components/ExplorerNavbar.vue'
 import ExplorerSummaryCard from '../components/ExplorerSummaryCard.vue'
 import ExplorerStatsGrid from '../components/ExplorerStatsGrid.vue'
 import ExplorationEventLog from '../components/ExplorationEventLog.vue'
+import ExplorationLootList from '../components/ExplorationLootList.vue'
 import ExplorerEquipmentSlots from '../components/ExplorerEquipmentSlots.vue'
 import ExplorerActions from '../components/ExplorerActions.vue'
 import type { RewardsSummary } from '../stores/exploration'
@@ -88,39 +90,34 @@ const goBack = () => {
 }
 
 // Progress calculation
-const progressPercentage = computed(() => {
-  if (!exploration.value) return 0
-  const now = Date.now()
-  let startTimeStr = exploration.value.start_time
-  if (!startTimeStr.endsWith('Z')) {
-    startTimeStr = startTimeStr.replace(' ', 'T') + 'Z'
-  }
-  const start = new Date(startTimeStr).getTime()
-  const duration = exploration.value.duration * 3600 * 1000
-  const elapsed = now - start
-  return Math.min(100, (elapsed / duration) * 100)
-})
-
-const timeRemaining = computed(() => {
-  if (!exploration.value) return ''
-  const progress = progressPercentage.value
-  if (progress >= 100) return 'Complete!'
-
-  const totalDuration = exploration.value.duration * 3600
-  const remaining = totalDuration * (1 - progress / 100)
-
-  const hours = Math.floor(remaining / 3600)
-  const minutes = Math.floor((remaining % 3600) / 60)
-
-  if (hours > 0) {
-    return `${hours}h ${minutes}m remaining`
-  }
-  return `${minutes}m remaining`
-})
+const { progress: progressPercentage, timeRemaining } = useExplorationProgress(() => exploration.value)
 
 // Equipment computed
 const weaponName = computed(() => detailedDweller.value?.weapon?.name ?? null)
 const outfitName = computed(() => detailedDweller.value?.outfit?.name ?? null)
+
+const healthJourney = computed(() =>
+  (exploration.value?.events ?? []).filter((e) => e.health_loss != null || e.health_restored != null)
+)
+const totalDamage = computed(() => healthJourney.value.reduce((sum, e) => sum + (e.health_loss ?? 0), 0))
+const totalHealed = computed(() => healthJourney.value.reduce((sum, e) => sum + (e.health_restored ?? 0), 0))
+const healthTrendPoints = computed(() => {
+  const deltas = healthJourney.value.map((event) => (event.health_restored ?? 0) - (event.health_loss ?? 0))
+  const values = [0]
+  for (const delta of deltas) values.push(values[values.length - 1]! + delta)
+  const min = Math.min(...values)
+  const max = Math.max(...values)
+  const range = max - min || 1
+  const width = 120
+  const height = 28
+  return values
+    .map((value, index) => {
+      const x = (index / Math.max(values.length - 1, 1)) * width
+      const y = height - ((value - min) / range) * height
+      return `${x.toFixed(1)},${y.toFixed(1)}`
+    })
+    .join(' ')
+})
 
 // Actions
 const handleCompleteExploration = async () => {
@@ -265,6 +262,35 @@ watch(
           />
 
           <ExplorerStatsGrid v-if="exploration" :exploration="exploration" />
+
+          <!-- Vitals journey: cumulative health change (not an absolute health history). -->
+          <div
+            v-if="healthJourney.length > 0"
+            class="mb-4 flex flex-wrap items-center gap-4 rounded-lg border-2 border-theme-primary/40 bg-terminal-background p-3 text-sm"
+          >
+            <span class="flex items-center gap-1.5">
+              <Icon icon="mdi:heart-broken" class="h-5 w-5 text-[#ff4444]" />
+              <span class="font-bold text-[#ff4444]">-{{ totalDamage }}</span>
+              <span class="text-theme-primary/70">damage</span>
+            </span>
+            <span class="flex items-center gap-1.5">
+              <Icon icon="mdi:heart-plus" class="h-5 w-5 text-[#00ced1]" />
+              <span class="font-bold text-[#00ced1]">+{{ totalHealed }}</span>
+              <span class="text-theme-primary/70">healed</span>
+            </span>
+            <span class="text-theme-primary/50">over {{ healthJourney.length }} events</span>
+            <svg
+              class="ml-auto h-7 w-[120px] overflow-visible"
+              viewBox="0 0 120 28"
+              role="img"
+              aria-label="Cumulative health change during this expedition"
+            >
+              <polyline :points="healthTrendPoints" fill="none" stroke="var(--color-theme-accent)" stroke-width="2" />
+            </svg>
+          </div>
+
+          <!-- Loot found mid-journey -->
+          <ExplorationLootList :items="exploration.loot_collected" />
 
           <!-- Event Log Section -->
           <ExplorationEventLog :events="exploration?.events ?? []" reverse />


### PR DESCRIPTION
## Summary
- show collected loot and cumulative health changes in exploration detail
- deep-link discovery events to their map marker
- persist discovery metadata atomically with the exploration transaction

## Verification
- uv run pytest app/tests/test_services/test_discovery_events.py app/tests/test_services/test_map_service.py
- pnpm exec vp test tests/unit/views/ExplorationDetailView.test.ts --run