### PR TITLE
fix(ci): deploy only configured API logs

### DIFF
--- a/.github/workflows/deploy-hetzner.yml
+++ b/.github/workflows/deploy-hetzner.yml
@@ -183,6 +183,16 @@ jobs:
             exit 1
           SHELL
 
+      - name: Verify persistent API logs
+        run: |
+          ssh -i ~/.ssh/hetzner_key ${{ secrets.HETZNER_USER }}@${{ secrets.HETZNER_HOST }} << 'SHELL'
+            set -euo pipefail
+
+            test "$(kubectl -n fallout get pvc backend-logs-pvc -o jsonpath='{.status.phase}')" = "Bound"
+            kubectl -n fallout exec deployment/backend -- test -s /var/log/fallout_shelter/backend.log
+            kubectl -n fallout exec deployment/backend -- tail -n 1 /var/log/fallout_shelter/backend.log
+          SHELL
+
       - name: Verify AI Gateway and Logfire
         run: |
           ssh -i ~/.ssh/hetzner_key ${{ secrets.HETZNER_USER }}@${{ secrets.HETZNER_HOST }} << 'SHELL'

--- a/.github/workflows/deploy-hetzner.yml
+++ b/.github/workflows/deploy-hetzner.yml
@@ -104,10 +104,8 @@ jobs:
       - name: Configure persistent application logs
         run: |
           set -euo pipefail
-          for manifest in deployment/k3s/backend-logs-pvc.yaml deployment/k3s/dramatiq-logs-pvc.yaml; do
-            ssh -i ~/.ssh/hetzner_key ${{ secrets.HETZNER_USER }}@${{ secrets.HETZNER_HOST }} \
-              'kubectl apply -n fallout -f -' < "$manifest"
-          done
+          ssh -i ~/.ssh/hetzner_key ${{ secrets.HETZNER_USER }}@${{ secrets.HETZNER_HOST }} \
+            'kubectl apply -n fallout -f -' < deployment/k3s/backend-logs-pvc.yaml
 
           ssh -i ~/.ssh/hetzner_key ${{ secrets.HETZNER_USER }}@${{ secrets.HETZNER_HOST }} << 'SHELL'
             set -euo pipefail
@@ -116,14 +114,7 @@ jobs:
               LOG_JSON_FORMAT=true \
               LOG_FILE_PATH=/var/log/fallout_shelter/backend.log \
               LOG_FILE_RETENTION_DAYS=14
-            kubectl -n fallout set env deployment/dramatiq-worker \
-              FALLOUT_WORKER=1 \
-              LOG_JSON_FORMAT=true \
-              LOG_FILE_PATH=/var/log/fallout_shelter/worker.log \
-              LOG_FILE_RETENTION_DAYS=14
-
             kubectl -n fallout patch deployment/backend --type='strategic' -p='{"spec":{"template":{"spec":{"securityContext":{"fsGroup":1000},"containers":[{"name":"backend","volumeMounts":[{"name":"application-logs","mountPath":"/var/log/fallout_shelter"}]}],"volumes":[{"name":"application-logs","persistentVolumeClaim":{"claimName":"backend-logs-pvc"}}]}}}}'
-            kubectl -n fallout patch deployment/dramatiq-worker --type='strategic' -p='{"spec":{"template":{"spec":{"securityContext":{"fsGroup":1000},"containers":[{"name":"dramatiq-worker","volumeMounts":[{"name":"application-logs","mountPath":"/var/log/fallout_shelter"}]}],"volumes":[{"name":"application-logs","persistentVolumeClaim":{"claimName":"dramatiq-logs-pvc"}}]}}}}'
           SHELL
 
       - name: Restart deployments and wait for rollout


### PR DESCRIPTION
The deployment workflow still applied and mounted the removed dramatiq log PVC. Keep persistent JSON API logs and stop provisioning the nonexistent worker log volume so v2.47.0 can deploy.