### PR TITLE
feat(map): render event-authoritative discovery routes

### DIFF
--- a/backend/app/schemas/wasteland_location.py
+++ b/backend/app/schemas/wasteland_location.py
@@ -53,8 +53,25 @@ class VaultMarkerRead(SQLModel):
     description: str
 
 
+class DiscoveryRoutePoint(SQLModel):
+    """One persisted discovery event, projected into map coordinates."""
+
+    location_id: UUID4
+    coord_x: float
+    coord_y: float
+    timestamp: str
+
+
+class DiscoveryRouteRead(SQLModel):
+    """Ordered discovery trail for a single exploration."""
+
+    exploration_id: UUID4
+    points: list[DiscoveryRoutePoint]
+
+
 class VaultMapResponse(SQLModel):
     """Full world-map payload: persisted locations + computed vault markers."""
 
     locations: list[WastelandLocationWithDwellers]
     vault_markers: list[VaultMarkerRead]
+    discovery_routes: list[DiscoveryRouteRead] = []

--- a/backend/app/services/map_service.py
+++ b/backend/app/services/map_service.py
@@ -13,9 +13,11 @@ from typing import TYPE_CHECKING, Protocol
 
 from pydantic import UUID4  # ruff: ignore[typing-only-third-party-import]
 from sqlalchemy.exc import IntegrityError
+from sqlmodel import select
 
 from app.core.game_config import game_config
 from app.crud.wasteland_location import wasteland_location as wl_crud
+from app.models.exploration import Exploration
 from app.models.notification import NotificationPriority, NotificationType
 from app.models.vault import Vault
 from app.models.wasteland_location import (
@@ -25,6 +27,8 @@ from app.models.wasteland_location import (
 )
 from app.schemas.common import RarityEnum  # ruff: ignore[typing-only-first-party-import]
 from app.schemas.wasteland_location import (
+    DiscoveryRoutePoint,
+    DiscoveryRouteRead,
     DwellerRef,
     VaultMapResponse,
     VaultMarkerRead,
@@ -291,6 +295,43 @@ class MapService:
                 exploration_id,
                 location_name,
             )
+            return None
+
+    async def _get_discovery_routes(
+        self, db_session: AsyncSession, vault_id: UUID4
+    ) -> list[DiscoveryRouteRead]:
+        """Project discovery events into ordered map trails.
+
+        A ``WastelandLocation`` is intentionally de-duplicated by place name,
+        so it cannot faithfully represent repeated visits across expeditions.
+        Event records are the journey history and therefore the route authority.
+        Older events without the Journal coordinate fields are simply omitted.
+        """
+        result = await db_session.execute(select(Exploration).where(Exploration.vault_id == vault_id))
+        routes: list[DiscoveryRouteRead] = []
+        for exploration in result.scalars().all():
+            points: list[DiscoveryRoutePoint] = []
+            for event in exploration.events:
+                if event.get("type") != "discovery":
+                    continue
+                location_id = event.get("location_id")
+                coord_x = event.get("coord_x")
+                coord_y = event.get("coord_y")
+                timestamp = event.get("timestamp")
+                if location_id is None or coord_x is None or coord_y is None or not isinstance(timestamp, str):
+                    continue
+                points.append(
+                    DiscoveryRoutePoint(
+                        location_id=location_id,
+                        coord_x=round(float(coord_x) * WORLD_SCALE, 1),
+                        coord_y=round(float(coord_y) * WORLD_SCALE, 1),
+                        timestamp=timestamp,
+                    )
+                )
+            if len(points) >= 2:
+                points.sort(key=lambda point: point.timestamp)
+                routes.append(DiscoveryRouteRead(exploration_id=exploration.id, points=points))
+        return routes
 
     # ------------------------------------------------------------------
     # map assembly
@@ -402,7 +443,12 @@ class MapService:
             for s in specs
         ]
 
-        return VaultMapResponse(locations=locations, vault_markers=vault_markers)
+        discovery_routes = await self._get_discovery_routes(db_session, vault.id)
+        return VaultMapResponse(
+            locations=locations,
+            vault_markers=vault_markers,
+            discovery_routes=discovery_routes,
+        )
 
 
 # ------------------------------------------------------------------

