### PR TITLE
fix(map): unlock discovered locations and fix exploration detail blank page

### DIFF
--- a/backend/app/crud/wasteland_location.py
+++ b/backend/app/crud/wasteland_location.py
@@ -148,10 +148,14 @@ class CRUDWastelandLocation:
         dweller_id: UUID4,
         location_id: UUID4,
         relation: DwellerLocationRelationEnum,
+        is_unlocked: bool = False,
+        commit: bool = True,
     ) -> DwellerLocation:
         """Idempotent get-or-insert a dweller-location link.
 
-        Uses the same IntegrityError-rollback-re-select pattern.
+        Uses the same IntegrityError-rollback-re-select pattern. When
+        ``commit`` is False the insert is flushed and remains part of the
+        caller's outer transaction.
         """
         # Fast path: already linked
         stmt = select(DwellerLocation).where(
@@ -162,10 +166,24 @@ class CRUDWastelandLocation:
         result = await db_session.execute(stmt)
         existing = result.scalar_one_or_none()
         if existing is not None:
+            if is_unlocked and not existing.is_unlocked:
+                existing.is_unlocked = True
+                db_session.add(existing)
+                if commit:
+                    await db_session.commit()
+                    await db_session.refresh(existing)
             return existing
 
-        link = DwellerLocation(dweller_id=dweller_id, location_id=location_id, relation=relation)
+        link = DwellerLocation(
+            dweller_id=dweller_id,
+            location_id=location_id,
+            relation=relation,
+            is_unlocked=is_unlocked,
+        )
         db_session.add(link)
+        if not commit:
+            await db_session.flush()
+            return link
         try:
             await db_session.commit()
         except IntegrityError:

--- a/backend/app/crud/wasteland_location.py
+++ b/backend/app/crud/wasteland_location.py
@@ -191,6 +191,11 @@ class CRUDWastelandLocation:
             result = await db_session.execute(stmt)
             existing = result.scalar_one_or_none()
             if existing is not None:
+                if is_unlocked and not existing.is_unlocked:
+                    existing.is_unlocked = True
+                    db_session.add(existing)
+                    await db_session.commit()
+                    await db_session.refresh(existing)
                 return existing
             raise
         else:

--- a/backend/app/services/exploration/coordinator.py
+++ b/backend/app/services/exploration/coordinator.py
@@ -90,7 +90,11 @@ class ExplorationCoordinator:
                 from app.services.map_service import map_service
 
                 location = await map_service.register_discovery(
-                    db_session, exploration.vault_id, exploration.id, location_name
+                    db_session,
+                    exploration.vault_id,
+                    exploration.id,
+                    exploration.dweller_id,
+                    location_name,
                 )
                 if location is not None:
                     location_id = location.id

--- a/backend/app/services/map_service.py
+++ b/backend/app/services/map_service.py
@@ -269,19 +269,25 @@ class MapService:
         db_session: AsyncSession,
         vault_id: UUID4,
         exploration_id: UUID4,
+        dweller_id: UUID4,
         location_name: str,
     ) -> WastelandLocation | None:
-        """Upsert a DISCOVERY location row for an exploration — best-effort.
-
-        Returns the location row (with id and coordinates) when successful, else None.
-        """
+        """Upsert a DISCOVERY row and unlock it for the exploring dweller (best-effort)."""
         try:
-            return await wl_crud.get_or_create(
+            location = await wl_crud.get_or_create(
                 db_session,
                 vault_id=vault_id,
                 name=location_name[:64],
                 type=LocationTypeEnum.DISCOVERY,
                 exploration_id=exploration_id,
+                commit=False,
+            )
+            await wl_crud.link_dweller(
+                db_session,
+                dweller_id,
+                location.id,
+                DwellerLocationRelationEnum.VISITED,
+                is_unlocked=True,
                 commit=False,
             )
         except Exception:
@@ -296,6 +302,8 @@ class MapService:
                 location_name,
             )
             return None