--- a/backend/app/services/map_service.py
+++ b/backend/app/services/map_service.py
@@ -297,9 +297,7 @@ class MapService:
             )
             return None
 
-    async def _get_discovery_routes(
-        self, db_session: AsyncSession, vault_id: UUID4
-    ) -> list[DiscoveryRouteRead]:
+    async def _get_discovery_routes(self, db_session: AsyncSession, vault_id: UUID4) -> list[DiscoveryRouteRead]:
         """Project discovery events into ordered map trails.
 
         A ``WastelandLocation`` is intentionally de-duplicated by place name,

--- a/backend/app/tests/test_api/test_map.py
+++ b/backend/app/tests/test_api/test_map.py
@@ -269,5 +269,12 @@ async def test_openapi_schema_includes_map_schemas(
     # WastelandLocationRead is a base model — Pydantic v2 inlines its fields
     # into WastelandLocationWithDwellers rather than exposing it as a separate
     # component.  Assert the schemas actually returned by the map endpoints.
-    for required_schema in ("VaultMapResponse", "WastelandLocationWithDwellers", "VaultMarkerRead", "DwellerRef"):
+    for required_schema in (
+        "VaultMapResponse",
+        "WastelandLocationWithDwellers",
+        "VaultMarkerRead",
+        "DiscoveryRouteRead",
+        "DiscoveryRoutePoint",
+        "DwellerRef",
+    ):
         assert required_schema in schemas, f"{required_schema} missing from OpenAPI schemas"

--- a/backend/app/tests/test_services/test_map_service.py
+++ b/backend/app/tests/test_services/test_map_service.py
@@ -232,7 +232,9 @@ async def test_get_vault_map_returns_vault_markers(async_session: AsyncSession, 
 
 
 @pytest.mark.asyncio
-async def test_register_discovery_rolls_back_with_callers_transaction(async_session: AsyncSession, vault: Vault) -> None:
+async def test_register_discovery_rolls_back_with_callers_transaction(
+    async_session: AsyncSession, vault: Vault
+) -> None:
     """Discovery registration must not commit before its event can be persisted."""
     location = await map_service.register_discovery(async_session, vault.id, uuid4(), "Rollback Depot")
     assert location is not None
@@ -240,12 +242,16 @@ async def test_register_discovery_rolls_back_with_callers_transaction(async_sess
     await async_session.rollback()
 
     rows = (
-        await async_session.execute(
-            select(WastelandLocation).where(
-                WastelandLocation.normalized_name == normalize_place_name("Rollback Depot")
+        (
+            await async_session.execute(
+                select(WastelandLocation).where(
+                    WastelandLocation.normalized_name == normalize_place_name("Rollback Depot")
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert rows == []
 
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -30,6 +30,36 @@ AI-powered dweller interactions.
 
 ## Planned
 
+### World Map — Multiplayer-First Architecture (Target: TBD)
+
+**Focus**: Evolve the wasteland map into the game's multiplayer surface — one deterministic shared world
+with per-player fog of war, over which async-PvP raiding, cross-vault encounters, and social features layer.
+Feature contract: `docs/features/WORLD_MAP.md`; delivery plan: `docs/WORLD_MAP_PLAN.md`.
+
+**Near-term release — "The Wasteland Journal" (implemented locally; pending release):**
+- ✅ **Exploration journal polish** — mid-journey `loot_collected`, cumulative health-change trail,
+  consolidated progress math, and dead-component deletion.
+- ✅ **Discovery → map integration** — discovery event coordinates/IDs, deep-links, and event-authoritative
+  per-exploration routes on `WorldMap` (no migration).
+- ✅ **Determinism correction** — globally seeded neighbor-vault signals with regression coverage.
+- ✅ **Quest party-members fix** — `QuestsView` populates `questPartyMembersMap`, so party rosters render.
+
+Feature description: `docs/features/WASTELAND_JOURNAL.md`; delivery checklist and verification:
+`docs/WORLD_MAP_PLAN.md`.
+
+**Deferred multiplayer phases** (see `docs/WORLD_MAP_PLAN.md`):
+- 🔄 **Phase B — async-PvP raiding** — `RaidTarget` snapshots + a `raid` exploration subtype.
+- 🔄 **Phase C — cross-vault fallen dwellers** — global `FallenDwellerRegistry` (dead dwellers as raiders).
+- 🔄 **Phase D — social** — friends, vault visits, leaderboards, global location registry.
+
+**Guardrails:** async only (no live shared-world simulation); coordinates always derived from names; no
+denormalized global registry until Phase D; respect the v2.35+ net-LOC constraint (journal polish deletes
+more than it adds).
+
+**Success criteria:** the near-term release delivers a legible per-explorer journey (loot + health-change trail +
+map route), discovery events deep-link to their map marker, and neighbor vaults sit at globally-consistent
+coordinates — all test-backed.
+
 ### Next Big Feature — Family Relations (Target: TBD)
 
 **Focus**: Make the existing breeding/relationship systems into a visible family experience: family trees,
@@ -292,7 +322,7 @@ update reduce net source LOC (features that add code must first offset it by rem
 ### Phase 2: Advanced Gameplay
 
 - Combat enhancements (statistics, log/replay)
-- Exploration enhancement (events with choices, journal)
+- Exploration enhancement (events with choices; "journal" is now the near-term Wasteland Journal release — see World Map plan above)
 - ~~Family visualization (relationship graph, family tree)~~ → **now the next big feature** (see Planned above)
 
 ### Phase 3: Endgame
@@ -425,4 +455,5 @@ recorded per D8. No gaps found; no future ROADMAP items added from this workstre
 
 ---
 
-_Last updated: 2026-08-21_ (Overseer Reports PR #449 in review; CodeRabbit follow-ups tracked under Planned; next focus: Family Relations, Pydantic AI Gateway activation)
+_Last updated: 2026-08-21_ (World Map feature contracts and delivery plan separated; next focus: releasing
+"The Wasteland Journal", then async-PvP raiding. Plan: `docs/WORLD_MAP_PLAN.md`.)

--- a/docs/WORLD_MAP_PLAN.md
+++ b/docs/WORLD_MAP_PLAN.md
@@ -1,0 +1,73 @@
+# World Map Delivery Plan
+
+This document owns implementation sequencing, delivery status, verification, and future-phase contracts for
+the World Map. Feature behavior belongs in [World Map — Multiplayer-First](features/WORLD_MAP.md) and
+[The Wasteland Journal](features/WASTELAND_JOURNAL.md).
+
+## Current status
+
+**Phase A — The Wasteland Journal:** implemented locally; pending commit/release.
+
+The release provides a per-explorer journey record, discovery-to-map links, event-authoritative map routes,
+and viewer-independent temporary vault signals. It also consolidates exploration progress calculation, removes
+two obsolete exploration components, and fixes quest party-member rendering.
+
+## Phase A delivery checklist
+
+- [x] Persist discovery `location_id` and unscaled map coordinates on JSON event records; no migration.
+- [x] Project ordered `discovery_routes` from `Exploration.events`, rather than from a de-duplicated
+  `WastelandLocation.exploration_id`.
+- [x] Keep historic events that have no route metadata compatible; they produce no trail segment.
+- [x] Add journal loot presentation and cumulative health-change trail. Automatic Stimpak use records its
+  healing delta.
+- [x] Link discovery events to `/vault/:id/map?place=<location_id>`.
+- [x] Use a fixed global neighbor-signal seed, with regression coverage.
+- [x] Consolidate exploration progress logic; delete `ExplorationConfigModal.vue` and `DwellerDropZone.vue`.
+- [x] Populate quest party members for quest cards.
+
+### Verification recorded for the current working tree
+
+| Check | Result |
+|---|---|
+| Backend focused exploration/map/place tests | 59 passed |
+| Backend `ruff check` | clean |
+| Frontend focused map/journal tests | 37 passed |
+| Frontend typecheck and lint | clean |
+| Diff whitespace check | clean |
+
+## Phase B — async raiding
+
+1. Introduce a stable `RaidTarget` keyed by target vault number plus snapshot version. The snapshot contains
+   only raid-relevant rooms, defenses, and eligible dwellers; never query a live vault while resolving combat.
+2. Give every real vault a marker derived from `normalize_place_name(f"Vault {number:03}")`. The global
+   roster remains only for NPC signals. A real marker replaces its matching NPC signal without moving.
+3. Add a `raid` exploration subtype with an idempotency key and explicit state machine:
+   `created → travelling → resolving → resolved|expired`. Apply rewards and losses in one transaction and
+   persist a durable result event for attacker and defender.
+4. Authorize target discovery server-side. The client may display a signal but cannot select arbitrary vault
+   IDs, request an old snapshot, or infer private dweller details from the map response.
+
+## Phase C — fallen-dweller encounters
+
+1. Add `FallenDwellerRegistry` as an immutable, minimal encounter projection: public combat stats,
+   deterministic encounter seed, transformation flags, source-vault pseudonym, and lifecycle state. Do not
+   expose a dead dweller's full biography or source-vault identity.
+2. Claim/resolution must be idempotent and use row-level ownership or a lease so concurrent explorers cannot
+   consume the same encounter twice.
+3. Seed encounter placement from registry ID/name, not death time or viewing vault, and retain a tombstone or
+   audit result for replay and support.
+
+## Phase D — social world registry
+
+1. Introduce `WorldLocation` (normalized-name authority and canonical coordinates) plus
+   `VaultLocationState` (discovered/unlocked/first-seen metadata). Backfill per-vault rows by normalized name
+   and compare coordinates before merging; retain conflicts for review rather than silently moving markers.
+2. Vault visits require an explicit friends/permission graph and versioned, read-only vault snapshots. Map and
+   leaderboard responses use privacy-safe aggregate data, pagination, and rate limits.
+3. Add observability before global queries: registry conflict count, route projection failures, raid resolution
+   retries, and per-vault map payload size. Migrate only once cross-vault queries, not speculation, justify it.
+
+## Deferred outside the map plan
+
+- Exploration events with player choices.
+- Persisted radiation deltas and an absolute radiation trend.

--- a/docs/features/WASTELAND_JOURNAL.md
+++ b/docs/features/WASTELAND_JOURNAL.md
@@ -1,0 +1,44 @@
+# The Wasteland Journal
+
+The Wasteland Journal makes an exploration legible as a journey: what an explorer found, what happened to
+them, and where discoveries sit in the wasteland. It is the per-vault, per-explorer layer of the World Map.
+
+> Related feature: [World Map — Multiplayer-First](WORLD_MAP.md). Delivery status and future work live in
+> [World Map delivery plan](../WORLD_MAP_PLAN.md).
+
+## Player experience
+
+### Journey record
+
+An explorer's detail view presents a chronological event log alongside the rewards collected during the
+expedition. Loot is shown by item and rarity rather than only as a counter. The current health journey is
+shown as total damage, total healing, and a cumulative health-change trail.
+
+The health trail is intentionally a record of changes, not an invented reconstruction of absolute historic
+health. Radiation is not charted until exploration events persist radiation deltas.
+
+### Discovery to map
+
+Every newly discovered location is added to the vault's map and its journal event provides a **View on map**
+action. The link opens that location's map detail for the same vault.
+
+The map draws a dashed route for an exploration when it has at least two recorded discoveries. Routes use the
+event order, so revisiting a known location remains part of the journey instead of being erased by the map's
+de-duplicated place marker.
+
+Older events that lack map metadata remain valid journal entries and markers; they simply do not produce route
+points.
+
+### Consistent exploration progress
+
+All exploration surfaces use the same elapsed-time calculation and time-zone-safe start-time parsing. A
+progress bar and remaining-time display therefore agree between explorer cards, the active list, and the
+detail view.
+
+## Boundaries
+
+- The Journal does not change exploration combat, reward, or encounter probabilities.
+- It is per-vault history; it neither exposes another player's exploration record nor creates live multiplayer
+  behavior.
+- A route is a visual journal trail, not a movement simulation or a navigation path.
+- Map coordinates remain deterministic and are governed by the World Map feature contract.

--- a/docs/features/WORLD_MAP.md
+++ b/docs/features/WORLD_MAP.md
@@ -1,0 +1,63 @@
+# World Map — Multiplayer-First Architecture
+
+The wasteland map is the game's multiplayer surface: one deterministic world that every player explores with
+their own fog of war. It supports the Wasteland Journal today and can later host asynchronous raiding,
+cross-vault encounters, visits, and leaderboards.
+
+> Related feature: [The Wasteland Journal](WASTELAND_JOURNAL.md). Delivery sequencing, status, and phase
+> implementation contracts live in the [World Map delivery plan](../WORLD_MAP_PLAN.md).
+
+## Shared-world model
+
+The map uses a deterministic coordinate engine, not a per-player drawing:
+
+| Utility | Behaviour |
+|---|---|
+| `schematic_coords(name)` | `sha256(place name) → (x,y)` in the 10.0–89.9 band. The same normalized name always lands in the same place. |
+| `collision_nudge(base, occupied)` | Deterministic spiral resolution for coordinate conflicts within a vault's persisted map state. |
+| `seeded_vault_specs(...)` | A fixed, viewer-independent roster of temporary neighbor-vault signals. |
+| frontend `wastelandTerrain.ts` | Fixed-seed procedural terrain, identical for every viewer. |
+
+Persistence stays on a 0–100 grid (`WastelandLocation.coord_x/y`, DB check-constrained); the map API scales
+it with `WORLD_SCALE = 1.6` to the 0–160 render world (`MAP_SIZE = 160`).
+
+Place rows are scoped to `vault_id`, which gives every vault independent discovery and unlock state. Since a
+place name resolves to the same base coordinate for every vault, this produces one shared physical world with
+per-player fog of war.
+
+## Invariants
+
+1. **One deterministic world, per-player fog.** Coordinates derive from names. Per-player discovery and
+   unlock state belongs to vault-scoped state, not the world model.
+2. **Async multiplayer.** A raid resolves against a snapshot, never a live vault simulation. The offline game
+   loop makes live shared-world authority incompatible with this architecture.
+3. **`Vault.number` is global identity.** A real vault's world marker derives from its number, never from the
+   viewer's identity.
+4. **Names are coordinate authority.** Future denormalization deduplicates normalized names, not stored
+   coordinates.
+
+## Vault signals
+
+Temporary neighbor signals come from one fixed global roster. Each signal's coordinate derives from its target
+vault number, with deterministic collision handling, so a given signal stays in the same place for every
+viewer. A viewer's own vault remains a separate home marker during the Journal stage.
+
+When real raid targets are introduced, a real vault marker replaces the matching temporary signal without
+moving it. A temporary signal is visual scaffolding only: it is not an authority for a target, raid result, or
+private vault data.
+
+## Multiplayer surface
+
+| Feature | Map role |
+|---|---|
+| Wasteland Journal | Explorer route, loot, discoveries, and map deep-links for one vault. |
+| Async raiding | Vault markers become targets for snapshot-based raid expeditions. |
+| Fallen dwellers | Deterministic encounters can reuse an eligible fallen dweller as an enemy. |
+| Vault visits | Friends can view a permissioned, read-only vault snapshot. |
+| Leaderboards | Aggregate discoveries, population, and raid results can be ranked safely. |
+
+## Boundaries
+
+- No live shared-world simulation.
+- No global location registry until cross-vault queries justify one.
+- No map-driven changes to exploration reward or combat mechanics.

--- a/frontend/src/core/types/api.generated.ts
+++ b/frontend/src/core/types/api.generated.ts
@@ -7876,6 +7876,26 @@ export interface components {
             locations: components["schemas"]["WastelandLocationWithDwellers"][];
             /** Vault Markers */
             vault_markers: components["schemas"]["VaultMarkerRead"][];
+            /** Discovery Routes */
+            discovery_routes?: components["schemas"]["DiscoveryRouteRead"][];
+        };
+        /** DiscoveryRoutePoint */
+        DiscoveryRoutePoint: {
+            /** Location Id */
+            location_id: string;
+            /** Coord X */
+            coord_x: number;
+            /** Coord Y */
+            coord_y: number;
+            /** Timestamp */
+            timestamp: string;
+        };
+        /** DiscoveryRouteRead */
+        DiscoveryRouteRead: {
+            /** Exploration Id */
+            exploration_id: string;
+            /** Points */
+            points: components["schemas"]["DiscoveryRoutePoint"][];
         };
         /**
          * VaultMarkerRead

--- a/frontend/src/modules/map/components/WorldMap.vue
+++ b/frontend/src/modules/map/components/WorldMap.vue
@@ -2,7 +2,7 @@
 import { computed, ref } from 'vue'
 import { Icon } from '@iconify/vue'
 import { UButton } from '@/core/components/ui'
-import type { WastelandLocationWithDwellers, VaultMarkerRead } from '../models/map'
+import type { DiscoveryRouteRead, WastelandLocationWithDwellers, VaultMarkerRead } from '../models/map'
 import MapMarker from './MapMarker.vue'
 import MapLegend from './MapLegend.vue'
 import MarkerListPanel from './MarkerListPanel.vue'
@@ -13,9 +13,10 @@ import { useMapZoomPan } from '../composables/useMapZoomPan'
 interface Props {
   locations: WastelandLocationWithDwellers[]
   vaultMarkers: VaultMarkerRead[]
+  discoveryRoutes?: DiscoveryRouteRead[]
 }
 
-const props = defineProps<Props>()
+const props = withDefaults(defineProps<Props>(), { discoveryRoutes: () => [] })
 
 const emit = defineEmits<{
   (
@@ -31,6 +32,10 @@ const emit = defineEmits<{
 // (they remain in the marker list panel and detail modal).
 const visibleLocations = computed(() =>
   props.locations.filter((loc) => !(loc.type === 'visited' && loc.dwellers.length < 2))
+)
+
+const discoveryRouteLines = computed(() =>
+  props.discoveryRoutes.map((route) => route.points.map((point) => `${point.coord_x},${point.coord_y}`).join(' '))
 )
 
 // ── Zoom & Pan ────────────────────────────────────────────────────────
@@ -196,6 +201,15 @@ function onPanelMarkerSelect(payload: {
         class="grid-line"
       />
 
+      <!-- Discovery routes (per-exploration trail) -->
+      <polyline
+        v-for="(route, i) in discoveryRouteLines"
+        :key="`route-${i}`"
+        :points="route"
+        class="discovery-route"
+        fill="none"
+      />
+
       <!-- Location markers (spread-adjusted positions) -->
       <MapMarker
         v-for="loc in visibleLocations"
@@ -280,6 +294,14 @@ function onPanelMarkerSelect(payload: {
 
 .world-map-container.is-dragging :deep(.map-marker) {
   cursor: grabbing;
+}
+
+.discovery-route {
+  stroke: var(--color-theme-accent);
+  stroke-width: 0.4;
+  stroke-dasharray: 2 2;
+  stroke-linecap: round;
+  opacity: 0.55;
 }
 
 .world-map-svg {

--- a/frontend/src/modules/map/models/map.ts
+++ b/frontend/src/modules/map/models/map.ts
@@ -3,6 +3,7 @@ import type { components } from '@/core/types/api.generated'
 // Type aliases from generated OpenAPI schemas
 export type WastelandLocationWithDwellers = components['schemas']['WastelandLocationWithDwellers']
 export type VaultMarkerRead = components['schemas']['VaultMarkerRead']
+export type DiscoveryRouteRead = components['schemas']['DiscoveryRouteRead']
 export type VaultMapResponse = components['schemas']['VaultMapResponse']
 export type DwellerRef = components['schemas']['DwellerRef']
 export type MapLocationType = components['schemas']['LocationTypeEnum']

--- a/frontend/src/modules/map/stores/map.ts
+++ b/frontend/src/modules/map/stores/map.ts
@@ -1,7 +1,7 @@
 import { ref, computed } from 'vue'
 import { defineStore } from 'pinia'
 import { useIntervalFn } from '@vueuse/core'
-import type { WastelandLocationWithDwellers, VaultMarkerRead } from '../models/map'
+import type { DiscoveryRouteRead, WastelandLocationWithDwellers, VaultMarkerRead } from '../models/map'
 import * as mapService from '../services/mapService'
 import { handleStoreError } from '@/core/utils/errorHandler'
 
@@ -9,6 +9,7 @@ export const useMapStore = defineStore('map', () => {
   // State
   const locations = ref<WastelandLocationWithDwellers[]>([])
   const vaultMarkers = ref<VaultMarkerRead[]>([])
+  const discoveryRoutes = ref<DiscoveryRouteRead[]>([])
   const isLoading = ref(false)
   const error = ref<string | null>(null)
 
@@ -28,6 +29,7 @@ export const useMapStore = defineStore('map', () => {
           if (gen !== _pollGeneration || vaultId !== _pollVaultId.value) return
           locations.value = data.locations
           vaultMarkers.value = data.vault_markers
+          discoveryRoutes.value = data.discovery_routes ?? []
         } catch (err) {
           if (gen !== _pollGeneration || vaultId !== _pollVaultId.value) return
           handleStoreError(err, 'Failed to poll map')
@@ -58,6 +60,7 @@ export const useMapStore = defineStore('map', () => {
       if (gen !== _pollGeneration) return
       locations.value = data.locations
       vaultMarkers.value = data.vault_markers
+      discoveryRoutes.value = data.discovery_routes ?? []
     } catch (err) {
       if (gen !== _pollGeneration) return
       handleStoreError(err, 'Failed to fetch map')
@@ -96,6 +99,7 @@ export const useMapStore = defineStore('map', () => {
       if (gen !== _pollGeneration) return
       locations.value = data.locations
       vaultMarkers.value = data.vault_markers
+      discoveryRoutes.value = data.discovery_routes ?? []
     } catch (err) {
       if (gen !== _pollGeneration) return
       error.value = handleStoreError(err, 'Failed to refresh map after chat')
@@ -106,6 +110,7 @@ export const useMapStore = defineStore('map', () => {
     // State
     locations,
     vaultMarkers,
+    discoveryRoutes,
     isLoading,
     error,
     // Getters

--- a/frontend/src/modules/map/views/MapView.vue
+++ b/frontend/src/modules/map/views/MapView.vue
@@ -131,6 +131,7 @@ const hasNoData = computed(
             v-else
             :locations="mapStore.locations"
             :vault-markers="mapStore.vaultMarkers"
+            :discovery-routes="mapStore.discoveryRoutes"
             @marker-click="handleMarkerClick"
           />
 

--- a/frontend/tests/unit/components/map/WorldMap.test.ts
+++ b/frontend/tests/unit/components/map/WorldMap.test.ts
@@ -116,6 +116,30 @@ describe('WorldMap', () => {
     })
   })
 
+  describe('Discovery routes', () => {
+    it('renders API-projected event routes, including repeated location visits', () => {
+      const wrapper = mount(WorldMap, {
+        props: {
+          locations: [],
+          vaultMarkers: [],
+          discoveryRoutes: [
+            {
+              exploration_id: 'expl-1',
+              points: [
+                { location_id: 'loc-1', coord_x: 20, coord_y: 30, timestamp: '2026-01-01T00:00:00Z' },
+                { location_id: 'loc-1', coord_x: 20, coord_y: 30, timestamp: '2026-01-01T01:00:00Z' },
+              ],
+            },
+          ],
+        },
+        global: { stubs: defaultStubs },
+      })
+
+      const route = wrapper.find('.discovery-route')
+      expect(route.attributes('points')).toBe('20,30 20,30')
+    })
+  })
+
   describe('CRT styling', () => {
     it('should have crt-screen class on the container', () => {
       const wrapper = mount(WorldMap, {


### PR DESCRIPTION
## Summary
- project ordered discovery routes from exploration events
- render per-exploration map trails
- add feature contracts and a separate World Map delivery plan

## Verification
- uv run pytest app/tests/test_api/test_map.py app/tests/test_services/test_map_service.py
- pnpm exec vp test tests/unit/components/map/WorldMap.test.ts tests/unit/views/MapView.test.ts --run