+        else:
+            return location
 
     async def _get_discovery_routes(self, db_session: AsyncSession, vault_id: UUID4) -> list[DiscoveryRouteRead]:
         """Project discovery events into ordered map trails.

--- a/backend/app/tests/test_scripts/test_backfill_unlock_discoveries.py
+++ b/backend/app/tests/test_scripts/test_backfill_unlock_discoveries.py
@@ -1,0 +1,59 @@
+"""Tests for the discovery-unlock backfill script."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import delete
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app import crud
+from app.models.dweller import Dweller
+from app.models.vault import Vault
+from app.models.wasteland_location import DwellerLocation
+from app.services.map_service import map_service
+from scripts.backfill_unlock_discoveries import _unlock_discoveries_for_vault
+
+
+@pytest.mark.asyncio
+async def test_backfill_unlocks_discoveries_and_is_idempotent(
+    async_session: AsyncSession, vault: Vault, dweller: Dweller
+) -> None:
+    """First run unlocks every discovery; a second run changes nothing."""
+    exploration = await crud.exploration.create_with_dweller_stats(
+        async_session,
+        vault_id=vault.id,
+        dweller_id=dweller.id,
+        duration=4,
+    )
+    await async_session.refresh(exploration)
+
+    location = await map_service.register_discovery(
+        async_session, vault.id, exploration.id, dweller.id, "Abandoned Bunker"
+    )
+    assert location is not None
+
+    # Simulate the pre-fix state: no dweller link on the DISCOVERY row.
+    await async_session.execute(delete(DwellerLocation).where(DwellerLocation.location_id == location.id))
+    await async_session.commit()
+
+    first = await _unlock_discoveries_for_vault(async_session, vault.id)
+    assert first >= 1
+
+    second = await _unlock_discoveries_for_vault(async_session, vault.id)
+    assert second == 0
+
+    # The link is now unlocked.
+    links = (
+        (
+            await async_session.execute(
+                select(DwellerLocation).where(
+                    DwellerLocation.location_id == location.id,
+                    DwellerLocation.is_unlocked.is_(True),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(links) == 1

--- a/backend/app/tests/test_services/test_discovery_events.py
+++ b/backend/app/tests/test_services/test_discovery_events.py
@@ -104,7 +104,7 @@ async def test_map_routes_preserve_repeated_discoveries_from_event_history(
         dweller_id=dweller.id,
         duration=4,
     )
-    location = await map_service.register_discovery(async_session, vault.id, exploration.id, "Rusty Depot")
+    location = await map_service.register_discovery(async_session, vault.id, exploration.id, dweller.id, "Rusty Depot")
     assert location is not None
 
     exploration.add_event(
@@ -296,6 +296,38 @@ async def test_process_event_registers_discovery_location(
     llm_count_stmt = select(LLMInteraction)
     llm_rows = (await async_session.execute(llm_count_stmt)).scalars().all()
     assert len(llm_rows) == 0
+
+
+@pytest.mark.asyncio
+async def test_process_event_discovery_unlocks_location_on_map(
+    async_session: AsyncSession,
+    vault: Vault,
+    dweller: Dweller,
+):
+    """Happy: a discovery event unlocks the place for the exploring dweller."""
+    exploration = await crud.exploration.create_with_dweller_stats(
+        async_session,
+        vault_id=vault.id,
+        dweller_id=dweller.id,
+        duration=4,
+    )
+    await async_session.refresh(exploration)
+    _make_expired_exploration(exploration)
+
+    mock_event = DiscoveryEventSchema(
+        description="Your dweller has discovered Rusty Depot in the wasteland. "
+        "This location has been added to your world map.",
+        location_name="Rusty Depot",
+    )
+
+    with patch.object(event_generator, "generate_event", return_value=mock_event):
+        await exploration_service.process_event(async_session, exploration)
+
+    payload = await map_service.get_vault_map(async_session, vault)
+    discovery_locs = [loc for loc in payload.locations if loc.type == LocationTypeEnum.DISCOVERY]
+    assert len(discovery_locs) == 1
+    assert discovery_locs[0].name == "Rusty Depot"
+    assert discovery_locs[0].is_unlocked is True
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_services/test_map_service.py
+++ b/backend/app/tests/test_services/test_map_service.py
@@ -161,6 +161,7 @@ async def test_register_discovery_links_and_unlocks_dweller(
     assert len(discovery_locs) == 1
     assert discovery_locs[0].id == location.id
     assert discovery_locs[0].is_unlocked is True
+    assert any(ref.dweller_id == dweller.id and ref.is_unlocked for ref in discovery_locs[0].dwellers)
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_services/test_map_service.py
+++ b/backend/app/tests/test_services/test_map_service.py
@@ -129,12 +129,14 @@ async def test_register_bio_places_skips_visited_wasteland(
 
 
 @pytest.mark.asyncio
-async def test_register_discovery_sets_exploration_id(async_session: AsyncSession, vault: Vault) -> None:
+async def test_register_discovery_sets_exploration_id(
+    async_session: AsyncSession, vault: Vault, dweller: Dweller
+) -> None:
     """register_discovery upserts a DISCOVERY row with exploration_id."""
     from uuid import uuid4
 
     exploration_id = uuid4()
-    await map_service.register_discovery(async_session, vault.id, exploration_id, "Abandoned Bunker")
+    await map_service.register_discovery(async_session, vault.id, exploration_id, dweller.id, "Abandoned Bunker")
 
     result = await async_session.execute(select(WastelandLocation).where(WastelandLocation.vault_id == vault.id))
     rows = result.scalars().all()
@@ -145,8 +147,25 @@ async def test_register_discovery_sets_exploration_id(async_session: AsyncSessio
 
 
 @pytest.mark.asyncio
+async def test_register_discovery_links_and_unlocks_dweller(
+    async_session: AsyncSession, vault: Vault, dweller: Dweller
+) -> None:
+    """register_discovery links the discovering dweller and unlocks the place."""
+    from uuid import uuid4
+
+    location = await map_service.register_discovery(async_session, vault.id, uuid4(), dweller.id, "Abandoned Bunker")
+    assert location is not None
+
+    payload = await map_service.get_vault_map(async_session, vault)
+    discovery_locs = [loc for loc in payload.locations if loc.type == LocationTypeEnum.DISCOVERY]
+    assert len(discovery_locs) == 1
+    assert discovery_locs[0].id == location.id
+    assert discovery_locs[0].is_unlocked is True
+
+
+@pytest.mark.asyncio
 async def test_register_discovery_forced_db_error_logged_not_raised(
-    async_session: AsyncSession, vault: Vault, caplog
+    async_session: AsyncSession, vault: Vault, dweller: Dweller, caplog
 ) -> None:
     """A forced DB error inside register_discovery is logged, not raised."""
     from uuid import uuid4
@@ -157,7 +176,7 @@ async def test_register_discovery_forced_db_error_logged_not_raised(
         side_effect=SQLAlchemyError("forced"),
     ):
         # Must NOT raise
-        await map_service.register_discovery(async_session, vault.id, uuid4(), "Crash Site")
+        await map_service.register_discovery(async_session, vault.id, uuid4(), dweller.id, "Crash Site")
 
     # The exception should have been logged
     assert any("register_discovery failed" in record.message for record in caplog.records)
@@ -233,10 +252,10 @@ async def test_get_vault_map_returns_vault_markers(async_session: AsyncSession, 
 
 @pytest.mark.asyncio
 async def test_register_discovery_rolls_back_with_callers_transaction(
-    async_session: AsyncSession, vault: Vault
+    async_session: AsyncSession, vault: Vault, dweller: Dweller
 ) -> None:
     """Discovery registration must not commit before its event can be persisted."""
-    location = await map_service.register_discovery(async_session, vault.id, uuid4(), "Rollback Depot")
+    location = await map_service.register_discovery(async_session, vault.id, uuid4(), dweller.id, "Rollback Depot")
     assert location is not None
 
     await async_session.rollback()

--- a/backend/scripts/README.md
+++ b/backend/scripts/README.md
@@ -33,6 +33,7 @@ Repo-root `scripts/` holds general *shell* scripts (`dev-up.sh`,
 | Script | Purpose |
 |---|---|
 | `backfill_dweller_bio_places.py` | Extract origin/visited places from existing dweller bios and register them on the world map (`--vault`, `--max-dwellers`) |
+| `backfill_unlock_discoveries.py` | Link DISCOVERY locations to their finding dweller and mark them unlocked (pre-fix discoveries had no dweller link) (`--vault`, `--all-active`) |
 | `fill_dweller_bios_templates.py` | Fill empty dweller bios with SPECIAL-driven template backstories that reference map places |
 
 ## Infrastructure

--- a/backend/scripts/backfill_unlock_discoveries.py
+++ b/backend/scripts/backfill_unlock_discoveries.py
@@ -1,0 +1,117 @@
+"""Retro-active discovery unlock backfill.
+
+Links each DISCOVERY-type wasteland location to the dweller who found it
+(exploration.dweller_id) with ``is_unlocked=True``. Discoveries created before
+the discovery-unlock fix never created a dweller link, so they stayed locked on
+the world map.
+
+Usage:
+    cd backend
+    uv run python scripts/backfill_unlock_discoveries.py --vault <uuid>
+    uv run python scripts/backfill_unlock_discoveries.py --all-active
+
+Requires ASYNC_DATABASE_URI in backend/.env.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from typing import Annotated
+from uuid import UUID
+
+import typer
+from sqlmodel import select
+
+from app.crud.wasteland_location import wasteland_location as wl_crud
+from app.db.session import async_session_maker
+from app.models.wasteland_location import DwellerLocationRelationEnum, LocationTypeEnum, WastelandLocation
+
+logger = logging.getLogger(__name__)
+
+
+async def _unlock_discoveries_for_vault(session, vault_id: UUID) -> int:
+    """Link every locked DISCOVERY location in a vault to its finding dweller."""
+    from app.models.exploration import Exploration
+
+    result = await session.execute(
+        select(WastelandLocation).where(
+            WastelandLocation.vault_id == vault_id,
+            WastelandLocation.type == LocationTypeEnum.DISCOVERY,
+            WastelandLocation.exploration_id.is_not(None),
+        )
+    )
+    fixed = 0
+    for location in result.scalars().all():
+        exploration = await session.get(Exploration, location.exploration_id)
+        if exploration is None:
+            logger.warning("No exploration %s for location %s", location.exploration_id, location.name)
+            continue
+        await wl_crud.link_dweller(
+            session,
+            exploration.dweller_id,
+            location.id,
+            DwellerLocationRelationEnum.VISITED,
+            is_unlocked=True,
+        )
+        fixed += 1
+    return fixed
+
+
+async def main(vault_uuid: str | None = None, all_active: bool = False) -> int | dict[UUID, int]:
+    """Unlock discovery locations for one vault or all vaults."""
+    from app.models.vault import Vault
+
+    if not vault_uuid and not all_active:
+        raise ValueError("Either --vault or --all-active must be provided")
+
+    async with async_session_maker() as session:
+        if all_active:
+            vault_result = await session.execute(select(Vault.id).where(Vault.is_deleted.is_(False)))
+            counts: dict[UUID, int] = {}
+            for (vault_id,) in vault_result.all():
+                counts[vault_id] = await _unlock_discoveries_for_vault(session, vault_id)
+            return counts
+
+        try:
+            vault = await session.get(Vault, UUID(vault_uuid))
+        except ValueError as exc:
+            raise ValueError(f"Invalid vault UUID: {vault_uuid!r}") from exc
+        if vault is None:
+            raise ValueError(f"Vault {vault_uuid} not found")
+        return await _unlock_discoveries_for_vault(session, vault.id)
+
+
+app = typer.Typer(help="Unlock DISCOVERY locations by linking their finding dwellers.")
+
+
+@app.command()
+def backfill(
+    vault: Annotated[
+        str | None, typer.Option(help="Vault UUID to limit scope; ignored when --all-active is set")
+    ] = None,
+    all_active: Annotated[bool, typer.Option(help="Process all non-deleted vaults")] = False,
+) -> None:
+    """Link each DISCOVERY location to its finding dweller and mark it unlocked."""
+    try:
+        result = asyncio.run(main(vault_uuid=vault, all_active=all_active))
+    except ValueError as exc:
+        print(f"Backfill failed: {exc}", file=sys.stderr)
+        raise typer.Exit(code=1) from exc
+
+    if isinstance(result, dict):
+        total = sum(result.values())
+        print(f"Backfill complete: {total} discovery locations unlocked across {len(result)} vaults.")
+        for vault_id, count in sorted(result.items()):
+            print(f"  {vault_id}: {count}")
+    else:
+        print(f"Backfill complete: {result} discovery location(s) unlocked.")
+
+
+def cli_entry() -> None:
+    app()
+
+
+if __name__ == "__main__":
+    cli_entry()

--- a/backend/scripts/backfill_unlock_discoveries.py
+++ b/backend/scripts/backfill_unlock_discoveries.py
@@ -26,7 +26,12 @@ from sqlmodel import select
 
 from app.crud.wasteland_location import wasteland_location as wl_crud
 from app.db.session import async_session_maker
-from app.models.wasteland_location import DwellerLocationRelationEnum, LocationTypeEnum, WastelandLocation
+from app.models.wasteland_location import (
+    DwellerLocation,
+    DwellerLocationRelationEnum,
+    LocationTypeEnum,
+    WastelandLocation,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +53,20 @@ async def _unlock_discoveries_for_vault(session, vault_id: UUID) -> int:
         if exploration is None:
             logger.warning("No exploration %s for location %s", location.exploration_id, location.name)
             continue
+        existing = (
+            (
+                await session.execute(
+                    select(DwellerLocation).where(
+                        DwellerLocation.dweller_id == exploration.dweller_id,
+                        DwellerLocation.location_id == location.id,
+                        DwellerLocation.relation == DwellerLocationRelationEnum.VISITED,
+                    )
+                )
+            )
+            .scalars()
+            .first()
+        )
+        was_locked = existing is None or not existing.is_unlocked
         await wl_crud.link_dweller(
             session,
             exploration.dweller_id,
@@ -55,7 +74,8 @@ async def _unlock_discoveries_for_vault(session, vault_id: UUID) -> int:
             DwellerLocationRelationEnum.VISITED,
             is_unlocked=True,
         )
-        fixed += 1
+        if was_locked:
+            fixed += 1
     return fixed
 
 

--- a/frontend/src/core/types/api.generated.ts
+++ b/frontend/src/core/types/api.generated.ts
@@ -4518,6 +4518,36 @@ export interface components {
             message: string;
         };
         /**
+         * DiscoveryRoutePoint
+         * @description One persisted discovery event, projected into map coordinates.
+         */
+        DiscoveryRoutePoint: {
+            /**
+             * Location Id
+             * Format: uuid4
+             */
+            location_id: string;
+            /** Coord X */
+            coord_x: number;
+            /** Coord Y */
+            coord_y: number;
+            /** Timestamp */
+            timestamp: string;
+        };
+        /**
+         * DiscoveryRouteRead
+         * @description Ordered discovery trail for a single exploration.
+         */
+        DiscoveryRouteRead: {
+            /**
+             * Exploration Id
+             * Format: uuid4
+             */
+            exploration_id: string;
+            /** Points */
+            points: components["schemas"]["DiscoveryRoutePoint"][];
+        };
+        /**
          * DwellerAssignmentItem
          * @description Individual dweller-to-room assignment result.
          */
@@ -7876,26 +7906,11 @@ export interface components {
             locations: components["schemas"]["WastelandLocationWithDwellers"][];
             /** Vault Markers */
             vault_markers: components["schemas"]["VaultMarkerRead"][];
-            /** Discovery Routes */
-            discovery_routes?: components["schemas"]["DiscoveryRouteRead"][];
-        };
-        /** DiscoveryRoutePoint */
-        DiscoveryRoutePoint: {
-            /** Location Id */
-            location_id: string;
-            /** Coord X */
-            coord_x: number;
-            /** Coord Y */
-            coord_y: number;
-            /** Timestamp */
-            timestamp: string;
-        };
-        /** DiscoveryRouteRead */
-        DiscoveryRouteRead: {
-            /** Exploration Id */
-            exploration_id: string;
-            /** Points */
-            points: components["schemas"]["DiscoveryRoutePoint"][];
+            /**
+             * Discovery Routes
+             * @default []
+             */
+            discovery_routes: components["schemas"]["DiscoveryRouteRead"][];
         };
         /**
          * VaultMarkerRead

--- a/frontend/src/modules/exploration/components/ExplorationLootList.vue
+++ b/frontend/src/modules/exploration/components/ExplorationLootList.vue
@@ -3,7 +3,7 @@ import { Icon } from '@iconify/vue'
 import type { LootItem } from '../stores/exploration'
 import { getRarityColor } from '../models/exploration'
 
-defineProps<{ items: LootItem[] }>()
+withDefaults(defineProps<{ items: LootItem[] }>(), { items: () => [] })
 </script>
 
 <template>

--- a/frontend/src/modules/exploration/views/ExplorationDetailView.vue
+++ b/frontend/src/modules/exploration/views/ExplorationDetailView.vue
@@ -194,12 +194,8 @@ onMounted(async () => {
   if (vaultId.value && authStore.token) {
     await explorationStore.fetchExplorationsByVault(vaultId.value, authStore.token)
 
-    // A direct link can target a completed exploration, which is absent from
-    // the active-only collection above. Fetch it immediately instead of
-    // leaving the detail view waiting for the polling interval.
-    if (!exploration.value) {
-      await explorationStore.fetchExplorationDetails(explorationId.value, authStore.token)
-    }
+    // Vault list returns the short schema — always fetch the full record (loot/events).
+    await explorationStore.fetchExplorationDetails(explorationId.value, authStore.token)
 
     // Fetch full dweller data for the explorer (includes weapon/outfit)
     if (exploration.value) {

--- a/frontend/tests/unit/views/ExplorationDetailView.test.ts
+++ b/frontend/tests/unit/views/ExplorationDetailView.test.ts
@@ -309,4 +309,24 @@ describe('ExplorationDetailView', () => {
       expect(wrapper.text()).toContain('No events yet')
     })
   })
+
+  describe('Short-schema exploration (missing loot_collected)', () => {
+    it('renders without crashing when loot_collected is undefined', async () => {
+      const { loot_collected: _omit, ...shortExploration } = mockExploration
+      explorationStore.activeExplorations['expl-1'] = shortExploration as typeof mockExploration
+
+      const wrapper = mount(ExplorationDetailView, {
+        global: {
+          plugins: [router],
+        },
+      })
+
+      await flushPromises()
+
+      // Should render the summary card, not throw / blank out
+      expect(wrapper.text()).toContain('Amata Almodovar')
+      expect(wrapper.text()).toContain('Event Log')
+      expect(wrapper.find('.loading-state').exists()).toBe(false)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Fixes two related bugs in the world-map / exploration flow:

### 1. Discovered locations never unlock on the map
`register_discovery` created a `DISCOVERY` `WastelandLocation` row but never created a `DwellerLocation` link for the exploring dweller. Since `get_vault_map` computes `is_unlocked = any(r.is_unlocked for r in dweller_refs)`, a discovery with zero dweller links was always locked — and the chat-based unlock flow could never help (it only updates *existing* links).

**Fix:** `register_discovery` now links the exploring dweller to the DISCOVERY location with `is_unlocked=True` (the dweller physically found it). `link_dweller` gained `is_unlocked` and `commit` params to support this.

### 2. Exploration detail page renders blank on direct links
`ExplorationDetailView` resolves `exploration` from `activeExplorations`, which the vault list populates with the **short** schema (no `loot_collected`/`events`). The full record was only fetched when the exploration wasn't already present — so direct links used the short object, and `ExplorationLootList` crashed on `items.length` of `undefined`, blanking the page.

**Fix:** always fetch the full exploration record on mount; `ExplorationLootList` defaults `items` to `[]` defensively.

## Changes
- `register_discovery` links dweller with `is_unlocked=True` (+ coordinator passes `dweller_id`)
- `link_dweller` supports `is_unlocked` / `commit` params (backwards-compatible)
- `ExplorationDetailView` always fetches full record; `ExplorationLootList` guards `items`
- Backfill script `backfill_unlock_discoveries.py` to repair pre-fix DISCOVERY rows (+ README entry)
- Regression tests for both fixes

## Verification
- Backend: ruff clean, 36/36 discovery/map tests pass
- Frontend: lint + typecheck clean, 11/11 detail-view tests pass
- Headless-browser verified: detail page renders fully, zero console errors
- Backfill run across all 32 vaults: 5 discoveries unlocked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Newly discovered locations are automatically linked to the exploring dweller and marked as unlocked.
  - Added a maintenance tool to unlock existing discovery locations across selected or active vaults.

- **Bug Fixes**
  - Exploration details now consistently load complete loot and event data.
  - Exploration views no longer crash when loot data is unavailable.

- **Tests**
  - Added coverage for discovery unlocking and incomplete exploration data handling.

- **Documentation**
  - Documented the new discovery backfill tool and its available options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->